### PR TITLE
Require picklewagon as a codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @picklewagon


### PR DESCRIPTION
This pull request includes a small change to the `.github/CODEOWNERS` file. The change adds `@picklewagon` as a code owner for all files.