### PR TITLE
feat(tools): checklist importer + parallel expander

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ Thumbs.db
 
 # Node
 node_modules/
+
+# Raw checklists
+import/

--- a/tools/expand_parallels.py
+++ b/tools/expand_parallels.py
@@ -1,0 +1,643 @@
+import argparse
+import re
+import uuid
+from pathlib import Path
+
+import requests
+import yaml
+from openpyxl import load_workbook
+
+
+DATA_DIR = Path("data") / "baseball"
+
+
+PARALLEL_PLANS = {
+    "2025-26-topps-chrome-platinum": {
+        "source_url": "https://baseballcardpedia.com/index.php/2025-26_Topps_Chrome_Platinum#Checklist",
+        "sections": {
+            "Base": [
+                ("Refractor", None),
+                ("Prism Refractor", None),
+                ("Blue Prism Refractor", None),
+                ("Red Prism Refractor", None),
+                ("Gold Prism Refractor", None),
+                ("Topps Refractor", 499),
+                ("Vibration Refractor", 250),
+                ("Blue Mini-Diamond Refractor", 199),
+                ("Speckle Refractor", 150),
+                ("Blue Vibration Refractor", 150),
+                ("Blue Lava Refractor", 100),
+                ("Platinum Toile Cream/Fuchsia Shimmer Refractor", 100),
+                ("Green Wave Refractor", 99),
+                ("Platinum Toile White/Green Refractor", 99),
+                ("Green Vibration Refractor", 99),
+                ("Platinum Toile Cream/Rose Gold Refractor", 75),
+                ("Rose Gold Refractor", 75),
+                ("Rose Gold Mini-Diamond Refractor", 75),
+                ("Diamond Etch Refractor", 55),
+                ("Gold Refractor", 50),
+                ("Gold Wave Refractor", 50),
+                ("Platinum Toile Cream/Gold Refractor", 50),
+                ("Gold Vibration Refractor", 50),
+                ("Platinum Toile White/Orange Refractor", 25),
+                ("Orange Refractor", 25),
+                ("Orange Wave Refractor", 25),
+                ("Orange Vibration Refractor", 25),
+                ("Black Refractor", 10),
+                ("Platinum Toile Cream/Black Refractor", 10),
+                ("Black Vibration Refractor", 10),
+                ("Red Refractor", 5),
+                ("Platinum Toile Cream/Red Refractor", 5),
+                ("Red Lava Refractor", 5),
+                ("Red Vibration Refractor", 5),
+                ("SuperFractor", 1),
+            ],
+            "1955 World Series": [
+                ("Green Refractor", 99),
+                ("Gold Refractor", 50),
+                ("Orange Refractor", 25),
+                ("Black Refractor", 10),
+                ("Red Refractor", 5),
+                ("SuperFractor", 1),
+            ],
+            "1955 Topps Rails And Sails": [
+                ("Green Refractor", 99),
+                ("Gold Refractor", 50),
+                ("Orange Refractor", 25),
+                ("Black Refractor", 10),
+                ("Red Refractor", 5),
+                ("SuperFractor", 1),
+            ],
+            "1955 Topps Doubleheaders": [
+                ("Green Refractor", 99),
+                ("Gold Refractor", 50),
+                ("Orange Refractor", 25),
+                ("Black Refractor", 10),
+                ("Red Refractor", 5),
+                ("SuperFractor", 1),
+            ],
+            "1955 Cards That Never Were": [("SuperFractor", 1)],
+            "Base - City Variations": [("SuperFractor", 1)],
+            "Chrome Platinum Autographs": [
+                ("Refractor", 199),
+                ("Aqua Refractor", 150),
+                ("Blue Prism Refractor", 99),
+                ("Platinum Toile Cream/Blue Refractor", 99),
+                ("Green Mini-Diamond Refractor", 75),
+                ("Gold Refractor", 50),
+                ("Orange Refractor", 25),
+                ("Pink Refractor", 15),
+                ("Black Refractor", 10),
+                ("Platinum Toile Cream/Red Refractor", 5),
+                ("Red Refractor", 5),
+                ("SuperFractor", 1),
+            ],
+            "1955 Topps City Variations Autographs": [("SuperFractor", 1)],
+        },
+    },
+    "2025-26-topps-definitive-collection": {
+        "source_url": "https://baseballcardpedia.com/index.php/2025-26_Topps_Definitive_Collection#Checklist",
+        "sections": {
+            "Jumbo Relic Collection": [("Orange", 25), ("Pink", 15), ("Black", 10), ("Red", 5), ("Gold", 1)],
+            "Definitive Helmet Collection": [("Red", 5), ("MLB Logo Gold", 1), ("Rawlings Authentic Tag Gold", 1), ("Rawlings Logo Gold", 1), ("Player Number Gold", 1)],
+            "Protector At The Plate": [("Black", 10), ("Red", 5), ("Gold", 1)],
+            "Quad Patch Collection": [("Gold", 1)],
+            "Definitive Rookie Autographs": [("Orange", 25), ("Black", 10), ("Red", 5), ("Gold", 1)],
+            "Framed Autograph Collection": [("Black", 10), ("Red", 5), ("Gold", 1)],
+            "Legendary Autograph Collection": [("Black", 10), ("Red", 5), ("Gold", 1)],
+            "Defining Images Autographs": [("Black", 10), ("Red", 5), ("Gold", 1)],
+            "Dual Autographs": [("Black", 10), ("Red", 5), ("Gold", 1)],
+            "Definitive Triple Autographs": [("Black", 10), ("Red", 5), ("Gold", 1)],
+            "Definitive Quad Autographs": [("Gold", 1)],
+            "Dual World Series Autograph Collection": [("Black", 10), ("Red", 5), ("Gold", 1)],
+            "Base Autographed Relics": [("Orange", 25), ("Black", 10), ("Red", 5), ("Jersey Button Gold", 1), ("Laundry Tag Gold", 1), ("Brand Logo Gold", 1), ("MLB Logo Gold", 1)],
+            "Definitive Autographed Relics": [("Green", 10), ("Purple", 5), ("Red", 1)],
+            "Definitive Rookie Patch Autographs": [("Orange", 25), ("Black", 10), ("Red", 5), ("Gold", 1)],
+            "Definitive Autographed First Batting Gloves": [("Red", 5), ("Gold", 1)],
+            "Autographed Patch Booklets": [("Red", 1)],
+            "Framed Autograph Patches": [("Black", 10), ("Red", 5), ("Gold", 1)],
+            "Definitive Helmet Collection Autographs": [("Gold", 1)],
+            "Protectors At The Plate Autographed Relics": [("Red", 1)],
+            "Dual Autograph Relic Collection": [("Black", 10), ("Red", 5), ("Gold", 1)],
+        },
+    },
+    "2025-26-topps-transcendent": {
+        "source_url": "https://baseballcardpedia.com/index.php/2025-26_Topps_Transcendent#Checklist",
+        "sections": {
+            "Base": [("Orange Refractor", 25), ("Gold Refractor", 10), ("Red Refractor", 5), ("SuperFractor", 1)],
+            "Base Set - Image Variations": [("Orange Refractor", 25), ("Gold Refractor", 10), ("Red Refractor", 5), ("SuperFractor", 1)],
+            "Transcendent Collection Legendary Relic Cards": [("Platinum", 1)],
+            "Transcendent Icons Chrome Autograph": [("Blue", 10), ("Emerald", 5), ("Platinum", 1)],
+            "Transcendent Collection Rookie Showcase Autographs": [("Blue", 10), ("Emerald", 5), ("Platinum", 1)],
+            "MLB Logo Autograph Patch Card": [("Black Refractor", 10), ("Red Refractor", 5), ("SuperFractor", 1)],
+            "Transcendent Autograph Relic": [("Blue", 10), ("Emerald", 5), ("Platinum", 1)],
+            "Transcendent Collection Patch Autographs": [("Blue", 10), ("Emerald", 5), ("Platinum", 1)],
+            "Transcendent Collection Dual Patch Autograph Variation": [("Emerald", 5), ("Platinum", 1)],
+            "Transcendent Collection Rookie Showcase Patch Autographs": [("Platinum", 1)],
+            "Transcendent Collection Jumbo Patch Autographs": [("Platinum", 1)],
+            "Record Breaking Autograph Relic": [("MLB Logo Patch", 1)],
+            "Transcendent Collection World Series Relic Autograph": [("Blue", 10), ("Emerald", 5), ("Platinum", 1)],
+            "Transcendent Collection World Series Patch Autograph": [("Blue", 10), ("Emerald", 5), ("Platinum", 1)],
+            "Transcendent Collection World Series Logo Patch Autograph": [("Platinum", 1)],
+        },
+    },
+    "2026-bowman": {
+        "source_url": "https://baseballcardpedia.com/index.php/2026_Bowman#Insertion_Ratios",
+        "wiki_table": "https://baseballcardpedia.com/index.php?title=2026_Bowman&action=raw",
+        "default_base_subset": "Base",
+        "default_base_total": 100,
+        "default_base_skip_prefixes": ["Mega Chrome", "Rookie Red RC"],
+        "table_aliases": {
+            "Base Set": "Base",
+            "Prospects": "Base Prospects",
+            "Chrome Prospects": "Chrome Prospects",
+            "Etched in Glass": "Base - Etched In Glass Variations",
+            "Chrome Prospects Etched in Glass": "Chrome Prospects - Etched In Glass Variations",
+            "PackFractor": "Chrome Prospects Packfractor Variation",
+            "Red RC Icon": "Base - Red RC Variations",
+            "Scouts' Top 100": "Bowman Scouts Top 100",
+            "Sterling": "Bowman Sterling",
+            "Electric Sluggers": "Electric Sluggers",
+            "Under the Radar": "Under The Radar",
+            "Power Chords": "Power Chords",
+            "Chrome Rookie Autographs": "Chrome Rookie Autographs",
+            "Chrome Prospect Autographs": "Chrome Prospect Autographs",
+            "Chrome Prospect Gold Ink Autographs": "Chrome Prospect Gold Ink Autographs",
+            "Chrome Prospect PackFractor Autographs": "Chrome Prospect Packfractor Autographs",
+            "Sterling Autographs": "Bowman Sterling Autographs",
+            "Electric Sluggers Autographs": "Electric Sluggers Autographs",
+            "Under the Radar Autographs": "Under The Radar Autographs",
+            "Power Chords Autographs": "Power Chords Autographs",
+        },
+    },
+    "2026-topps-series-2": {
+        "source_url": "https://baseballcardpedia.com/index.php/2026_Topps#Insertion_Ratios",
+        "wiki_table": "https://baseballcardpedia.com/index.php?title=2026_Topps&action=raw",
+        "start_heading": "==Series Two==",
+        "end_heading": "=Checklist=",
+        "default_base_subset": "Base",
+        "default_base_total": 350,
+        "default_base_skip_prefixes": [
+            "Team Color Border",
+            "True Photo",
+            "Golden Mirror",
+            "Holiday",
+            "Vintage Stock",
+            "Clear",
+            "Apple Foil",
+            "1991",
+        ],
+        "table_aliases": {
+            "Base": "Base",
+            "Team Color Border Variation": "Team Color Border Variations",
+            "True Photo Variation": "True Photo Variations",
+            "Golden Mirror Variation": "Golden Mirror Variations",
+            "Holiday Variation": "Holiday Variations",
+            "Vintage Stock Variation": "Vintage Stock Variations",
+            "Clear Variation": "Clear Variation",
+            "Apple Foil Variation": "Apple Foil Variations",
+            "1991 Topps Baseball": "1991 Topps Baseball",
+            "1991 Topps Baseball Chrome": "1991 Topps Baseball Chrome",
+            "1991 Topps All-Stars": "1991 Topps All-Stars",
+            "1991 Topps Baseball Chrome All-Stars": "1991 Topps Baseball Chrome All-Stars",
+            "The Flagship Collection": "The Flagship Collection",
+            "The Flagship Collection Chrome": "The Flagship Collection - Chrome",
+            "Stars of MLB": "Stars Of MLB",
+            "All Aces": "All Aces",
+            "All Kings": "All Kings",
+            "Crooked Numbers": "Crooked Numbers",
+            "Glove Work": "Glove Work",
+            "Heavy Lumber": "Heavy Lumber",
+            "Home Field Advantage": "Home Field",
+            "Cover Athletes": "Cover Athletes",
+            "Titans of the Game": "Titans Of The Game",
+            "Swinging with the Stars": "Swinging With The Stars",
+            "Diamond Dust": "Diamond Dust",
+            "Topps Flagship Autograph Patches": "Topps Flagship Autograph Patches",
+            "Baseball Stars Autographs": "Baseball Stars Autographs",
+            "First Pitch Autographs": "First Pitch Autographs",
+            "1991 Topps Baseball Autographs": "1991 Topps Baseball Autographs",
+            "1991 Topps Baseball Chrome Autographs": "1991 Topps Baseball Chrome Autographs",
+            "1991 Topps Baseball All-Star Autographs": "1991 Topps Baseball All-Star Autographs",
+            "1991 Topps Baseball Chrome All-Star Autographs": "1991 Topps Baseball Chrome All-Star Autographs",
+            "Major League Materials Autographs": "Major League Materials Autographs",
+            "Major League Material": "Major League Material",
+            "City Connect Swatch Collection": "City Connect Swatch Collection",
+            "City Connect Swatches Autographs": "City Connect Swatches Autographs",
+            "Real One Relics": "Real One Relics",
+            "Rounding the Bases Relics": "Rounding The Bases Relics",
+            "Rounding the Bases Autographs": "Rounding The Bases Autographs",
+            "In the Name Relics": "In The Name Relics",
+        },
+    },
+    "2026-topps-chrome-black": {
+        "source_url": "https://baseballcardpedia.com/index.php/2026_Topps_Chrome_Black#Insertion_Ratios",
+        "sections": {
+            "Base": [
+                ("Refractor", 199),
+                ("Blue Refractor", 150),
+                ("Green Refractor", 99),
+                ("Purple Refractor", 75),
+                ("Purple Mini-Diamond Refractor", 75),
+                ("Purple Wave Refractor", 75),
+                ("Gold Refractor", 50),
+                ("Gold Mini Diamond Refractor", 50),
+                ("Gold Wave Refractor", 50),
+                ("Orange Refractor", 25),
+                ("Orange Mini Diamond Refractor", 25),
+                ("Orange Wave Refractor", 25),
+                ("Rose Gold Refractor", 10),
+                ("Rose Gold Mini Diamond Refractor", 10),
+                ("Rose Gold Wave Refractor", 10),
+                ("Red Refractor", 5),
+                ("Red Mini Diamond Refractor", 5),
+                ("Red Wave Refractor", 5),
+                ("SuperFractor", 1),
+            ],
+            "Base - Rookie Design Variations": [
+                ("Purple Refractor", 75),
+                ("Gold Refractor", 50),
+                ("Orange Refractor", 25),
+                ("Rose Gold Refractor", 10),
+                ("Red Refractor", 5),
+                ("SuperFractor", 1),
+            ],
+            "Damascus": [("SuperFractor", 1)],
+            "Nocturnal": [("SuperFractor", 1)],
+            "Home Field": [("Black Refractor", 1)],
+            "Depth Of Darkness": [
+                ("Red Refractor", 5),
+                ("SuperFractor", 1),
+            ],
+            "Chrome Black Autographs": [
+                ("Refractor", 199),
+                ("Blue Refractor", 150),
+                ("Green Refractor", 99),
+                ("Purple Refractor", 75),
+                ("Gold Refractor", 50),
+                ("Gold Mini Diamond Refractor", 50),
+                ("Orange Refractor", 25),
+                ("Orange Mini Diamond Refractor", 25),
+                ("Rose Gold Refractor", 10),
+                ("Rose Gold Mini Diamond Refractor", 10),
+                ("Red Refractor", 5),
+                ("Red Mini Diamond Refractor", 5),
+                ("SuperFractor", 1),
+            ],
+            "Super Futures Autographs": [
+                ("Gold Refractor", 50),
+                ("Orange Refractor", 25),
+                ("Rose Gold Refractor", 10),
+                ("Red Refractor", 5),
+                ("SuperFractor", 1),
+            ],
+            "Ivory Autographs": [
+                ("Orange Trim", 25),
+                ("Red Trim", 5),
+                ("SuperFractor", 1),
+            ],
+            "Paint It": [
+                ("Red Refractor", 5),
+                ("SuperFractor", 1),
+            ],
+            "Pitch Black Pairings Dual Autographs": [
+                ("Orange Refractor", 25),
+                ("Rose Gold Refractor", 10),
+                ("Red Refractor", 5),
+                ("SuperFractor", 1),
+            ],
+        },
+    },
+    "2026-donruss": {
+        "source_url": "https://baseballcardpedia.com/index.php/2026_Donruss#Checklist",
+        "master_xlsx": "import/2026-Donruss-Baseball-Checklist.xlsx",
+        "master_team": True,
+    },
+    "2026-panini-prizm-stars-stripes": {
+        "source_url": "https://baseballcardpedia.com/index.php/2026_Panini_Stars_%26_Stripes_Prizm#Checklist",
+        "master_xlsx": "import/2026-Panini-Prizm-Stars-Stripes-Baseball-Checklist.xlsx",
+        "master_default_team": "USA Baseball",
+    },
+}
+
+
+FIELD_ORDER = [
+    "number",
+    "uuid",
+    "genre",
+    "sport",
+    "sports",
+    "set_id",
+    "subjects",
+    "subset",
+    "card_name",
+    "description",
+    "series",
+    "variation",
+    "parallel",
+    "print_run",
+    "rookie_card",
+    "autograph",
+    "relic",
+    "serial_numbered",
+    "release_date",
+    "image_url",
+    "external_links",
+]
+
+
+def slugify(value):
+    value = str(value).lower().replace("&", "and")
+    value = re.sub(r"[^a-z0-9]+", "-", value)
+    return value.strip("-")
+
+
+def normalize(value):
+    return re.sub(r"[^a-z0-9]+", "", str(value).lower())
+
+
+def print_run_from_text(value):
+    value = str(value).strip().lower().replace(",", "")
+    if not value or value in {"-", "n/a", "?"}:
+        return None
+    if "one-of-one" in value or value == "1/1":
+        return 1
+    if "four for each" in value:
+        return 4
+    words = {"ten": 10, "fifteen": 15, "five": 5}
+    if value in words:
+        return words[value]
+    match = re.search(r"\d+", value)
+    return int(match.group(0)) if match else None
+
+
+def yaml_quote(value):
+    escaped = str(value).replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'
+
+
+def read_yaml(path):
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def is_parallel_card_file(path):
+    return re.search(r"^parallel:", path.read_text(encoding="utf-8"), re.MULTILINE) is not None
+
+
+def read_existing_uuid(path):
+    if not path.exists():
+        return None
+    match = re.search(r'^uuid:\s*"?([0-9a-fA-F-]{36})"?\s*$', path.read_text(encoding="utf-8"), re.MULTILINE)
+    return match.group(1) if match else None
+
+
+def write_card(path, data):
+    lines = []
+    for field in FIELD_ORDER:
+        if field not in data:
+            continue
+        value = data[field]
+        if value is None:
+            continue
+        if field == "subjects":
+            lines.append("subjects:")
+            for subject in value:
+                lines.append(f"  - name: {yaml_quote(subject['name'])}")
+                if "role" in subject:
+                    lines.append(f"    role: {yaml_quote(subject['role'])}")
+                if "team" in subject:
+                    lines.append(f"    team: {yaml_quote(subject['team'])}")
+        elif field == "external_links":
+            lines.append("external_links:")
+            for link in value:
+                lines.append(f"  - name: {yaml_quote(link['name'])}")
+                lines.append(f"    url: {yaml_quote(link['url'])}")
+        elif isinstance(value, bool):
+            lines.append(f"{field}: {str(value).lower()}")
+        elif isinstance(value, int):
+            lines.append(f"{field}: {value}")
+        elif isinstance(value, list):
+            lines.append(f"{field}: [{', '.join(yaml_quote(item) for item in value)}]")
+        else:
+            lines.append(f"{field}: {yaml_quote(value)}")
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def section_name(card):
+    return card.get("subset", "Base")
+
+
+def build_parallel_card(card, base_path, parallel, print_run, source_url):
+    variant_path = base_path.with_name(f"{base_path.stem}-{slugify(parallel)}.yaml")
+    variant = dict(card)
+    variant["uuid"] = read_existing_uuid(variant_path) or str(uuid.uuid4())
+    variant["parallel"] = parallel
+    variant["print_run"] = print_run
+    variant["serial_numbered"] = print_run is not None
+    title = card.get("card_name", card["number"])
+    if f" - {parallel}" not in title:
+        variant["card_name"] = f"{title} - {parallel}"
+    variant["description"] = f"{parallel} parallel of {card.get('description', title)}"
+    image_root = card.get("image_url", "").rsplit("/", 1)[0]
+    if image_root:
+        variant["image_url"] = f"{image_root}/{variant_path.stem}.jpg"
+    links = list(card.get("external_links", []))
+    if not any(link.get("name") == "BaseballCardpedia" and link.get("url") == source_url for link in links):
+        links.append({"name": "BaseballCardpedia", "url": source_url})
+    variant["external_links"] = links
+    return variant_path, variant
+
+
+def update_set_count(set_dir):
+    set_path = set_dir / "set.yaml"
+    text = set_path.read_text(encoding="utf-8")
+    count = len(list((set_dir / "cards").glob("*.yaml")))
+    text = re.sub(r"^card_count:\s*\d+\s*$", f"card_count: {count}", text, flags=re.MULTILINE)
+    set_path.write_text(text, encoding="utf-8")
+
+
+def master_rows(plan):
+    wb = load_workbook(plan["master_xlsx"], read_only=True, data_only=True)
+    ws = wb["Master Card List"]
+    for row in ws.iter_rows(min_row=2, values_only=True):
+        if not row or not row[0]:
+            continue
+        if plan.get("master_team"):
+            card_set, number, athlete, team, sequence = (list(row) + [None] * 5)[:5]
+        else:
+            card_set, number, athlete, sequence = (list(row) + [None] * 4)[:4]
+            team = plan.get("master_default_team", "")
+        yield {
+            "card_set": str(card_set).strip(),
+            "number": str(number).strip(),
+            "athlete": str(athlete).strip().rstrip(","),
+            "team": str(team).strip() if team is not None else "",
+            "print_run": int(sequence) if isinstance(sequence, int) else None,
+        }
+
+
+def existing_base_cards(cards_dir):
+    cards = []
+    for path in sorted(cards_dir.glob("*.yaml")):
+        if is_parallel_card_file(path):
+            continue
+        card = read_yaml(path)
+        cards.append((path, card, section_name(card), normalize(section_name(card))))
+    return cards
+
+
+def best_base_match(row, base_cards):
+    row_set = normalize(row["card_set"])
+    row_number = str(row["number"])
+    candidates = []
+    for path, card, subset, normalized_subset in base_cards:
+        if str(card.get("number")) != row_number:
+            continue
+        if row_set == normalized_subset or row_set.startswith(normalized_subset):
+            candidates.append((len(normalized_subset), path, card, subset))
+    if not candidates:
+        return None
+    _, path, card, subset = max(candidates, key=lambda item: item[0])
+    return path, card, subset
+
+
+def master_parallel_name(card_set, subset):
+    normalized_subset = normalize(subset)
+    words = re.findall(r"[A-Za-z0-9]+", card_set)
+    consumed = []
+    for index in range(1, len(words) + 1):
+        if normalize(" ".join(words[:index])) == normalized_subset:
+            consumed = words[:index]
+    if not consumed:
+        return ""
+    return " ".join(words[len(consumed) :]).strip()
+
+
+def expand_master_set(set_id, limit):
+    plan = PARALLEL_PLANS[set_id]
+    set_dir = DATA_DIR / set_id
+    cards_dir = set_dir / "cards"
+    base_cards = existing_base_cards(cards_dir)
+    written = 0
+    for row in master_rows(plan):
+        match = best_base_match(row, base_cards)
+        if not match:
+            continue
+        base_path, card, subset = match
+        parallel = master_parallel_name(row["card_set"], subset)
+        if not parallel:
+            continue
+        variant_path, variant = build_parallel_card(card, base_path, parallel, row["print_run"], plan["source_url"])
+        if variant_path.exists():
+            continue
+        write_card(variant_path, variant)
+        written += 1
+        if written >= limit:
+            update_set_count(set_dir)
+            return written
+    update_set_count(set_dir)
+    return written
+
+
+def wiki_table_rows(plan):
+    text = requests.get(plan["wiki_table"], timeout=30).text
+    if plan.get("start_heading"):
+        start = text.find(plan["start_heading"])
+        if start != -1:
+            text = text[start:]
+    if plan.get("end_heading"):
+        end = text.find(plan["end_heading"])
+        if end != -1:
+            text = text[:end]
+    for line in text.splitlines():
+        if not line.startswith("|"):
+            continue
+        cells = [cell.strip() for cell in line.strip("|").split("||")]
+        if len(cells) < 3:
+            continue
+        label = re.sub(r"''+", "", cells[0]).strip()
+        label = re.sub(r"\[\[(?:[^|\]]+\|)?([^\]]+)\]\]", r"\1", label)
+        total = print_run_from_text(cells[1])
+        print_run = print_run_from_text(cells[2])
+        if not label or label.lower() == "cards":
+            continue
+        yield label, total, print_run
+
+
+def wiki_variants(plan):
+    aliases = sorted(plan["table_aliases"].items(), key=lambda item: len(normalize(item[0])), reverse=True)
+    variants = {}
+    for label, total, print_run in wiki_table_rows(plan):
+        normalized_label = normalize(label)
+        matched = False
+        for prefix, subset in aliases:
+            normalized_prefix = normalize(prefix)
+            if normalized_label == normalized_prefix:
+                matched = True
+                break
+            if normalized_label.startswith(normalized_prefix):
+                parallel = label[len(prefix) :].strip(" -")
+                if not parallel or normalize(parallel) in {"s", "base", "set", "autograph", "autographs", "relic", "relics"}:
+                    matched = True
+                    break
+                variants.setdefault(subset, [])
+                item = (parallel, print_run)
+                if item not in variants[subset]:
+                    variants[subset].append(item)
+                matched = True
+                break
+        if matched:
+            continue
+        if plan.get("default_base_subset") and total == plan.get("default_base_total"):
+            skip = any(normalized_label.startswith(normalize(prefix)) for prefix in plan.get("default_base_skip_prefixes", []))
+            if not skip and normalized_label not in {"base", "baseset"}:
+                variants.setdefault(plan["default_base_subset"], [])
+                item = (label, print_run)
+                if item not in variants[plan["default_base_subset"]]:
+                    variants[plan["default_base_subset"]].append(item)
+    return variants
+
+
+def expand_set(set_id, limit):
+    plan = PARALLEL_PLANS[set_id]
+    if "master_xlsx" in plan:
+        return expand_master_set(set_id, limit)
+    if "wiki_table" in plan:
+        plan = dict(plan)
+        plan["sections"] = wiki_variants(plan)
+    set_dir = DATA_DIR / set_id
+    cards_dir = set_dir / "cards"
+    written = 0
+    for path in sorted(cards_dir.glob("*.yaml")):
+        if is_parallel_card_file(path):
+            continue
+        card = read_yaml(path)
+        variants = plan["sections"].get(section_name(card), [])
+        for parallel, print_run in variants:
+            variant_path, variant = build_parallel_card(card, path, parallel, print_run, plan["source_url"])
+            if variant_path.exists():
+                continue
+            write_card(variant_path, variant)
+            written += 1
+            if written >= limit:
+                update_set_count(set_dir)
+                return written
+    update_set_count(set_dir)
+    return written
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--set-id", choices=sorted(PARALLEL_PLANS), required=True)
+    parser.add_argument("--limit", type=int, default=1000)
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    written = expand_set(args.set_id, args.limit)
+    print(f"Wrote {written} parallel cards for {args.set_id}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/import_checklist.py
+++ b/tools/import_checklist.py
@@ -1,0 +1,603 @@
+import argparse
+import html
+import re
+import uuid
+from html.parser import HTMLParser
+from pathlib import Path
+from urllib.request import Request, urlopen
+
+from openpyxl import load_workbook
+
+
+DATA_DIR = Path("data")
+
+
+PROFILES = {
+    "2025-26-topps-chrome-platinum": {
+        "xlsx": "import/2025-Topps-Chrome-Platinum-Baseball-Checklist.xlsx",
+        "url": "https://baseballcardpedia.com/index.php/2025-26_Topps_Chrome_Platinum",
+        "set_name": "2025-26 Topps Chrome Platinum Anniversary",
+        "series": "Topps Chrome Platinum Anniversary",
+        "season": "2025-26",
+        "years": [2025, 2026],
+        "release_date": "2026-06-05",
+        "manufacturer": "Topps",
+        "sheets": ["Base", "Variations", "Autographs", "Inserts"],
+        "base_sections": {"Base"},
+        "image_root": "https://example.com/cards/2025-26-topps-chrome-platinum",
+        "set_image_url": "https://example.com/images/2025-26-topps-chrome-platinum.jpg",
+    },
+    "2026-bowman": {
+        "xlsx": "import/2026-Bowman-Baseball-Checklist.xlsx",
+        "url": "https://baseballcardpedia.com/index.php/2026_Bowman#Checklist",
+        "set_name": "2026 Bowman",
+        "series": "2026 Bowman",
+        "season": "2026",
+        "years": [2026],
+        "release_date": "2026-05-13",
+        "manufacturer": "Topps",
+        "sheets": ["Base", "Prospects", "Autographs", "Inserts"],
+        "base_sections": {"Base Set"},
+        "image_root": "https://example.com/cards/2026-bowman",
+        "set_image_url": "https://example.com/images/2026-bowman.jpg",
+        "section_print_runs": {
+            "Chrome Prospects Packfractor Variation": 89,
+            "Chrome Prospect Gold Ink Autographs": 15,
+            "Chrome Prospect Packfractor Autographs": 89,
+            "Draft Pick Pairings": 25,
+            "Bowman Sterling Autographs": 150,
+            "Electric Sluggers Autographs": 99,
+            "Under The Radar Autographs": 99,
+            "Power Chords Autographs": 99,
+            "Ultimate Autograph Booklet": 10,
+        },
+        "section_estimated_print_runs": {
+            "Bowman Sterling": 107800,
+            "Electric Sluggers": 69625,
+            "Under The Radar": 80900,
+            "Power Chords": 29075,
+        },
+    },
+    "2026-topps-series-2": {
+        "xlsx": "import/2026-Topps-Series-2-Baseball-Checklist.xlsx",
+        "url": "https://baseballcardpedia.com/index.php/2026_Topps#Checklist",
+        "set_name": "2026 Topps Series 2",
+        "series": "2026 Topps Baseball",
+        "series_number": 2,
+        "season": "2026",
+        "years": [2026],
+        "release_date": "2026-06-11",
+        "manufacturer": "Topps",
+        "sheets": ["Base", "Variations", "Autographs", "Memorabilia", "Inserts"],
+        "base_sections": {"Base"},
+        "image_root": "https://example.com/cards/2026-topps-series-2",
+        "set_image_url": "https://example.com/images/2026-topps-series-2.jpg",
+        "section_print_runs": {
+            "In The Name Relics": 1,
+        },
+        "section_relics": {
+            "Major League Material",
+            "City Connect Swatch Collection",
+            "Real One Relics",
+            "Rounding The Bases Relics",
+            "1991 Topps Baseball Relics",
+            "1991 Topps Baseball All-Star Relics",
+            "In The Name Relics",
+            "Topps Flagship Autograph Patches",
+            "Heavy Lumber Autograph Relics",
+            "Major League Materials Autographs",
+            "Major Legaue Materials Dual Autographs",
+            "City Connect Swatches Autographs",
+            "Rounding The Bases Autographs",
+        },
+    },
+    "2026-donruss": {
+        "xlsx": "import/2026-Donruss-Baseball-Checklist.xlsx",
+        "url": "https://baseballcardpedia.com/index.php/2026_Donruss#Checklist",
+        "set_name": "2026 Donruss",
+        "series": "2026 Donruss",
+        "season": "2026",
+        "years": [2026],
+        "release_date": "2026-05-27",
+        "manufacturer": "Panini",
+        "category": ["Baseball"],
+        "sheets": ["Base", "Optic", "Autographs", "Memorabilia", "Inserts"],
+        "base_sections": {"Base Set"},
+        "image_root": "https://example.com/cards/2026-donruss",
+        "set_image_url": "https://example.com/images/2026-donruss.jpg",
+        "section_relics": {"Jersey Kings", "Prospect Jersey Kings", "Retro 1985 Materials"},
+    },
+    "2026-topps-chrome-black": {
+        "xlsx": "import/2026-Topps-Chrome-Black-Baseball-Checklist.xlsx",
+        "url": "https://baseballcardpedia.com/index.php/2026_Topps_Chrome_Black#Checklist",
+        "set_name": "2026 Topps Chrome Black",
+        "series": "2026 Topps Chrome Black",
+        "season": "2026",
+        "years": [2026],
+        "release_date": "2026-04-29",
+        "manufacturer": "Topps",
+        "sheets": ["Base", "Autographs", "Inserts"],
+        "base_sections": {"Base Set"},
+        "image_root": "https://example.com/cards/2026-topps-chrome-black",
+        "set_image_url": "https://example.com/images/2026-topps-chrome-black.jpg",
+    },
+    "2025-26-topps-definitive-collection": {
+        "xlsx": "import/2025-Topps-Definitive-Baseball-Checklist.xlsx",
+        "url": "https://baseballcardpedia.com/index.php/2025-26_Topps_Definitive_Collection#Checklist",
+        "set_name": "2025-26 Topps Definitive Collection",
+        "series": "Topps Definitive Collection",
+        "season": "2025-26",
+        "years": [2025, 2026],
+        "release_date": "2026-04-29",
+        "manufacturer": "Topps",
+        "sheets": ["Base", "Autographs", "Autographed Relics", "Memorabilia Cards"],
+        "base_sections": set(),
+        "image_root": "https://example.com/cards/2025-26-topps-definitive-collection",
+        "set_image_url": "https://example.com/images/2025-26-topps-definitive-collection.jpg",
+        "all_cards_serial_numbered": True,
+        "default_print_run": 50,
+    },
+    "2026-panini-prizm-stars-stripes": {
+        "xlsx": "import/2026-Panini-Prizm-Stars-Stripes-Baseball-Checklist.xlsx",
+        "url": "https://baseballcardpedia.com/index.php/2026_Panini_Stars_%26_Stripes_Prizm#Checklist",
+        "set_name": "2026 Panini Stars & Stripes Prizm",
+        "series": "2026 Panini Stars & Stripes Prizm",
+        "season": "2026",
+        "years": [2026],
+        "release_date": "2026-04-03",
+        "manufacturer": "Panini",
+        "category": ["USA Baseball"],
+        "sheets": ["Base", "Autographs", "Memorabilia", "Inserts"],
+        "base_sections": {"Base Set"},
+        "default_team": "USA Baseball",
+        "image_root": "https://example.com/cards/2026-panini-prizm-stars-stripes",
+        "set_image_url": "https://example.com/images/2026-panini-prizm-stars-stripes.jpg",
+        "section_relics": {"Jumbo Materials Flag", "Jumbo Materials Jersey", "Jumbo Materials Cap", "USA Materials"},
+    },
+    "2025-26-topps-transcendent": {
+        "xlsx": "import/2025-Topps-Transcendent-Baseball-Checklist.xlsx",
+        "url": "https://baseballcardpedia.com/index.php/2025-26_Topps_Transcendent#Checklist",
+        "set_name": "2025-26 Topps Transcendent",
+        "series": "Topps Transcendent",
+        "season": "2025-26",
+        "years": [2025, 2026],
+        "release_date": "2026-04-01",
+        "manufacturer": "Topps",
+        "sheets": ["Base", "Autographs", "Memorabilia Cards", "Inserts"],
+        "base_sections": {"Base Set"},
+        "image_root": "https://example.com/cards/2025-26-topps-transcendent",
+        "set_image_url": "https://example.com/images/2025-26-topps-transcendent.jpg",
+        "section_relics": {
+            "Transcendent Collection Patches",
+            "Legendary Relics",
+            "Transcendent Collection Dual Patches",
+            "Transcendent Collection Triple Patches",
+            "Transcendent Collection MLB Logo Patches",
+            "Autographed Relics",
+            "Autographed Patches",
+            "Rookie Showcase Autographed Patches",
+            "Jumbo Autographed Patches",
+            "World Series Autographed Relics",
+            "Autographed MLB Logo Patch",
+            "Cut Signature Relic Book",
+        },
+    },
+}
+
+
+class DescriptionParser(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.in_heading = False
+        self.in_description = False
+        self.current_heading = None
+        self.heading_parts = []
+        self.description_parts = []
+        self.descriptions = []
+
+    def handle_starttag(self, tag, attrs):
+        if tag in {"h1", "h2", "h3"}:
+            self.in_heading = True
+            self.heading_parts = []
+        elif tag == "p" and self.current_heading == "Description":
+            self.in_description = True
+            self.description_parts = []
+
+    def handle_endtag(self, tag):
+        if self.in_heading and tag in {"h1", "h2", "h3"}:
+            self.current_heading = clean_text("".join(self.heading_parts))
+            self.in_heading = False
+        elif tag == "p" and self.in_description:
+            text = clean_text("".join(self.description_parts))
+            if text:
+                self.descriptions.append(text)
+            self.in_description = False
+
+    def handle_data(self, data):
+        if self.in_heading:
+            self.heading_parts.append(data)
+        if self.in_description:
+            self.description_parts.append(data)
+
+    def handle_entityref(self, name):
+        self.handle_data(html.unescape(f"&{name};"))
+
+    def handle_charref(self, name):
+        self.handle_data(html.unescape(f"&#{name};"))
+
+
+def clean_text(value):
+    if value is None:
+        return ""
+    return re.sub(r"\s+", " ", html.unescape(str(value))).strip()
+
+
+def clean_name(value):
+    return clean_text(value).rstrip(",").strip()
+
+
+def slugify(value):
+    value = str(value).lower().replace("&", "and")
+    value = re.sub(r"[^a-z0-9]+", "-", value)
+    return value.strip("-")
+
+
+def yaml_quote(value):
+    escaped = str(value).replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'
+
+
+def read_existing_uuid(path):
+    if not path.exists():
+        return None
+    match = re.search(r'^uuid:\s*"?([0-9a-fA-F-]{36})"?\s*$', path.read_text(encoding="utf-8"), re.MULTILINE)
+    return match.group(1) if match else None
+
+
+def get_uuid(path):
+    return read_existing_uuid(path) or str(uuid.uuid4())
+
+
+def is_count_line(value):
+    return bool(re.match(r"^\d+\s+(cards?|players|figures)$", clean_text(value), re.IGNORECASE))
+
+
+def is_single_value_row(values):
+    first = clean_text(values[0] if values else None)
+    return all(clean_text(value) == "" for value in values[1:4])
+
+
+def next_nonblank_first(rows, start_index):
+    for row in rows[start_index:]:
+        values = list(row) + [None] * 5
+        first = clean_text(values[0])
+        if first:
+            return first
+    return ""
+
+
+def is_section_header(rows, index):
+    values = list(rows[index]) + [None] * 5
+    first = clean_text(values[0])
+    if not first or is_count_line(first) or not is_single_value_row(values):
+        return False
+    return is_count_line(next_nonblank_first(rows, index + 1))
+
+
+def parse_print_run(value):
+    text = clean_text(value)
+    match = re.match(r"^/(\d+)$", text)
+    return int(match.group(1)) if match else None
+
+
+def is_card_row(values, profile):
+    name = clean_text(values[1] if len(values) > 1 else None)
+    team = clean_text(values[2] if len(values) > 2 else None)
+    if not name:
+        return False
+    if team and parse_print_run(team) is None:
+        return True
+    return bool(profile.get("default_team"))
+
+
+def split_values(value):
+    return [part.strip() for part in re.split(r"\s*/\s*", clean_name(value)) if part.strip()]
+
+
+def team_for_subject(index, teams):
+    if not teams:
+        return ""
+    if len(teams) == 1:
+        return teams[0]
+    if index < len(teams):
+        return teams[index]
+    return teams[-1]
+
+
+def is_rookie(value):
+    return clean_text(value).upper() == "RC"
+
+
+def section_abbreviation(section):
+    words = re.findall(r"[A-Za-z0-9]+", section)
+    abbreviation = "".join(word[0] for word in words if word).upper()
+    return abbreviation or "CARD"
+
+
+def generated_number(section, count):
+    return f"{section_abbreviation(section)}-{count}"
+
+
+def read_cards_from_workbook(path, profile):
+    wb = load_workbook(path, read_only=True, data_only=True)
+    rows = []
+    missing_number_counts = {}
+
+    for sheet_name in profile["sheets"]:
+        ws = wb[sheet_name]
+        worksheet_rows = list(ws.iter_rows(values_only=True))
+        current_section = None
+        for index, row in enumerate(worksheet_rows):
+            values = list(row) + [None] * 5
+            if is_section_header(worksheet_rows, index):
+                current_section = clean_text(values[0])
+                continue
+            if not current_section or not is_card_row(values, profile):
+                continue
+
+            number = clean_text(values[0])
+            generated = False
+            if not number:
+                missing_number_counts[current_section] = missing_number_counts.get(current_section, 0) + 1
+                number = generated_number(current_section, missing_number_counts[current_section])
+                generated = True
+
+            names = split_values(values[1])
+            print_run = next((parse_print_run(value) for value in values[2:6] if parse_print_run(value) is not None), None)
+            raw_team = clean_text(values[2])
+            teams = split_values(raw_team) if raw_team and parse_print_run(raw_team) is None else []
+            if not teams and profile.get("default_team"):
+                teams = [profile["default_team"]]
+            rows.append(
+                {
+                    "number": number,
+                    "generated_number": generated,
+                    "subjects": [
+                        {
+                            "name": name,
+                            "team": team_for_subject(index, teams),
+                        }
+                        for index, name in enumerate(names)
+                    ],
+                    "rookie_card": is_rookie(values[3]),
+                    "serial_numbered": print_run is not None,
+                    "print_run": print_run,
+                    "section": current_section,
+                    "source_sheet": sheet_name,
+                    "note": clean_text(values[3]),
+                }
+            )
+
+    return merge_duplicate_cards(rows)
+
+
+def merge_duplicate_cards(rows):
+    cards = []
+    by_key = {}
+    for row in rows:
+        key = (row["section"], row["number"])
+        if key not in by_key:
+            row["subjects"] = list(row["subjects"])
+            by_key[key] = row
+            cards.append(row)
+            continue
+        existing = by_key[key]
+        existing["subjects"].extend(row["subjects"])
+        existing["rookie_card"] = existing["rookie_card"] or row["rookie_card"]
+        existing["serial_numbered"] = existing.get("serial_numbered") or row.get("serial_numbered")
+        existing["print_run"] = existing.get("print_run") or row.get("print_run")
+    return cards
+
+
+def fetch_description(url, fallback):
+    request = Request(url, headers={"User-Agent": "open-checklist-project-importer/0.3"})
+    with urlopen(request, timeout=30) as response:
+        parser = DescriptionParser()
+        parser.feed(response.read().decode("utf-8", errors="replace"))
+    return parser.descriptions[0] if parser.descriptions else fallback
+
+
+def card_filename(number, section, profile):
+    prefix = "" if section in profile["base_sections"] else f"{slugify(section)}-"
+    safe = re.sub(r"[^A-Za-z0-9_-]+", "-", f"{prefix}{number}").strip("-")
+    return f"{safe}.yaml"
+
+
+def display_section(section, profile):
+    return "Base" if section in profile["base_sections"] else section
+
+
+def card_title(card, profile):
+    return " / ".join(subject["name"] for subject in card["subjects"])
+
+
+def card_name(card, profile):
+    title = card_title(card, profile)
+    section = display_section(card["section"], profile)
+    return f"{title} - {section}"
+
+
+def card_description(card, profile):
+    title = card_title(card, profile)
+    section = display_section(card["section"], profile)
+    if is_autograph(card, profile):
+        if section.lower().startswith("autographed"):
+            return f"{section} card featuring {title}."
+        return f"Autographed {section} card featuring {title}."
+    if is_relic(card, profile):
+        return f"{section} memorabilia card featuring {title}."
+    return f"{section} card featuring {title}."
+
+
+def is_relic(card, profile):
+    if card["section"] in profile.get("section_relics", set()):
+        return True
+    section = card["section"].lower()
+    return any(term in section for term in ["relic", "material", "swatch", "patch", "jersey", "memorabilia"])
+
+
+def is_autograph(card, profile):
+    section = card["section"].lower()
+    return any(term in section for term in ["autograph", "signature", "signatures", "aurograph"])
+
+
+def variation_value(section):
+    normalized = section.lower()
+    if "variation" not in normalized:
+        return None
+    if "red rc" in normalized:
+        return "Red RC Variation"
+    if "etched in glass" in normalized:
+        return "Etched In Glass Variation"
+    if "city" in normalized:
+        return "City Variation"
+    if "image" in normalized:
+        return "Image Variation"
+    if "packfractor" in normalized:
+        return "Packfractor Variation"
+    if "kanji" in normalized:
+        return "Kanji Variation"
+    return section
+
+
+def write_set(set_dir, set_id, source_url, source_file, description, cards, profile):
+    set_path = set_dir / "set.yaml"
+    counts = {}
+    for card in cards:
+        counts[card["section"]] = counts.get(card["section"], 0) + 1
+
+    lines = [
+        f"uuid: {get_uuid(set_path)}",
+        f"set_id: {yaml_quote(set_id)}",
+        f"name: {yaml_quote(profile['set_name'])}",
+        'genre: "Sports"',
+        f"category: [{', '.join(yaml_quote(category) for category in profile.get('category', ['MLB']))}]",
+        'sports: ["Baseball"]',
+        f"season: {yaml_quote(profile['season'])}",
+        f"years: [{', '.join(str(year) for year in profile['years'])}]",
+        f"series: {yaml_quote(profile['series'])}",
+    ]
+    if "series_number" in profile:
+        lines.append(f"series_number: {profile['series_number']}")
+    lines.extend(
+        [
+            f"release_date: {yaml_quote(profile['release_date'])}",
+            f"manufacturer: {yaml_quote(profile['manufacturer'])}",
+            f"card_count: {len(cards)}",
+            f"description: {yaml_quote(description)}",
+            f"image_url: {yaml_quote(profile['set_image_url'])}",
+            "metadata:",
+            '  language: "en"',
+            f"  year: {profile['years'][-1]}",
+            f"  source_name: {yaml_quote('BaseballCardpedia')}",
+            f"  source_url: {yaml_quote(source_url)}",
+            f"  source_file: {yaml_quote(source_file)}",
+            "  subsets:",
+        ]
+    )
+    for section, count in counts.items():
+        lines.append(f"    - name: {yaml_quote(section)}")
+        lines.append(f"      card_count: {count}")
+
+    set_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def write_cards(set_dir, set_id, cards, profile):
+    cards_dir = set_dir / "cards"
+    cards_dir.mkdir(parents=True, exist_ok=True)
+    section_print_runs = profile.get("section_print_runs", {})
+    section_estimated_print_runs = profile.get("section_estimated_print_runs", {})
+
+    for card in cards:
+        path = cards_dir / card_filename(card["number"], card["section"], profile)
+        section = display_section(card["section"], profile)
+        autograph = is_autograph(card, profile)
+        relic = is_relic(card, profile)
+        role = "Player"
+        if "Team Card" in card.get("note", ""):
+            role = "Team"
+        image_slug = path.stem
+        print_run = card.get("print_run") or section_print_runs.get(card["section"])
+        if print_run is None and profile.get("all_cards_serial_numbered"):
+            print_run = profile.get("default_print_run")
+        estimated_print_run = section_estimated_print_runs.get(card["section"])
+        serial_numbered = bool(card.get("serial_numbered")) or print_run is not None
+
+        lines = [
+            f"number: {yaml_quote(card['number'])}",
+            f"uuid: {yaml_quote(get_uuid(path))}",
+            'genre: "Sports"',
+            'sport: "Baseball"',
+            f"set_id: {yaml_quote(set_id)}",
+            "subjects:",
+        ]
+        for subject in card["subjects"]:
+            lines.append(f"  - name: {yaml_quote(subject['name'])}")
+            lines.append(f"    role: {yaml_quote(role)}")
+            lines.append(f"    team: {yaml_quote(subject['team'])}")
+
+        if card["section"] not in profile["base_sections"]:
+            lines.append(f"subset: {yaml_quote(card['section'])}")
+        lines.extend(
+            [
+                f"card_name: {yaml_quote(card_name(card, profile))}",
+                f"description: {yaml_quote(card_description(card, profile))}",
+                f"series: {yaml_quote(profile['series'])}",
+            ]
+        )
+        variation = variation_value(card["section"])
+        if variation:
+            lines.append(f"variation: {yaml_quote(variation)}")
+        if print_run is not None:
+            lines.append(f"print_run: {print_run}")
+        elif estimated_print_run is not None:
+            lines.append(f"print_run: {estimated_print_run}")
+        lines.extend(
+            [
+                f"rookie_card: {str(card['rookie_card']).lower()}",
+                f"autograph: {str(autograph).lower()}",
+                f"relic: {str(relic).lower()}",
+                f"serial_numbered: {str(serial_numbered).lower()}",
+                f"release_date: {yaml_quote(profile['release_date'])}",
+                f"image_url: {yaml_quote(f'{profile['image_root']}/{image_slug}.jpg')}",
+            ]
+        )
+
+        path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--set-id", choices=sorted(PROFILES), default="2025-26-topps-chrome-platinum")
+    parser.add_argument("--url")
+    parser.add_argument("--xlsx")
+    parser.add_argument("--category", default="baseball")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    profile = PROFILES[args.set_id]
+    source_url = args.url or profile["url"]
+    source_file = args.xlsx or profile["xlsx"]
+    cards = read_cards_from_workbook(Path(source_file), profile)
+    set_dir = DATA_DIR / args.category / args.set_id
+    set_dir.mkdir(parents=True, exist_ok=True)
+    description = fetch_description(source_url, f"{profile['set_name']} checklist.")
+    write_set(set_dir, args.set_id, source_url, source_file, description, cards, profile)
+    write_cards(set_dir, args.set_id, cards, profile)
+    print(f"Wrote {len(cards)} cards to {set_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/validate.py
+++ b/tools/validate.py
@@ -11,7 +11,16 @@ DATA_DIR = Path("data")
 
 def load_schema(schema_file):
     with open(schema_file, "r") as f:
-        return yaml.safe_load(f)
+        schema = yaml.safe_load(f)
+
+    # Windows checkouts without symlink support can read schema symlinks as
+    # plain files containing targets like "v0.2/schema.yaml".
+    if isinstance(schema, str) and schema.endswith((".yaml", ".yml")):
+        target = schema_file.parent / schema
+        with open(target, "r") as f:
+            schema = yaml.safe_load(f)
+
+    return schema
 
 def validate_file(file_path, schema):
     with open(file_path, "r") as f:


### PR DESCRIPTION
Foundation tooling split out from #13.

- `tools/import_checklist.py` — XLSX-first BaseballCardpedia importer
- `tools/expand_parallels.py` — per-set parallel/variation expander with resume/skip
- `tools/validate.py` — resolve schema symlink pointer files on Windows checkouts
- `.gitignore` — ignore raw `import/` workbooks

Per-set data PRs (one per set) will follow against `main`.

Closes #14. Original author: @jmurphyrum

Co-authored-by: jmurphyrum <jmurphy@royalunited.com>