### PR TITLE
fix(tools): resolve schema symlink pointer files on Windows checkouts

### DIFF
--- a/tools/validate.py
+++ b/tools/validate.py
@@ -10,6 +10,7 @@ SCHEMA_DIR = Path("schemas")
 DATA_DIR = Path("data")
 
 def load_schema(schema_file):
+    schema_file = Path(schema_file)
     with open(schema_file, "r") as f:
         schema = yaml.safe_load(f)
 

--- a/tools/validate.py
+++ b/tools/validate.py
@@ -11,7 +11,16 @@ DATA_DIR = Path("data")
 
 def load_schema(schema_file):
     with open(schema_file, "r") as f:
-        return yaml.safe_load(f)
+        schema = yaml.safe_load(f)
+
+    # Windows checkouts without symlink support can read schema symlinks as
+    # plain files containing targets like "v0.2/schema.yaml".
+    if isinstance(schema, str) and schema.endswith((".yaml", ".yml")):
+        target = schema_file.parent / schema
+        with open(target, "r") as f:
+            schema = yaml.safe_load(f)
+
+    return schema
 
 def validate_file(file_path, schema):
     with open(file_path, "r") as f:


### PR DESCRIPTION
Small, general fix to the existing validator, split out from #13.

On Windows checkouts without symlink support, `schemas/*/schema.yaml` is read as a plain text file containing its target (e.g. `v0.1/schema.yaml`). `load_schema` now detects that and follows the pointer.

This is the only piece of #13's `/tools` changes worth keeping — the import/expand generator scripts were one-off, set-specific scaffolding (hardcoded to this PR's 8 sets) and are intentionally not included.

Original author: @jmurphyrum
Co-authored-by: jmurphyrum <jmurphy@royalunited.com>