### PR TITLE
Proposal: v0.3 manifest form (compact generating form)

### DIFF
--- a/proposals/v0.3-manifest-form/IDENTITY.md
+++ b/proposals/v0.3-manifest-form/IDENTITY.md
@@ -100,7 +100,7 @@ nodes reuse the same card `number`.
    of that node. (Undeclared id = hard error.)
 9. Node `id`s MUST be unique across the whole manifest (base sets and subsets share
    one id-space — each maps to `checklists/<id>.yaml`). A base set carries no `type`;
-   a subset MUST carry one.
+   a subset MUST carry at least one type (a list; e.g. [autograph, relic] for an auto-relic).
 
 ## Namespace constant
 

--- a/proposals/v0.3-manifest-form/IDENTITY.md
+++ b/proposals/v0.3-manifest-form/IDENTITY.md
@@ -9,16 +9,23 @@ the same UUID for every consumer. Three ways a UUID comes to exist:
 ## 1. Minted (committed)
 
 Assigned once by the identity authority (**tcapi**) and committed verbatim in OCP.
-Applies to:
+The product is a hierarchy — one **product/umbrella** containing one or more **base
+sets**, each containing recursive **subsets**, each holding **rows** — and every node
+in it carries a committed anchor uuid:
 
-- **set** `uuid` (in `set.yaml`)
-- **base checklist row** `uuid` (each row in `checklists/<subset>.yaml`)
+- **product** `uuid` (in `set.yaml`) — the umbrella above the base sets.
+- **base set** `uuid` (each entry in `manifest.base_sets[]`) — a base set is its own
+  identity anchor, distinct from the product. One product may have several.
+- **subset** `uuid` (each `subsets[]` node, at any nesting depth) — an insert /
+  autograph / relic / variation is its own anchor.
+- **checklist row** `uuid` (each row in `checklists/<node-id>.yaml`).
 - **entities** — player/team/attribute UUIDs, referenced via `subject.ref` /
   `team.ref`. Owned entirely by tcapi (see the identity/resolution workstream).
 
 Minted UUIDs are UUIDv4 (random). They never change. In particular a row's `uuid` is
 **stable under renumbering**: if a card's `number` is later corrected, keep the
-`uuid` and change only `number` — identity does not move.
+`uuid` and change only `number` — identity does not move. The same holds for a node's
+`uuid` under renaming or re-parenting: the anchor is stable, the label is not.
 
 ## 2. Derived (never committed)
 
@@ -60,31 +67,40 @@ def parallel_uuid(base_row_uuid: str, parallel_name: str) -> str:
     return str(uuid.uuid5(uuid.UUID(base_row_uuid), parallel_name))
 ```
 
-## 3. Nested parallels
+## 3. Uniform across the hierarchy
 
-A subset that is itself an insert (`kind: insert`, etc.) has its **own** committed
-checklist rows with their own minted `uuid`s. Its parallels derive off *those* row
-uuids by the exact same rule — the derivation is uniform across all subset kinds.
+Derivation is **identical at every node and every depth**. A base set, an insert
+subset, an autograph subset nested inside it — each has its **own** committed
+checklist rows with their own minted `uuid`s, and each node's parallels derive off
+*those* row uuids by the exact same `uuidv5(row.uuid, parallel.name)` rule. There is
+no special case for base vs. subset, or for nesting level: a node is a node. Because
+each row uuid is globally unique, parallels never collide across nodes even when two
+nodes reuse the same card `number`.
 
 ## Invariants (enforced by the validation gate)
 
-1. `parallels[].name` MUST be unique within a subset (else two parallels collide to
-   one UUID).
+1. `parallels[].name` MUST be unique within a node (else two parallels collide to one
+   UUID).
 2. A checklist row `uuid` MUST be present and a valid UUID before expansion.
-3. Row `uuid` MUST NOT be reused across rows or across sets.
-4. Changing `number`, `subjects`, or any field on a row MUST NOT change its `uuid`.
+3. Every anchor `uuid` — product, base set, subset (any depth), and row — MUST be
+   unique across the whole product; none reused across nodes or across sets.
+4. Changing `number`, `subjects`, or any field on a row MUST NOT change its `uuid`;
+   likewise renaming or re-parenting a node MUST NOT change the node's `uuid`.
 5. Renaming a `parallels[].name` DOES change that parallel's derived UUIDs — treat a
    rename as a breaking identity change, not a typo fix.
 6. Every card number listed in a parallel's `applies_to.numbers` or `applies_to.except`
-   MUST exist in that subset's base checklist. A reference to a nonexistent number is
-   a hard error — it catches typos and silent no-ops (an `except` that excludes
-   nothing, a `numbers` that includes nothing).
-7. **Sections partition the checklist.** `sections` is OPTIONAL; a subset with none is
+   MUST exist in that node's checklist. A reference to a nonexistent number is a hard
+   error — it catches typos and silent no-ops (an `except` that excludes nothing, a
+   `numbers` that includes nothing).
+7. **Sections partition the checklist.** `sections` is OPTIONAL; a node with none is
    one implicit section. When declared, every committed row MUST match EXACTLY ONE
    section — a row matching zero (uncovered) or more than one (overlap) is a hard
-   error. Section `id`s MUST be unique within the subset.
+   error. Section `id`s MUST be unique within the node.
 8. Every section id in a parallel's `applies_to.sections` MUST be a declared section
-   of that subset. (Undeclared id = hard error.)
+   of that node. (Undeclared id = hard error.)
+9. Node `id`s MUST be unique across the whole manifest (base sets and subsets share
+   one id-space — each maps to `checklists/<id>.yaml`). A base set carries no `type`;
+   a subset MUST carry one.
 
 ## Namespace constant
 

--- a/proposals/v0.3-manifest-form/IDENTITY.md
+++ b/proposals/v0.3-manifest-form/IDENTITY.md
@@ -1,0 +1,70 @@
+# OCP Identity & UUID Derivation — FROZEN SPEC
+
+**Version:** 1.0 (draft, 2026-07-06). **Once published, this contract cannot change
+without breaking every downstream consumer.** Treat edits as a versioned migration.
+
+Canonical UUIDs are OCP's public interoperability primitive: the same set/card means
+the same UUID for every consumer. Three ways a UUID comes to exist:
+
+## 1. Minted (committed)
+
+Assigned once by the identity authority (**tcapi**) and committed verbatim in OCP.
+Applies to:
+
+- **set** `uuid` (in `set.yaml`)
+- **base checklist row** `uuid` (each row in `checklists/<subset>.yaml`)
+- **entities** — player/team/attribute UUIDs, referenced via `subject.ref` /
+  `team.ref`. Owned entirely by tcapi (see the identity/resolution workstream).
+
+Minted UUIDs are UUIDv4 (random). They never change. In particular a row's `uuid` is
+**stable under renumbering**: if a card's `number` is later corrected, keep the
+`uuid` and change only `number` — identity does not move.
+
+## 2. Derived (never committed)
+
+The mechanical parallel explosion. For a parallel `p` of a checklist row `r`:
+
+```
+parallel_card.uuid = uuidv5(namespace = r.uuid, name = p.name)
+```
+
+- `namespace` is the row's committed `uuid` (a valid UUID → valid v5 namespace).
+  This binds the parallel to its specific base card.
+- `name` is the manifest `parallels[].name` string, used as its **exact UTF-8 bytes**:
+  no case-folding, no trimming, no Unicode normalization. Authoring must keep the
+  string clean; consumers must not transform it. Both inputs are OCP-published
+  canonical values, so every consumer computes the identical UUID.
+
+Reference implementation:
+
+```python
+import uuid
+def parallel_uuid(base_row_uuid: str, parallel_name: str) -> str:
+    return str(uuid.uuid5(uuid.UUID(base_row_uuid), parallel_name))
+```
+
+## 3. Nested parallels
+
+A subset that is itself an insert (`kind: insert`, etc.) has its **own** committed
+checklist rows with their own minted `uuid`s. Its parallels derive off *those* row
+uuids by the exact same rule — the derivation is uniform across all subset kinds.
+
+## Invariants (enforced by the validation gate)
+
+1. `parallels[].name` MUST be unique within a subset (else two parallels collide to
+   one UUID).
+2. A checklist row `uuid` MUST be present and a valid UUID before expansion.
+3. Row `uuid` MUST NOT be reused across rows or across sets.
+4. Changing `number`, `subjects`, or any field on a row MUST NOT change its `uuid`.
+5. Renaming a `parallels[].name` DOES change that parallel's derived UUIDs — treat a
+   rename as a breaking identity change, not a typo fix.
+
+## Namespace constant
+
+Base/entity UUIDs are minted, not derived, so no global namespace constant is
+required for card identity. Should a future version ever derive a base UUID, the
+frozen namespace to use is defined here first:
+
+```
+OCP_NAMESPACE = "<CHOOSE-ONCE-AND-FREEZE-BEFORE-FIRST-PUBLISH>"   # UUIDv4, placeholder
+```

--- a/proposals/v0.3-manifest-form/IDENTITY.md
+++ b/proposals/v0.3-manifest-form/IDENTITY.md
@@ -41,8 +41,11 @@ parallel_card.uuid = uuidv5(namespace = r.uuid, name = p.name)
 
 - **`applies_to` is a membership filter, not an identity input.** It selects *which*
   rows produce a derived card; adding or removing a row from a parallel's coverage
-  (e.g. correcting an `except`) makes a card appear/disappear but never changes any
-  other card's UUID. Re-sync stays idempotent.
+  (e.g. correcting an `except`, or a row moving between `sections`) makes a card
+  appear/disappear but never changes any other card's UUID. Re-sync stays idempotent.
+- **`sections` are derived membership, not identity.** A row's section is computed at
+  consume time from the manifest's section declarations; it is not committed on the
+  row and is not a `uuidv5` input. Re-sectioning a checklist never moves a UUID.
 - **Reserved seam for exceptions.** A card present in a parallel with a *different*
   attribute (e.g. a one-off print run) can be expressed by a future additive
   `overrides` field WITHOUT an identity migration — because the override changes an
@@ -76,6 +79,12 @@ uuids by the exact same rule — the derivation is uniform across all subset kin
    MUST exist in that subset's base checklist. A reference to a nonexistent number is
    a hard error — it catches typos and silent no-ops (an `except` that excludes
    nothing, a `numbers` that includes nothing).
+7. **Sections partition the checklist.** `sections` is OPTIONAL; a subset with none is
+   one implicit section. When declared, every committed row MUST match EXACTLY ONE
+   section — a row matching zero (uncovered) or more than one (overlap) is a hard
+   error. Section `id`s MUST be unique within the subset.
+8. Every section id in a parallel's `applies_to.sections` MUST be a declared section
+   of that subset. (Undeclared id = hard error.)
 
 ## Namespace constant
 

--- a/proposals/v0.3-manifest-form/IDENTITY.md
+++ b/proposals/v0.3-manifest-form/IDENTITY.md
@@ -8,7 +8,7 @@ the same UUID for every consumer. Three ways a UUID comes to exist:
 
 ## 1. Minted (committed)
 
-Assigned once by the identity authority (**tcapi**) and committed verbatim in OCP.
+Assigned once and committed verbatim in OCP (anchors, as opposed to derived ids).
 The product is a hierarchy — one **product/umbrella** containing one or more **base
 sets**, each containing recursive **subsets**, each holding **rows** — and every node
 in it carries a committed anchor uuid:
@@ -20,7 +20,7 @@ in it carries a committed anchor uuid:
   autograph / relic / variation is its own anchor.
 - **checklist row** `uuid` (each row in `checklists/<node-id>.yaml`).
 - **entities** — player/team/attribute UUIDs, referenced via `subject.ref` /
-  `team.ref`. Owned entirely by tcapi (see the identity/resolution workstream).
+  `team.ref`. Resolved via a separate identity/resolution workstream.
 
 Minted UUIDs are UUIDv4 (random). They never change. In particular a row's `uuid` is
 **stable under renumbering**: if a card's `number` is later corrected, keep the

--- a/proposals/v0.3-manifest-form/IDENTITY.md
+++ b/proposals/v0.3-manifest-form/IDENTITY.md
@@ -35,6 +35,20 @@ parallel_card.uuid = uuidv5(namespace = r.uuid, name = p.name)
   string clean; consumers must not transform it. Both inputs are OCP-published
   canonical values, so every consumer computes the identical UUID.
 
+**Identity depends on `(r.uuid, p.name)` and nothing else.** `print_run`,
+`serial_numbered`, `applies_to`, and any future per-card attribute override are
+**not** derivation inputs. Two consequences the spec commits to:
+
+- **`applies_to` is a membership filter, not an identity input.** It selects *which*
+  rows produce a derived card; adding or removing a row from a parallel's coverage
+  (e.g. correcting an `except`) makes a card appear/disappear but never changes any
+  other card's UUID. Re-sync stays idempotent.
+- **Reserved seam for exceptions.** A card present in a parallel with a *different*
+  attribute (e.g. a one-off print run) can be expressed by a future additive
+  `overrides` field WITHOUT an identity migration — because the override changes an
+  attribute, not `(r.uuid, p.name)`. This is deliberately not built in v0.3, but the
+  invariant above is what keeps it a non-breaking change when it is.
+
 Reference implementation:
 
 ```python
@@ -58,6 +72,10 @@ uuids by the exact same rule — the derivation is uniform across all subset kin
 4. Changing `number`, `subjects`, or any field on a row MUST NOT change its `uuid`.
 5. Renaming a `parallels[].name` DOES change that parallel's derived UUIDs — treat a
    rename as a breaking identity change, not a typo fix.
+6. Every card number listed in a parallel's `applies_to.numbers` or `applies_to.except`
+   MUST exist in that subset's base checklist. A reference to a nonexistent number is
+   a hard error — it catches typos and silent no-ops (an `except` that excludes
+   nothing, a `numbers` that includes nothing).
 
 ## Namespace constant
 

--- a/proposals/v0.3-manifest-form/README.md
+++ b/proposals/v0.3-manifest-form/README.md
@@ -48,10 +48,10 @@ data/<genre>/<set-id>/
 
 | Thing | Committed? | How |
 |---|---|---|
-| product `uuid` (set.yaml) | ✅ committed | the umbrella; minted by tcapi (identity authority) |
-| base set / subset `uuid` (each node) | ✅ committed | each node is its own anchor — minted by tcapi |
+| product `uuid` (set.yaml) | ✅ committed | the umbrella; a committed canonical id |
+| base set / subset `uuid` (each node) | ✅ committed | each node is its own committed anchor |
 | checklist row `uuid` | ✅ committed | the canonical card identity — stable forever |
-| entity `ref` (in a subject) | ✅ referenced | owned by tcapi; resolution populates it |
+| entity `ref` (in a subject) | ✅ referenced | a canonical entity id; resolution populates it |
 | **parallel card `uuid`** | ❌ **derived** | `uuidv5(row.uuid, parallel.name)` — see IDENTITY.md |
 | card `name` | ❌ derived / ✅ `title` | derived from `subjects` (see below); the optional row `title` overrides |
 | card `description` | ✅ committed (optional) | explicit blurb on the row, when a card has one |
@@ -61,7 +61,7 @@ data/<genre>/<set-id>/
 ## Consume-time expansion (deterministic)
 
 ```python
-# pseudocode — runs in the consumer/CI, output goes to tcapi. Nothing persisted in OCP.
+# pseudocode — runs in the consumer/CI, output goes to the consumer. Nothing persisted in OCP.
 # One recursive walk handles base sets, subsets, and any nesting — a node is a node.
 for base_set in manifest.base_sets:
     expand(base_set)
@@ -94,7 +94,7 @@ def applies(p, row, sections):
 to `uuidv5`. So an exception adds/removes a card without moving any other uuid, and
 re-sync stays idempotent.
 
-`emit_card` maps OCP fields → tcapi's card schema and upserts by `uuid` (idempotent
+`emit_card` maps OCP fields → the consumer's card schema and upserts by `uuid` (idempotent
 re-sync). Because every uuid is deterministic, re-running produces byte-identical
 identities — an update is an update, never a duplicate.
 

--- a/proposals/v0.3-manifest-form/README.md
+++ b/proposals/v0.3-manifest-form/README.md
@@ -30,10 +30,13 @@ data/<genre>/<set-id>/
 
 - **set.yaml** — descriptive **product / umbrella** metadata. No parallels, no card
   counts (derived). Its `uuid` is the product's; each base set has its own.
-- **manifest.yaml** — `base_sets[]` (**one or more** roots) plus, under each, recursive
-  `subsets[]`. A base set and a subset are the **same node shape** — own checklist,
-  `parallels`, optional `sections`, and child `subsets` — differing only in that a base
-  set has no `type` and a subset carries one (`insert`/`autograph`/…). `sections` is a
+- **manifest.yaml** — `base_sets[]` (**one or more** roots) plus an optional
+  product-level `subsets[]` (inserts not tied to a base set, e.g. "Anime"), and under
+  each node a recursive `subsets[]`. A base set and a subset are the **same node shape**
+  — own checklist, `parallels`, optional `sections`, and child `subsets` — differing only
+  in that a base set has no `type` and a subset carries one (`insert`/`autograph`/…). A
+  subset nests wherever it belongs: under a base set (its variations/autos), under another
+  subset (an insert's autos), or at the product level (a standalone insert). `sections` is a
   singular editorial partition of a node's checklist (e.g. Veterans / Rookies), declared
   as a `range` or explicit `numbers` and derived onto rows at consume time; a parallel
   can target one via `applies_to.sections`.

--- a/proposals/v0.3-manifest-form/README.md
+++ b/proposals/v0.3-manifest-form/README.md
@@ -54,13 +54,23 @@ for subset in manifest.subsets:
     for row in rows:
         emit_card(uuid=row.uuid, subset=subset, parallel=None, row=row)   # the base card (committed uuid)
         for p in subset.parallels:
-            if applies(p, row):                                           # applies_to: all | numbers[...]
+            if applies(p, row):                                           # membership filter, below
                 emit_card(
                     uuid = uuidv5(row.uuid, p.name),                      # DERIVED, reproducible everywhere
                     subset = subset, parallel = p, row = row,
                     print_run = p.print_run, serial_numbered = p.serial_numbered,
                 )
+
+def applies(p, row):
+    a = p.get("applies_to", "all")
+    if a == "all":       return True
+    if "numbers" in a:   return row.number in a["numbers"]   # ONLY these rows
+    if "except"  in a:   return row.number not in a["except"] # all rows EXCEPT these
 ```
+
+`applies_to` only gates *whether* a row emits a parallel card — it is never an input
+to `uuidv5`. So an exception adds/removes a card without moving any other uuid, and
+re-sync stays idempotent.
 
 `emit_card` maps OCP fields → tcapi's card schema and upserts by `uuid` (idempotent
 re-sync). Because every uuid is deterministic, re-running produces byte-identical

--- a/proposals/v0.3-manifest-form/README.md
+++ b/proposals/v0.3-manifest-form/README.md
@@ -1,0 +1,81 @@
+# OCP v0.3 — the manifest (compact generating form)
+
+**Status:** draft for review (2026-07-06). Supersedes the exploded one-file-per-card layout.
+
+## Why
+
+The v0.2 layout commits every parallel of every card as its own file. Real proof:
+2026 Bowman (PR #19) = **17,928 card files**, where all variants of a card are
+identical except `uuid`, a per-parallel-constant `print_run`/`serial_numbered`, and
+templated `card_name`/`description`/`image_url` (17,928 *fabricated* placeholder
+image URLs). No human can review that.
+
+v0.3 commits the **compact generating form** and derives the explosion at consume
+time. 2026 Bowman collapses from **17,928 files → ~4 readable ones**.
+
+## Layout
+
+```
+data/<genre>/<set-id>/
+  set.yaml                 # set-level metadata + source attribution (what it IS)
+  manifest.yaml            # subsets + parallels (the generating STRUCTURE)
+  checklists/
+    base.yaml              # committed row identities for subset `base`
+    bowman-scouts-top-100.yaml
+    chrome-prospect-autographs.yaml
+    ...                    # one file per subset id
+```
+
+- **set.yaml** — descriptive metadata. No parallels, no card counts (derived).
+- **manifest.yaml** — the list of subsets; each subset declares its `kind`, its
+  declared base-checklist size (a review check), and its `parallels`.
+- **checklists/&lt;subset-id&gt;.yaml** — an array of rows (`number → subjects`), each
+  with a **committed `uuid`** (the canonical, shared card identity). One file per
+  subset; the filename matches the subset `id`.
+
+## What is committed vs. derived
+
+| Thing | Committed? | How |
+|---|---|---|
+| set `uuid` | ✅ committed | minted by tcapi (identity authority), published here |
+| base checklist row `uuid` | ✅ committed | the canonical card identity — stable forever |
+| entity `ref` (player/team UUID) | ✅ referenced | owned by tcapi; resolution populates it |
+| **parallel card `uuid`** | ❌ **derived** | `uuidv5(base_row.uuid, parallel.name)` — see IDENTITY.md |
+| `card_name` / `description` | ❌ derived | composed at display time from subject + subset + parallel |
+| `image_url` | ❌ enrichment | keyed by card uuid, added later — never fabricated |
+| total `card_count` | ❌ derived | expansion count; the review report checks it |
+
+## Consume-time expansion (deterministic)
+
+```python
+# pseudocode — runs in the consumer/CI, output goes to tcapi. Nothing persisted in OCP.
+for subset in manifest.subsets:
+    rows = load(f"checklists/{subset.id}.yaml")
+    for row in rows:
+        emit_card(uuid=row.uuid, subset=subset, parallel=None, row=row)   # the base card (committed uuid)
+        for p in subset.parallels:
+            if applies(p, row):                                           # applies_to: all | numbers[...]
+                emit_card(
+                    uuid = uuidv5(row.uuid, p.name),                      # DERIVED, reproducible everywhere
+                    subset = subset, parallel = p, row = row,
+                    print_run = p.print_run, serial_numbered = p.serial_numbered,
+                )
+```
+
+`emit_card` maps OCP fields → tcapi's card schema and upserts by `uuid` (idempotent
+re-sync). Because every uuid is deterministic, re-running produces byte-identical
+identities — an update is an update, never a duplicate.
+
+## Review report (separate artifact, not built here)
+
+The manifest form is what makes the computed review report possible: base counts vs.
+declared, numbering gaps, duplicate parallel names, print-run sanity — all read from
+a handful of files at editorial altitude. Spec'd separately.
+
+## Files in this draft
+
+- `schemas/set.v0.3.schema.yaml`
+- `schemas/manifest.v0.1.schema.yaml`
+- `schemas/checklist.v0.1.schema.yaml`
+- `IDENTITY.md` — the frozen UUID-derivation spec
+- `example/2026-bowman/` — a folded, abbreviated worked example

--- a/proposals/v0.3-manifest-form/README.md
+++ b/proposals/v0.3-manifest-form/README.md
@@ -1,6 +1,6 @@
 # OCP v0.3 — the manifest (compact generating form)
 
-**Status:** draft for review (2026-07-06). Supersedes the exploded one-file-per-card layout.
+**Status:** draft for review (updated 2026-07-09). Supersedes the exploded one-file-per-card layout.
 
 ## Why
 
@@ -11,40 +11,45 @@ templated `card_name`/`description`/`image_url` (17,928 *fabricated* placeholder
 image URLs). No human can review that.
 
 v0.3 commits the **compact generating form** and derives the explosion at consume
-time. 2026 Bowman collapses from **17,928 files → ~4 readable ones**.
+time. 2026 Bowman collapses from **17,928 files → a handful of readable ones** (a
+`set.yaml`, a `manifest.yaml`, and one checklist per base set / subset).
 
 ## Layout
 
 ```
 data/<genre>/<set-id>/
-  set.yaml                 # set-level metadata + source attribution (what it IS)
-  manifest.yaml            # subsets + parallels (the generating STRUCTURE)
+  set.yaml                 # PRODUCT metadata + source attribution (what it IS)
+  manifest.yaml            # base_sets + subsets + parallels (the generating STRUCTURE)
   checklists/
-    base.yaml              # committed row identities for subset `base`
+    bowman.yaml            # committed row identities for base set `bowman`
     bowman-scouts-top-100.yaml
+    bowman-chrome-prospects.yaml
     chrome-prospect-autographs.yaml
-    ...                    # one file per subset id
+    ...                    # one file per node id (base set OR subset)
 ```
 
-- **set.yaml** — descriptive metadata. No parallels, no card counts (derived).
-- **manifest.yaml** — the list of subsets; each subset declares its `kind`, its
-  declared base-checklist size (a review check), its `parallels`, and optionally
-  `sections` — a singular editorial partition of its checklist (e.g. Veterans /
-  Rookies) that a parallel can target via `applies_to.sections`. Sections are
-  membership declarations (a `range` or explicit `numbers`), derived onto rows at
-  consume time — not committed on the rows.
-- **checklists/&lt;subset-id&gt;.yaml** — an array of rows (`number → subjects`), each
-  with a **committed `uuid`** (the canonical, shared card identity). One file per
-  subset; the filename matches the subset `id`.
+- **set.yaml** — descriptive **product / umbrella** metadata. No parallels, no card
+  counts (derived). Its `uuid` is the product's; each base set has its own.
+- **manifest.yaml** — `base_sets[]` (**one or more** roots) plus, under each, recursive
+  `subsets[]`. A base set and a subset are the **same node shape** — own checklist,
+  `parallels`, optional `sections`, and child `subsets` — differing only in that a base
+  set has no `type` and a subset carries one (`insert`/`autograph`/…). `sections` is a
+  singular editorial partition of a node's checklist (e.g. Veterans / Rookies), declared
+  as a `range` or explicit `numbers` and derived onto rows at consume time; a parallel
+  can target one via `applies_to.sections`.
+- **checklists/&lt;node-id&gt;.yaml** — an array of rows (`number → subjects`), each with a
+  **committed `uuid`** (the canonical, shared card identity). One file per node; the
+  filename matches the node `id` (base set or subset — they share one id-space).
 
 ## What is committed vs. derived
 
 | Thing | Committed? | How |
 |---|---|---|
-| set `uuid` | ✅ committed | minted by tcapi (identity authority), published here |
-| base checklist row `uuid` | ✅ committed | the canonical card identity — stable forever |
+| product `uuid` (set.yaml) | ✅ committed | the umbrella; minted by tcapi (identity authority) |
+| base set / subset `uuid` (each node) | ✅ committed | each node is its own anchor — minted by tcapi |
+| checklist row `uuid` | ✅ committed | the canonical card identity — stable forever |
 | entity `ref` (player/team UUID) | ✅ referenced | owned by tcapi; resolution populates it |
-| **parallel card `uuid`** | ❌ **derived** | `uuidv5(base_row.uuid, parallel.name)` — see IDENTITY.md |
+| **parallel card `uuid`** | ❌ **derived** | `uuidv5(row.uuid, parallel.name)` — see IDENTITY.md |
 | `card_name` / `description` | ❌ derived | composed at display time from subject + subset + parallel |
 | `image_url` | ❌ enrichment | keyed by card uuid, added later — never fabricated |
 | total `card_count` | ❌ derived | expansion count; the review report checks it |
@@ -53,19 +58,25 @@ data/<genre>/<set-id>/
 
 ```python
 # pseudocode — runs in the consumer/CI, output goes to tcapi. Nothing persisted in OCP.
-for subset in manifest.subsets:
-    rows = load(f"checklists/{subset.id}.yaml")
-    sections = section_of(subset, rows)                                    # {row.number: section_id}, derived
+# One recursive walk handles base sets, subsets, and any nesting — a node is a node.
+for base_set in manifest.base_sets:
+    expand(base_set)
+
+def expand(node):
+    rows = load(f"checklists/{node.id}.yaml")
+    sections = section_of(node, rows)                                      # {row.number: section_id}, derived
     for row in rows:
-        emit_card(uuid=row.uuid, subset=subset, parallel=None, row=row,
+        emit_card(uuid=row.uuid, node=node, parallel=None, row=row,
                   section=sections.get(row.number))                       # section is DERIVED, not committed
-        for p in subset.parallels:
+        for p in node.get("parallels", []):
             if applies(p, row, sections):                                 # membership filter, below
                 emit_card(
                     uuid = uuidv5(row.uuid, p.name),                      # DERIVED, reproducible everywhere
-                    subset = subset, parallel = p, row = row,
+                    node = node, parallel = p, row = row,
                     print_run = p.print_run, serial_numbered = p.serial_numbered,
                 )
+    for child in node.get("subsets", []):                                 # recurse — same rule at every depth
+        expand(child)
 
 def applies(p, row, sections):
     a = p.get("applies_to", "all")

--- a/proposals/v0.3-manifest-form/README.md
+++ b/proposals/v0.3-manifest-form/README.md
@@ -28,7 +28,11 @@ data/<genre>/<set-id>/
 
 - **set.yaml** — descriptive metadata. No parallels, no card counts (derived).
 - **manifest.yaml** — the list of subsets; each subset declares its `kind`, its
-  declared base-checklist size (a review check), and its `parallels`.
+  declared base-checklist size (a review check), its `parallels`, and optionally
+  `sections` — a singular editorial partition of its checklist (e.g. Veterans /
+  Rookies) that a parallel can target via `applies_to.sections`. Sections are
+  membership declarations (a `range` or explicit `numbers`), derived onto rows at
+  consume time — not committed on the rows.
 - **checklists/&lt;subset-id&gt;.yaml** — an array of rows (`number → subjects`), each
   with a **committed `uuid`** (the canonical, shared card identity). One file per
   subset; the filename matches the subset `id`.
@@ -51,21 +55,24 @@ data/<genre>/<set-id>/
 # pseudocode — runs in the consumer/CI, output goes to tcapi. Nothing persisted in OCP.
 for subset in manifest.subsets:
     rows = load(f"checklists/{subset.id}.yaml")
+    sections = section_of(subset, rows)                                    # {row.number: section_id}, derived
     for row in rows:
-        emit_card(uuid=row.uuid, subset=subset, parallel=None, row=row)   # the base card (committed uuid)
+        emit_card(uuid=row.uuid, subset=subset, parallel=None, row=row,
+                  section=sections.get(row.number))                       # section is DERIVED, not committed
         for p in subset.parallels:
-            if applies(p, row):                                           # membership filter, below
+            if applies(p, row, sections):                                 # membership filter, below
                 emit_card(
                     uuid = uuidv5(row.uuid, p.name),                      # DERIVED, reproducible everywhere
                     subset = subset, parallel = p, row = row,
                     print_run = p.print_run, serial_numbered = p.serial_numbered,
                 )
 
-def applies(p, row):
+def applies(p, row, sections):
     a = p.get("applies_to", "all")
-    if a == "all":       return True
-    if "numbers" in a:   return row.number in a["numbers"]   # ONLY these rows
-    if "except"  in a:   return row.number not in a["except"] # all rows EXCEPT these
+    if a == "all":        return True
+    if "numbers"  in a:   return row.number in a["numbers"]          # ONLY these rows
+    if "except"   in a:   return row.number not in a["except"]       # all rows EXCEPT these
+    if "sections" in a:   return sections.get(row.number) in a["sections"]  # rows in these sections
 ```
 
 `applies_to` only gates *whether* a row emits a parallel card — it is never an input

--- a/proposals/v0.3-manifest-form/README.md
+++ b/proposals/v0.3-manifest-form/README.md
@@ -48,9 +48,10 @@ data/<genre>/<set-id>/
 | product `uuid` (set.yaml) | ✅ committed | the umbrella; minted by tcapi (identity authority) |
 | base set / subset `uuid` (each node) | ✅ committed | each node is its own anchor — minted by tcapi |
 | checklist row `uuid` | ✅ committed | the canonical card identity — stable forever |
-| entity `ref` (player/team UUID) | ✅ referenced | owned by tcapi; resolution populates it |
+| entity `ref` (in a subject) | ✅ referenced | owned by tcapi; resolution populates it |
 | **parallel card `uuid`** | ❌ **derived** | `uuidv5(row.uuid, parallel.name)` — see IDENTITY.md |
-| `card_name` / `description` | ❌ derived | composed at display time from subject + subset + parallel |
+| card `name` | ❌ derived / ✅ `title` | derived from `subjects` (see below); the optional row `title` overrides |
+| card `description` | ✅ committed (optional) | explicit blurb on the row, when a card has one |
 | `image_url` | ❌ enrichment | keyed by card uuid, added later — never fabricated |
 | total `card_count` | ❌ derived | expansion count; the review report checks it |
 
@@ -93,6 +94,28 @@ re-sync stays idempotent.
 `emit_card` maps OCP fields → tcapi's card schema and upserts by `uuid` (idempotent
 re-sync). Because every uuid is deterministic, re-running produces byte-identical
 identities — an update is an update, never a duplicate.
+
+## Card name derivation
+
+A card's display name is **derived** from its row, never committed — unless the row
+carries an explicit `title`, which wins. The rule composes the parts that exist:
+
+- prefix the row `number`;
+- render each **subject** by joining its `entities`' names (sports: a `player` + a
+  `team` → "Name - Team");
+- join multiple subjects with " / ".
+
+| Row | Derived name |
+|---|---|
+| #2 · subject [player "Shohei Ohtani", team "Los Angeles Dodgers"] | `2 Shohei Ohtani - Los Angeles Dodgers` |
+| #10 · subject [player "Shohei Ohtani"] | `10 Shohei Ohtani` |
+| #5 · subject [team "Los Angeles Dodgers"] | `5 Los Angeles Dodgers` |
+| #50 · two subjects | `50 A - TeamA / B - TeamB` |
+| #300 · no subjects, `title: "Checklist"` | `300 Checklist` |
+
+The separator/format ("player - team") is **genre-specific display logic**, not schema:
+the row just stores `entities` + their `role`s. Adding TCG/non-sport adds new `role`
+values (creature, character, …), not new fields — the card schema stays stable.
 
 ## Review report (separate artifact, not built here)
 

--- a/proposals/v0.3-manifest-form/example/2026-bowman/checklists/base.yaml
+++ b/proposals/v0.3-manifest-form/example/2026-bowman/checklists/base.yaml
@@ -1,0 +1,30 @@
+# Subset `base` — committed row identities. ABBREVIATED (3 of 100 rows).
+# Each row is committed ONCE. Its 6 base parallels (see manifest.yaml) are DERIVED:
+#   Aaron Judge "Black"  uuid = uuidv5("11111111-1111-4111-8111-111111111111", "Black")
+# ...so this one row + the manifest replaces the 7 files card #1 needed in PR #19.
+# (uuids below are illustrative committed anchors; tcapi mints the real ones.)
+
+- number: "1"
+  uuid: "11111111-1111-4111-8111-111111111111"
+  subjects:
+    - name: "Aaron Judge"
+      ref: null                 # populated by resolution (tcapi entity uuid)
+      role: "Player"
+      team: { name: "New York Yankees", ref: null }
+
+- number: "2"
+  uuid: "22222222-2222-4222-8222-222222222222"
+  subjects:
+    - name: "Shohei Ohtani"
+      ref: null
+      role: "Player"
+      team: { name: "Los Angeles Dodgers", ref: null }
+
+- number: "3"
+  uuid: "33333333-3333-4333-8333-333333333333"
+  rookie_card: true
+  subjects:
+    - name: "Example Prospect"     # a genuinely-new prospect -> resolution registers it in tcapi
+      ref: null
+      role: "Player"
+      team: { name: "Example Team", ref: null }

--- a/proposals/v0.3-manifest-form/example/2026-bowman/checklists/bowman.yaml
+++ b/proposals/v0.3-manifest-form/example/2026-bowman/checklists/bowman.yaml
@@ -2,30 +2,34 @@
 # Filename matches the node id (base_sets[].id = "bowman" -> checklists/bowman.yaml).
 # Each row is committed ONCE. Its base parallels (see manifest.yaml) are DERIVED:
 #   Aaron Judge "Black"  uuid = uuidv5("11111111-1111-4111-8111-111111111111", "Black")
-# ...so this one row + the manifest replaces the 7 files card #1 needed in PR #19.
+# The card NAME is DERIVED from subjects (see README "Card name derivation"), e.g.
+#   #2 -> "2 Shohei Ohtani - Los Angeles Dodgers". A subject is a combination of
+#   `entities` (here: a player + a team). Nothing about the name is committed.
 # (uuids below are illustrative committed anchors; tcapi mints the real ones.)
 
 - number: "1"
   uuid: "11111111-1111-4111-8111-111111111111"
   subjects:
-    - name: "Aaron Judge"
-      ref: null                 # populated by resolution (tcapi entity uuid)
-      role: "Player"
-      team: { name: "New York Yankees", ref: null }
+    - entities:
+        - { role: player, name: "Aaron Judge",      ref: null }   # ref populated by resolution (tcapi)
+        - { role: team,   name: "New York Yankees", ref: null }
 
 - number: "2"
   uuid: "22222222-2222-4222-8222-222222222222"
   subjects:
-    - name: "Shohei Ohtani"
-      ref: null
-      role: "Player"
-      team: { name: "Los Angeles Dodgers", ref: null }
+    - entities:
+        - { role: player, name: "Shohei Ohtani",       ref: null }
+        - { role: team,   name: "Los Angeles Dodgers", ref: null }
 
 - number: "3"
   uuid: "33333333-3333-4333-8333-333333333333"
   rookie_card: true
   subjects:
-    - name: "Example Prospect"     # a genuinely-new prospect -> resolution registers it in tcapi
-      ref: null
-      role: "Player"
-      team: { name: "Example Team", ref: null }
+    - entities:
+        - { role: player, name: "Example Prospect", ref: null }   # a genuinely-new prospect -> resolution registers it
+        - { role: team,   name: "Example Team",     ref: null }
+
+# Other shapes this schema supports (illustrative — not rows of this set):
+#   Team card:      subjects: [ { entities: [ { role: team, name: "Los Angeles Dodgers" } ] } ]  -> "N Los Angeles Dodgers"
+#   Dual card:      subjects: [ {entities:[player,team]}, {entities:[player,team]} ]              -> "N A - TeamA / B - TeamB"
+#   Checklist card: title: "Checklist", subjects: []                                              -> "N Checklist"

--- a/proposals/v0.3-manifest-form/example/2026-bowman/checklists/bowman.yaml
+++ b/proposals/v0.3-manifest-form/example/2026-bowman/checklists/bowman.yaml
@@ -5,13 +5,13 @@
 # The card NAME is DERIVED from subjects (see README "Card name derivation"), e.g.
 #   #2 -> "2 Shohei Ohtani - Los Angeles Dodgers". A subject is a combination of
 #   `entities` (here: a player + a team). Nothing about the name is committed.
-# (uuids below are illustrative committed anchors; tcapi mints the real ones.)
+# (uuids below are illustrative committed anchors; the real ones are assigned upstream.)
 
 - number: "1"
   uuid: "11111111-1111-4111-8111-111111111111"
   subjects:
     - entities:
-        - { role: player, name: "Aaron Judge",      ref: null }   # ref populated by resolution (tcapi)
+        - { role: player, name: "Aaron Judge",      ref: null }   # ref populated by resolution
         - { role: team,   name: "New York Yankees", ref: null }
 
 - number: "2"

--- a/proposals/v0.3-manifest-form/example/2026-bowman/checklists/bowman.yaml
+++ b/proposals/v0.3-manifest-form/example/2026-bowman/checklists/bowman.yaml
@@ -1,5 +1,6 @@
-# Subset `base` — committed row identities. ABBREVIATED (3 of 100 rows).
-# Each row is committed ONCE. Its 6 base parallels (see manifest.yaml) are DERIVED:
+# Base set `bowman` — committed row identities. ABBREVIATED (3 of 100 rows).
+# Filename matches the node id (base_sets[].id = "bowman" -> checklists/bowman.yaml).
+# Each row is committed ONCE. Its base parallels (see manifest.yaml) are DERIVED:
 #   Aaron Judge "Black"  uuid = uuidv5("11111111-1111-4111-8111-111111111111", "Black")
 # ...so this one row + the manifest replaces the 7 files card #1 needed in PR #19.
 # (uuids below are illustrative committed anchors; tcapi mints the real ones.)

--- a/proposals/v0.3-manifest-form/example/2026-bowman/manifest.yaml
+++ b/proposals/v0.3-manifest-form/example/2026-bowman/manifest.yaml
@@ -1,0 +1,41 @@
+# The generating structure. ABBREVIATED — showing 3 of ~30 real subsets and a
+# representative slice of parallels. In PR #19 each of these parallels was a
+# separate file PER CARD (100 base cards x ~76 parallels = the explosion).
+set_id: "2026-bowman"
+subsets:
+
+  - id: base
+    name: "Base"
+    kind: base
+    declared_card_count: 100          # checked against len(checklists/base.yaml)
+    parallels:
+      - { name: "Sky Blue",     print_run: 499, serial_numbered: true }
+      - { name: "Blue",         print_run: 150, serial_numbered: true }
+      - { name: "Gold Pattern", print_run: 50,  serial_numbered: true }
+      - { name: "Fuchsia",      print_run: 250, serial_numbered: true }
+      - { name: "Black",        print_run: 10,  serial_numbered: true }
+      - { name: "Superfractor", print_run: 1,   serial_numbered: true }
+      # ...remaining base parallels
+
+  # NOTE: PR #19 mis-modeled this as a *base parallel* (files like
+  # 1-bowman-scouts-top-100.yaml under card #1). It is really its own INSERT with
+  # its own checklist and its own parallels. v0.3 models it correctly:
+  - id: bowman-scouts-top-100
+    name: "Bowman Scouts Top 100"
+    kind: insert
+    declared_card_count: 100          # its OWN checklist -> checklists/bowman-scouts-top-100.yaml
+    parallels:
+      - { name: "Aqua Refractor",   print_run: 125, serial_numbered: true }
+      - { name: "Gold Refractor",   print_run: 50,  serial_numbered: true }
+      - { name: "Orange Refractor", print_run: 25,  serial_numbered: true }
+      - { name: "Red Refractor",    print_run: 5,   serial_numbered: true }
+      - { name: "SuperFractor",     print_run: 1,   serial_numbered: true }
+
+  - id: chrome-prospect-autographs
+    name: "Chrome Prospect Autographs"
+    kind: autograph                   # every row is an auto — no per-card flag needed
+    declared_card_count: 87
+    parallels:
+      - { name: "Gold Refractor", print_run: 50, serial_numbered: true }
+      - { name: "Red Refractor",  print_run: 5,  serial_numbered: true }
+      - { name: "Superfractor",   print_run: 1,  serial_numbered: true }

--- a/proposals/v0.3-manifest-form/example/2026-bowman/manifest.yaml
+++ b/proposals/v0.3-manifest-form/example/2026-bowman/manifest.yaml
@@ -1,15 +1,20 @@
-# The generating structure. ABBREVIATED — showing 3 of ~30 real subsets and a
-# representative slice of parallels. In PR #19 each of these parallels was a
-# separate file PER CARD (100 base cards x ~76 parallels = the explosion).
-set_id: "2026-bowman"
-subsets:
+# The generating structure for the "2026 Bowman" PRODUCT. ABBREVIATED.
+# 2026 Bowman ships TWO base sets in one product — the 100-card paper Bowman base and
+# the 150-card Bowman Chrome Prospects — so `base_sets` is a list. Each base set and
+# each subset is the same recursive node (own checklist + parallels + sections +
+# child subsets); base sets are the roots (no `type`), subsets carry a `type`.
+# In PR #19 every parallel of every card was a separate file (the 17,928-file explosion).
+# (uuids are illustrative committed anchors; tcapi mints the real ones.)
+set_id: "2026-bowman"                    # matches set.yaml — the product / umbrella
+base_sets:
 
-  - id: base
-    name: "Base"
-    kind: base
-    declared_card_count: 100          # checked against len(checklists/base.yaml)
-    sections:                         # OPTIONAL editorial partition; every row lands in exactly one
-      - { id: veterans, name: "Veterans", range: { from: "1", to: "50" },  declared_card_count: 50 }
+  # ── BASE SET 1: paper Bowman ────────────────────────────────────────────────────
+  - id: bowman
+    name: "Bowman"
+    uuid: "aaaaaaaa-0000-4000-8000-000000000001"
+    declared_card_count: 100             # checked against len(checklists/bowman.yaml)
+    sections:                            # OPTIONAL partition; every row lands in exactly one
+      - { id: veterans, name: "Veterans", range: { from: "1",  to: "50"  }, declared_card_count: 50 }
       - { id: rookies,  name: "Rookies",  range: { from: "51", to: "100" }, declared_card_count: 50 }
       # Non-sequential numbering would use `numbers` instead of `range`, e.g.:
       #   - { id: legends, name: "Legends", numbers: ["7", "23", "US1"] }
@@ -18,39 +23,54 @@ subsets:
       - { name: "Blue",         print_run: 150, serial_numbered: true }
       - { name: "Gold Pattern", print_run: 50,  serial_numbered: true }
       - { name: "Fuchsia",      print_run: 250, serial_numbered: true }
-      # EXCEPTION: this parallel skips one base card the others carry (e.g. the card
-      # was pulled or never produced in Black). `except` stays correct as the base
-      # grows; the referenced number MUST exist in checklists/base.yaml (validated).
-      # Result: Black derives 99 cards, not 100 — #2 gets no Black uuid.
+      # EXCEPTION: Black skips one base card the others carry. `except` stays correct as
+      # the base grows; the referenced number MUST exist in the checklist (validated).
       - { name: "Black",        print_run: 10,  serial_numbered: true, applies_to: { except: ["2"] } }
       - { name: "Superfractor", print_run: 1,   serial_numbered: true }
       # A parallel scoped to a SECTION — rookies-only, drift-free as the base grows:
-      - { name: "Rookie Foil", print_run: 25, serial_numbered: true, applies_to: { sections: ["rookies"] } }
-      # ...remaining base parallels
-      #
+      - { name: "Rookie Foil",  print_run: 25,  serial_numbered: true, applies_to: { sections: ["rookies"] } }
       # applies_to forms (mutually exclusive; omit for "all"):
-      #   numbers  — only these rows          except — all rows but these
-      #   sections — all rows in these sections (preferred over numbers when a section fits)
+      #   numbers — only these rows   except — all but these   sections — rows in these sections
+    subsets:
+      # An INSERT is a subset of the paper base set. Its own checklist + own parallels.
+      - id: bowman-scouts-top-100
+        name: "Bowman Scouts Top 100"
+        type: insert
+        uuid: "bbbbbbbb-0000-4000-8000-000000000001"
+        declared_card_count: 100         # own checklist -> checklists/bowman-scouts-top-100.yaml
+        parallels:
+          - { name: "Aqua Refractor",   print_run: 125, serial_numbered: true }
+          - { name: "Gold Refractor",   print_run: 50,  serial_numbered: true }
+          - { name: "Red Refractor",    print_run: 5,   serial_numbered: true }
+          - { name: "SuperFractor",     print_run: 1,   serial_numbered: true }
 
-  # NOTE: PR #19 mis-modeled this as a *base parallel* (files like
-  # 1-bowman-scouts-top-100.yaml under card #1). It is really its own INSERT with
-  # its own checklist and its own parallels. v0.3 models it correctly:
-  - id: bowman-scouts-top-100
-    name: "Bowman Scouts Top 100"
-    kind: insert
-    declared_card_count: 100          # its OWN checklist -> checklists/bowman-scouts-top-100.yaml
+  # ── BASE SET 2: Bowman Chrome Prospects ─────────────────────────────────────────
+  - id: bowman-chrome-prospects
+    name: "Bowman Chrome Prospects"
+    uuid: "aaaaaaaa-0000-4000-8000-000000000002"
+    declared_card_count: 150             # -> checklists/bowman-chrome-prospects.yaml (omitted here)
     parallels:
-      - { name: "Aqua Refractor",   print_run: 125, serial_numbered: true }
+      - { name: "Refractor",        print_run: 0,   serial_numbered: false }
       - { name: "Gold Refractor",   print_run: 50,  serial_numbered: true }
-      - { name: "Orange Refractor", print_run: 25,  serial_numbered: true }
-      - { name: "Red Refractor",    print_run: 5,   serial_numbered: true }
-      - { name: "SuperFractor",     print_run: 1,   serial_numbered: true }
-
-  - id: chrome-prospect-autographs
-    name: "Chrome Prospect Autographs"
-    kind: autograph                   # every row is an auto — no per-card flag needed
-    declared_card_count: 87
-    parallels:
-      - { name: "Gold Refractor", print_run: 50, serial_numbered: true }
-      - { name: "Red Refractor",  print_run: 5,  serial_numbered: true }
-      - { name: "Superfractor",   print_run: 1,  serial_numbered: true }
+      - { name: "Superfractor",     print_run: 1,   serial_numbered: true }
+    subsets:
+      # The autograph subset of the Chrome prospects. `type: autograph` = every row an auto.
+      - id: chrome-prospect-autographs
+        name: "Chrome Prospect Autographs"
+        type: autograph
+        uuid: "bbbbbbbb-0000-4000-8000-000000000002"
+        declared_card_count: 87
+        parallels:
+          - { name: "Gold Refractor", print_run: 50, serial_numbered: true }
+          - { name: "Red Refractor",  print_run: 5,  serial_numbered: true }
+          - { name: "Superfractor",   print_run: 1,  serial_numbered: true }
+        # NESTING: a subset can itself contain subsets. Illustrative — checklist omitted.
+        subsets:
+          - id: chrome-prospect-autographs-dual
+            name: "Chrome Prospect Dual Autographs"
+            type: autograph
+            uuid: "cccccccc-0000-4000-8000-000000000002"
+            declared_card_count: 15
+            parallels:
+              - { name: "Gold Refractor", print_run: 25, serial_numbered: true }
+              - { name: "Superfractor",   print_run: 1,  serial_numbered: true }

--- a/proposals/v0.3-manifest-form/example/2026-bowman/manifest.yaml
+++ b/proposals/v0.3-manifest-form/example/2026-bowman/manifest.yaml
@@ -35,7 +35,7 @@ base_sets:
       # An INSERT is a subset of the paper base set. Its own checklist + own parallels.
       - id: bowman-scouts-top-100
         name: "Bowman Scouts Top 100"
-        type: insert
+        type: [insert]
         uuid: "bbbbbbbb-0000-4000-8000-000000000001"
         declared_card_count: 100         # own checklist -> checklists/bowman-scouts-top-100.yaml
         parallels:
@@ -57,7 +57,7 @@ base_sets:
       # The autograph subset of the Chrome prospects. `type: autograph` = every row an auto.
       - id: chrome-prospect-autographs
         name: "Chrome Prospect Autographs"
-        type: autograph
+        type: [autograph]
         uuid: "bbbbbbbb-0000-4000-8000-000000000002"
         declared_card_count: 87
         parallels:
@@ -68,7 +68,7 @@ base_sets:
         subsets:
           - id: chrome-prospect-autographs-dual
             name: "Chrome Prospect Dual Autographs"
-            type: autograph
+            type: [autograph]
             uuid: "cccccccc-0000-4000-8000-000000000002"
             declared_card_count: 15
             parallels:

--- a/proposals/v0.3-manifest-form/example/2026-bowman/manifest.yaml
+++ b/proposals/v0.3-manifest-form/example/2026-bowman/manifest.yaml
@@ -4,7 +4,7 @@
 # each subset is the same recursive node (own checklist + parallels + sections +
 # child subsets); base sets are the roots (no `type`), subsets carry a `type`.
 # In PR #19 every parallel of every card was a separate file (the 17,928-file explosion).
-# (uuids are illustrative committed anchors; tcapi mints the real ones.)
+# (uuids are illustrative committed anchors; the real ones are assigned upstream.)
 set_id: "2026-bowman"                    # matches set.yaml — the product / umbrella
 base_sets:
 

--- a/proposals/v0.3-manifest-form/example/2026-bowman/manifest.yaml
+++ b/proposals/v0.3-manifest-form/example/2026-bowman/manifest.yaml
@@ -13,9 +13,17 @@ subsets:
       - { name: "Blue",         print_run: 150, serial_numbered: true }
       - { name: "Gold Pattern", print_run: 50,  serial_numbered: true }
       - { name: "Fuchsia",      print_run: 250, serial_numbered: true }
-      - { name: "Black",        print_run: 10,  serial_numbered: true }
+      # EXCEPTION: this parallel skips one base card the others carry (e.g. the card
+      # was pulled or never produced in Black). `except` stays correct as the base
+      # grows; the referenced number MUST exist in checklists/base.yaml (validated).
+      # Result: Black derives 99 cards, not 100 — #2 gets no Black uuid.
+      - { name: "Black",        print_run: 10,  serial_numbered: true, applies_to: { except: ["2"] } }
       - { name: "Superfractor", print_run: 1,   serial_numbered: true }
       # ...remaining base parallels
+      #
+      # Contrast — a *partial* parallel that covers ONLY listed rows (rookies-only):
+      #   - { name: "Rookie Foil", print_run: 25, serial_numbered: true, applies_to: { numbers: ["1", "2"] } }
+      # `numbers` = only these; `except` = all but these. Mutually exclusive; omit for "all".
 
   # NOTE: PR #19 mis-modeled this as a *base parallel* (files like
   # 1-bowman-scouts-top-100.yaml under card #1). It is really its own INSERT with

--- a/proposals/v0.3-manifest-form/example/2026-bowman/manifest.yaml
+++ b/proposals/v0.3-manifest-form/example/2026-bowman/manifest.yaml
@@ -8,6 +8,11 @@ subsets:
     name: "Base"
     kind: base
     declared_card_count: 100          # checked against len(checklists/base.yaml)
+    sections:                         # OPTIONAL editorial partition; every row lands in exactly one
+      - { id: veterans, name: "Veterans", range: { from: "1", to: "50" },  declared_card_count: 50 }
+      - { id: rookies,  name: "Rookies",  range: { from: "51", to: "100" }, declared_card_count: 50 }
+      # Non-sequential numbering would use `numbers` instead of `range`, e.g.:
+      #   - { id: legends, name: "Legends", numbers: ["7", "23", "US1"] }
     parallels:
       - { name: "Sky Blue",     print_run: 499, serial_numbered: true }
       - { name: "Blue",         print_run: 150, serial_numbered: true }
@@ -19,11 +24,13 @@ subsets:
       # Result: Black derives 99 cards, not 100 — #2 gets no Black uuid.
       - { name: "Black",        print_run: 10,  serial_numbered: true, applies_to: { except: ["2"] } }
       - { name: "Superfractor", print_run: 1,   serial_numbered: true }
+      # A parallel scoped to a SECTION — rookies-only, drift-free as the base grows:
+      - { name: "Rookie Foil", print_run: 25, serial_numbered: true, applies_to: { sections: ["rookies"] } }
       # ...remaining base parallels
       #
-      # Contrast — a *partial* parallel that covers ONLY listed rows (rookies-only):
-      #   - { name: "Rookie Foil", print_run: 25, serial_numbered: true, applies_to: { numbers: ["1", "2"] } }
-      # `numbers` = only these; `except` = all but these. Mutually exclusive; omit for "all".
+      # applies_to forms (mutually exclusive; omit for "all"):
+      #   numbers  — only these rows          except — all rows but these
+      #   sections — all rows in these sections (preferred over numbers when a section fits)
 
   # NOTE: PR #19 mis-modeled this as a *base parallel* (files like
   # 1-bowman-scouts-top-100.yaml under card #1). It is really its own INSERT with

--- a/proposals/v0.3-manifest-form/example/2026-bowman/set.yaml
+++ b/proposals/v0.3-manifest-form/example/2026-bowman/set.yaml
@@ -1,6 +1,8 @@
 # Folded from PR #19 (2026 Bowman) — 17,928 card files collapse to this dir.
-# set.yaml is now purely descriptive: no parallels, no exploded card_count.
-uuid: "edb5a80d-2881-4ebb-9a64-67f594eb8c67"    # real set uuid from PR #19
+# set.yaml is the PRODUCT / umbrella: purely descriptive, no parallels, no card_count.
+# The product's two base sets (paper Bowman, Chrome Prospects) carry their own uuids
+# in manifest.yaml (base_sets[].uuid); this uuid sits above them.
+uuid: "edb5a80d-2881-4ebb-9a64-67f594eb8c67"    # real product uuid from PR #19
 set_id: "2026-bowman"
 name: "2026 Bowman"
 genre: "Sports"

--- a/proposals/v0.3-manifest-form/example/2026-bowman/set.yaml
+++ b/proposals/v0.3-manifest-form/example/2026-bowman/set.yaml
@@ -1,0 +1,20 @@
+# Folded from PR #19 (2026 Bowman) — 17,928 card files collapse to this dir.
+# set.yaml is now purely descriptive: no parallels, no exploded card_count.
+uuid: "edb5a80d-2881-4ebb-9a64-67f594eb8c67"    # real set uuid from PR #19
+set_id: "2026-bowman"
+name: "2026 Bowman"
+genre: "Sports"
+category: ["MLB"]
+sports: ["Baseball"]
+season: "2026"
+years: [2026]
+series: "2026 Bowman"
+manufacturer: "Topps"
+release_date: "2026-05-13"
+description: >
+  2026 Bowman — 100-card base set plus a 150-card Prospects set. Hobby boxes yield
+  one autograph and 18 inserts.
+source:
+  name: "BaseballCardpedia"
+  url: "https://baseballcardpedia.com/index.php/2026_Bowman#Checklist"
+  file: "import/2026-Bowman-Baseball-Checklist.xlsx"

--- a/proposals/v0.3-manifest-form/schemas/checklist.v0.1.schema.yaml
+++ b/proposals/v0.3-manifest-form/schemas/checklist.v0.1.schema.yaml
@@ -1,16 +1,16 @@
 $schema_version: "0.1"
-description: "Checklist schema for the Open Checklist Project — the committed row identities for one subset. File is an array of rows; filename matches the subset id (checklists/<subset-id>.yaml)."
+description: "Checklist schema for the Open Checklist Project — the committed row identities for one node (base set or subset). File is an array of rows; filename matches the node id (checklists/<node-id>.yaml)."
 title: Checklist
 type: array
 minItems: 1
 items:
   type: object
-  required: [number, uuid, subjects]
+  required: [number, uuid]
   additionalProperties: false
   properties:
     number:
       type: string
-      description: 'Printed card number/identifier (string — may be non-numeric, e.g. "US1", "BS-1").'
+      description: 'Printed card number/identifier (string — may be non-numeric, e.g. "US1", "BS-1"). Unique within this node.'
     uuid:
       type: string
       format: uuid
@@ -18,36 +18,56 @@ items:
         Canonical card identity (UUIDv4), minted by tcapi and committed here. Stable
         forever — including under renumbering (correct `number`, keep `uuid`). Parallels
         of this row derive their UUIDs from this value (see IDENTITY.md).
+    title:
+      type: ["string", "null"]
+      description: >
+        Optional EXPLICIT card name. Set only when the name is not derivable from
+        `subjects` (e.g. "Checklist", "Home Run Leaders") or the printed name differs from
+        the derived one. When present it wins; otherwise the card name is DERIVED from
+        subjects (see README "Card name derivation"). Ordinary cards omit it and derive.
+    description:
+      type: ["string", "null"]
+      description: Optional card blurb / flavor text (e.g. insert copy, commemorative text). Most cards omit it.
     subjects:
       type: array
-      minItems: 1
+      description: >
+        Who/what the card is about — zero or more subjects. (A card may have none, e.g. a
+        Checklist card named by `title`.) EACH subject is a combination of one or more
+        `entities` — the combination IS the subject (e.g. a player + their team). Multiple
+        subjects = a multi-subject card (dual / triple / leaders).
       items:
         type: object
-        required: [name]
+        required: [entities]
         additionalProperties: false
         properties:
-          name:
-            type: string
-            description: Display name as submitted. Human-reviewable; the authoritative entity is `ref`.
-          ref:
-            type: string
-            format: uuid
+          entities:
+            type: array
+            minItems: 1
             description: >
-              Canonical entity (player/subject) UUID, owned by tcapi. Populated by the
-              resolution step (separate workstream). Absent = unresolved; the validation
-              gate flags it.
-          role:
-            type: string
-            description: 'e.g. "Player", "Coach", "Team", "Mascot".'
-          team:
-            type: object
-            additionalProperties: false
-            properties:
-              name: { type: string, description: Display team name. }
-              ref:  { type: string, format: uuid, description: Canonical team UUID (tcapi), populated by resolution. }
-    # Genuine per-card intrinsics (NOT derivable). Everything else — card_name,
-    # description, image, autograph/serial flags, print_run — is derived or lives on
-    # the subset/parallel, not here.
+              The entities that make up this subject, each a reference to a tcapi entity in
+              a role. The entity's TYPE lives in tcapi; `role` is this entity's part within
+              the subject — an OPEN vocabulary (player, team, coach, creature, type,
+              character, …), deliberately not an enum so new genres add roles without a
+              schema change.
+            items:
+              type: object
+              required: [role, name]
+              additionalProperties: false
+              properties:
+                role:
+                  type: string
+                  description: 'This entity''s part in the subject (open vocabulary): e.g. "player", "team", "coach", "creature", "character".'
+                name:
+                  type: string
+                  description: Display name as submitted. Human-reviewable; the authoritative entity is `ref`.
+                ref:
+                  type: ["string", "null"]
+                  format: uuid
+                  description: >
+                    Canonical entity UUID, owned by tcapi. Populated by the resolution step
+                    (separate workstream). Null/absent = unresolved; the validation gate flags it.
+    # Genuine per-card intrinsics (NOT derivable). These are candidate ATTRIBUTES — a
+    # separate (tcapi-side) workstream — modeled inline for now; may migrate there later.
     rookie_card:
       type: boolean
     variation:

--- a/proposals/v0.3-manifest-form/schemas/checklist.v0.1.schema.yaml
+++ b/proposals/v0.3-manifest-form/schemas/checklist.v0.1.schema.yaml
@@ -15,7 +15,7 @@ items:
       type: string
       format: uuid
       description: >
-        Canonical card identity (UUIDv4), minted by tcapi and committed here. Stable
+        Canonical card identity (UUIDv4), committed here. Stable
         forever — including under renumbering (correct `number`, keep `uuid`). Parallels
         of this row derive their UUIDs from this value (see IDENTITY.md).
     title:
@@ -44,8 +44,8 @@ items:
             type: array
             minItems: 1
             description: >
-              The entities that make up this subject, each a reference to a tcapi entity in
-              a role. The entity's TYPE lives in tcapi; `role` is this entity's part within
+              The entities that make up this subject, each a reference to a canonical entity in
+              a role. The entity's TYPE lives in the entity registry; `role` is this entity's part within
               the subject — an OPEN vocabulary (player, team, coach, creature, type,
               character, …), deliberately not an enum so new genres add roles without a
               schema change.
@@ -64,10 +64,10 @@ items:
                   type: ["string", "null"]
                   format: uuid
                   description: >
-                    Canonical entity UUID, owned by tcapi. Populated by the resolution step
+                    Canonical entity UUID. Populated by the resolution step
                     (separate workstream). Null/absent = unresolved; the validation gate flags it.
     # Genuine per-card intrinsics (NOT derivable). These are candidate ATTRIBUTES — a
-    # separate (tcapi-side) workstream — modeled inline for now; may migrate there later.
+    # separate workstream — modeled inline for now; may migrate there later.
     rookie_card:
       type: boolean
     variation:

--- a/proposals/v0.3-manifest-form/schemas/checklist.v0.1.schema.yaml
+++ b/proposals/v0.3-manifest-form/schemas/checklist.v0.1.schema.yaml
@@ -1,0 +1,58 @@
+$schema_version: "0.1"
+description: "Checklist schema for the Open Checklist Project — the committed row identities for one subset. File is an array of rows; filename matches the subset id (checklists/<subset-id>.yaml)."
+title: Checklist
+type: array
+minItems: 1
+items:
+  type: object
+  required: [number, uuid, subjects]
+  additionalProperties: false
+  properties:
+    number:
+      type: string
+      description: 'Printed card number/identifier (string — may be non-numeric, e.g. "US1", "BS-1").'
+    uuid:
+      type: string
+      format: uuid
+      description: >
+        Canonical card identity (UUIDv4), minted by tcapi and committed here. Stable
+        forever — including under renumbering (correct `number`, keep `uuid`). Parallels
+        of this row derive their UUIDs from this value (see IDENTITY.md).
+    subjects:
+      type: array
+      minItems: 1
+      items:
+        type: object
+        required: [name]
+        additionalProperties: false
+        properties:
+          name:
+            type: string
+            description: Display name as submitted. Human-reviewable; the authoritative entity is `ref`.
+          ref:
+            type: string
+            format: uuid
+            description: >
+              Canonical entity (player/subject) UUID, owned by tcapi. Populated by the
+              resolution step (separate workstream). Absent = unresolved; the validation
+              gate flags it.
+          role:
+            type: string
+            description: 'e.g. "Player", "Coach", "Team", "Mascot".'
+          team:
+            type: object
+            additionalProperties: false
+            properties:
+              name: { type: string, description: Display team name. }
+              ref:  { type: string, format: uuid, description: Canonical team UUID (tcapi), populated by resolution. }
+    # Genuine per-card intrinsics (NOT derivable). Everything else — card_name,
+    # description, image, autograph/serial flags, print_run — is derived or lives on
+    # the subset/parallel, not here.
+    rookie_card:
+      type: boolean
+    variation:
+      type: string
+      description: 'Photo/text variation identifier, when a row is a genuine variation (e.g. "Red RC Variation").'
+    notes:
+      type: string
+      description: Optional short editorial note (e.g. short-print, error card).

--- a/proposals/v0.3-manifest-form/schemas/manifest.v0.1.schema.yaml
+++ b/proposals/v0.3-manifest-form/schemas/manifest.v0.1.schema.yaml
@@ -1,0 +1,81 @@
+$schema_version: "0.1"
+description: "Manifest schema for the Open Checklist Project — the compact generating structure: subsets and their parallels. The per-card explosion is derived from this + checklists/, never committed."
+title: Manifest
+type: object
+required:
+  - set_id
+  - subsets
+additionalProperties: false
+properties:
+  set_id:
+    type: string
+    pattern: "^[a-z0-9]+(-[a-z0-9]+)*$"
+    description: Must match set.yaml set_id.
+  subsets:
+    type: array
+    minItems: 1
+    items:
+      type: object
+      required: [id, name, kind]
+      additionalProperties: false
+      properties:
+        id:
+          type: string
+          pattern: "^[a-z0-9]+(-[a-z0-9]+)*$"
+          description: 'Subset slug. The row identities live in checklists/<id>.yaml.'
+        name:
+          type: string
+          description: 'Human name of the subset (e.g. "Base", "Bowman Scouts Top 100").'
+        kind:
+          type: string
+          enum: [base, insert, autograph, relic, variation]
+          description: >
+            Subset kind. Absorbs the old per-card flags: an `autograph` subset means
+            every row is an auto, etc. A set has exactly one `base` subset.
+        base_ref:
+          type: string
+          format: uuid
+          description: Optional — the base subset/set uuid this subset derives from, when applicable.
+        declared_card_count:
+          type: integer
+          minimum: 1
+          description: >
+            Producer-declared size of THIS subset's base checklist (rows only, not
+            parallels). A review-report check against the actual checklist length.
+        parallels:
+          type: array
+          description: Parallel definitions for this subset. Each expands the subset's checklist by (rows that match applies_to).
+          items:
+            type: object
+            required: [name]
+            additionalProperties: false
+            properties:
+              name:
+                type: string
+                description: >
+                  Canonical parallel name (e.g. "Black", "Gold Pattern", "Superfractor").
+                  UNIQUE within a subset. Used verbatim as the UUID-derivation input
+                  (see IDENTITY.md) — renaming is a breaking identity change.
+              print_run:
+                type: integer
+                minimum: 0
+                description: Serial-numbering print run, when known (e.g. 10, 50, 1). Per-parallel constant.
+              serial_numbered:
+                type: boolean
+                default: false
+              applies_to:
+                description: >
+                  Which base rows this parallel covers. Default "all". Use an explicit
+                  number list for partial parallels (e.g. rookies-only). Ranges are
+                  intentionally omitted (card numbers are strings, e.g. "US1").
+                oneOf:
+                  - { type: string, enum: [all] }
+                  - type: object
+                    required: [numbers]
+                    additionalProperties: false
+                    properties:
+                      numbers:
+                        type: array
+                        minItems: 1
+                        items: { type: string }
+                default: all

--- a/proposals/v0.3-manifest-form/schemas/manifest.v0.1.schema.yaml
+++ b/proposals/v0.3-manifest-form/schemas/manifest.v0.1.schema.yaml
@@ -92,11 +92,20 @@ $defs:
         format: uuid
         description: Committed identity anchor for this subset, minted by tcapi. Stable forever.
       type:
-        type: string
-        enum: [insert, autograph, relic, variation]
+        type: array
+        minItems: 1
+        uniqueItems: true
+        items:
+          type: string
+          enum: [insert, autograph, relic, variation]
         description: >
-          Subset type. Absorbs the old per-card flags: an `autograph` subset means every
-          row is an auto, etc. (A base set has no `type`; it lives in base_sets[].)
+          One or more type tags. Usually one (`[insert]`, `[variation]`), but material
+          subsets combine orthogonal properties: an autograph relic / autograph patch is
+          `[autograph, relic]`, a variation-autograph is `[autograph, variation]`.
+          Absorbs the old per-card flags (an `autograph` subset means every row is an
+          auto; a `relic` subset means every row carries a relic/patch/swatch). `insert`
+          and `variation` are structural; `autograph` and `relic` are material properties
+          that can co-occur. (A base set has no `type`; it lives in base_sets[].)
       declared_card_count:
         type: integer
         minimum: 1

--- a/proposals/v0.3-manifest-form/schemas/manifest.v0.1.schema.yaml
+++ b/proposals/v0.3-manifest-form/schemas/manifest.v0.1.schema.yaml
@@ -42,6 +42,60 @@ properties:
           description: >
             Producer-declared size of THIS subset's base checklist (rows only, not
             parallels). A review-report check against the actual checklist length.
+        sections:
+          type: array
+          minItems: 1
+          description: >
+            Optional editorial partition of THIS subset's checklist into named blocks
+            (e.g. "Veterans", "Rookies"). A section is SINGULAR: every checklist row
+            belongs to exactly one declared section. Membership is declared here and
+            DERIVED onto rows at consume time — rows carry no section field. If a
+            subset declares sections, the declared sections MUST partition the
+            checklist exactly: every committed row matches exactly one section (a row
+            matching zero, or more than one, is a hard validation error — see
+            IDENTITY.md). A subset with no `sections` is one implicit section (today's
+            behavior). NOTE: a section is a structural block, distinct from a per-card
+            ATTRIBUTE (rookie, team-leader, short-print), which is multi-valued and a
+            separate (tcapi-side) feature — not modeled here.
+          items:
+            type: object
+            required: [id, name]
+            additionalProperties: false
+            properties:
+              id:
+                type: string
+                pattern: "^[a-z0-9]+(-[a-z0-9]+)*$"
+                description: Section slug. UNIQUE within the subset. Referenced by parallels' applies_to.sections.
+              name:
+                type: string
+                description: 'Human name of the section (e.g. "Veterans", "Rookies").'
+              declared_card_count:
+                type: integer
+                minimum: 1
+                description: Producer-declared size of this section — a review-report check against matched rows.
+              range:
+                type: object
+                required: [from, to]
+                additionalProperties: false
+                description: >
+                  Contiguous membership for sequential numbering. A row matches iff its
+                  `number` shares this range's literal non-digit prefix and its trailing
+                  integer is within [from, to] inclusive. Handles "1"–"100" and
+                  "US1"–"US25"; NOT mixed-prefix or arbitrary numbering (use `numbers`).
+                  Gaps are fine — the range matches whichever rows exist.
+                properties:
+                  from: { type: string }
+                  to:   { type: string }
+              numbers:
+                type: array
+                minItems: 1
+                items: { type: string }
+                description: >
+                  Explicit membership for non-sequential / interleaved / mixed-prefix
+                  numbering. Lists the exact card numbers in this section.
+            oneOf:
+              - { required: [range] }
+              - { required: [numbers] }
         parallels:
           type: array
           description: Parallel definitions for this subset. Each expands the subset's checklist by (rows that match applies_to).
@@ -65,17 +119,19 @@ properties:
                 default: false
               applies_to:
                 description: >
-                  Which base rows this parallel covers. Default "all". Two partial
-                  forms, mutually exclusive: `numbers` (ONLY these rows — e.g.
-                  rookies-only) and `except` (all base rows EXCEPT these — e.g. a
-                  parallel that skips one card the others carry). Prefer `except` when
-                  the parallel is base-minus-a-few: it stays correct as the base
-                  checklist grows, whereas a `numbers` list is a snapshot. Every
-                  referenced number MUST exist in the subset's base checklist (a hard
-                  validation error — see IDENTITY.md). Ranges are intentionally
-                  omitted (card numbers are strings, e.g. "US1"). This filter selects
-                  which rows produce a derived parallel card; it never affects the
-                  derived UUID.
+                  Which base rows this parallel covers. Default "all". Three partial
+                  forms, mutually exclusive: `numbers` (ONLY these rows), `except` (all
+                  base rows EXCEPT these — e.g. a parallel that skips one card the
+                  others carry), and `sections` (all rows in the named declared
+                  section(s) — e.g. a rookies-only parallel). Prefer `sections` or
+                  `except` over `numbers` when applicable: they stay correct as the
+                  base checklist grows, whereas a `numbers` list is a snapshot. Every
+                  referenced number MUST exist in the subset's base checklist, and every
+                  referenced section MUST be a declared section id (hard validation
+                  errors — see IDENTITY.md). Ranges are intentionally omitted here
+                  (card numbers are strings, e.g. "US1"; use a section for a range).
+                  This filter selects which rows produce a derived parallel card; it
+                  never affects the derived UUID.
                 oneOf:
                   - { type: string, enum: [all] }
                   - type: object
@@ -91,6 +147,14 @@ properties:
                     additionalProperties: false
                     properties:
                       except:
+                        type: array
+                        minItems: 1
+                        items: { type: string }
+                  - type: object
+                    required: [sections]
+                    additionalProperties: false
+                    properties:
+                      sections:
                         type: array
                         minItems: 1
                         items: { type: string }

--- a/proposals/v0.3-manifest-form/schemas/manifest.v0.1.schema.yaml
+++ b/proposals/v0.3-manifest-form/schemas/manifest.v0.1.schema.yaml
@@ -51,7 +51,7 @@ $defs:
         type: string
         format: uuid
         description: >
-          Committed identity anchor for this base set, minted by tcapi. set.yaml carries
+          Committed identity anchor for this base set. set.yaml carries
           the PRODUCT (umbrella) uuid; each base set carries its own. Stable forever.
       declared_card_count:
         type: integer
@@ -90,7 +90,7 @@ $defs:
       uuid:
         type: string
         format: uuid
-        description: Committed identity anchor for this subset, minted by tcapi. Stable forever.
+        description: Committed identity anchor for this subset. Stable forever.
       type:
         type: array
         minItems: 1
@@ -135,7 +135,7 @@ $defs:
       (zero or 2+ = hard error, see IDENTITY.md). A node with no `sections` is one
       implicit section. NOTE: a section is a structural block, distinct from a per-card
       ATTRIBUTE (rookie, team-leader, short-print), which is multi-valued and a separate
-      (tcapi-side) feature — not modeled here.
+      feature — not modeled here.
     properties:
       id:
         type: string

--- a/proposals/v0.3-manifest-form/schemas/manifest.v0.1.schema.yaml
+++ b/proposals/v0.3-manifest-form/schemas/manifest.v0.1.schema.yaml
@@ -65,9 +65,17 @@ properties:
                 default: false
               applies_to:
                 description: >
-                  Which base rows this parallel covers. Default "all". Use an explicit
-                  number list for partial parallels (e.g. rookies-only). Ranges are
-                  intentionally omitted (card numbers are strings, e.g. "US1").
+                  Which base rows this parallel covers. Default "all". Two partial
+                  forms, mutually exclusive: `numbers` (ONLY these rows — e.g.
+                  rookies-only) and `except` (all base rows EXCEPT these — e.g. a
+                  parallel that skips one card the others carry). Prefer `except` when
+                  the parallel is base-minus-a-few: it stays correct as the base
+                  checklist grows, whereas a `numbers` list is a snapshot. Every
+                  referenced number MUST exist in the subset's base checklist (a hard
+                  validation error — see IDENTITY.md). Ranges are intentionally
+                  omitted (card numbers are strings, e.g. "US1"). This filter selects
+                  which rows produce a derived parallel card; it never affects the
+                  derived UUID.
                 oneOf:
                   - { type: string, enum: [all] }
                   - type: object
@@ -75,6 +83,14 @@ properties:
                     additionalProperties: false
                     properties:
                       numbers:
+                        type: array
+                        minItems: 1
+                        items: { type: string }
+                  - type: object
+                    required: [except]
+                    additionalProperties: false
+                    properties:
+                      except:
                         type: array
                         minItems: 1
                         items: { type: string }

--- a/proposals/v0.3-manifest-form/schemas/manifest.v0.1.schema.yaml
+++ b/proposals/v0.3-manifest-form/schemas/manifest.v0.1.schema.yaml
@@ -1,161 +1,201 @@
 $schema_version: "0.1"
-description: "Manifest schema for the Open Checklist Project — the compact generating structure: subsets and their parallels. The per-card explosion is derived from this + checklists/, never committed."
+description: "Manifest schema for the Open Checklist Project — the compact generating structure. A product (set.yaml) holds ONE OR MORE base sets; a base set and a subset are the same recursive node (own checklist + parallels + sections + child subsets), differing only in role: base sets are the roots and carry no `type`; subsets are nested and carry a `type`. The per-card explosion is derived from this + checklists/, never committed."
 title: Manifest
 type: object
 required:
   - set_id
-  - subsets
+  - base_sets
 additionalProperties: false
 properties:
   set_id:
     type: string
     pattern: "^[a-z0-9]+(-[a-z0-9]+)*$"
-    description: Must match set.yaml set_id.
-  subsets:
+    description: Must match set.yaml set_id (the product / umbrella).
+  base_sets:
     type: array
     minItems: 1
+    description: >
+      One or more base sets — the roots of the product. A base set is NOT a subset: it
+      has no `type` and is never nested. Each is a recursive node (see $defs/baseSet).
     items:
-      type: object
-      required: [id, name, kind]
-      additionalProperties: false
-      properties:
-        id:
-          type: string
-          pattern: "^[a-z0-9]+(-[a-z0-9]+)*$"
-          description: 'Subset slug. The row identities live in checklists/<id>.yaml.'
-        name:
-          type: string
-          description: 'Human name of the subset (e.g. "Base", "Bowman Scouts Top 100").'
-        kind:
-          type: string
-          enum: [base, insert, autograph, relic, variation]
-          description: >
-            Subset kind. Absorbs the old per-card flags: an `autograph` subset means
-            every row is an auto, etc. A set has exactly one `base` subset.
-        base_ref:
-          type: string
-          format: uuid
-          description: Optional — the base subset/set uuid this subset derives from, when applicable.
-        declared_card_count:
-          type: integer
-          minimum: 1
-          description: >
-            Producer-declared size of THIS subset's base checklist (rows only, not
-            parallels). A review-report check against the actual checklist length.
-        sections:
-          type: array
-          minItems: 1
-          description: >
-            Optional editorial partition of THIS subset's checklist into named blocks
-            (e.g. "Veterans", "Rookies"). A section is SINGULAR: every checklist row
-            belongs to exactly one declared section. Membership is declared here and
-            DERIVED onto rows at consume time — rows carry no section field. If a
-            subset declares sections, the declared sections MUST partition the
-            checklist exactly: every committed row matches exactly one section (a row
-            matching zero, or more than one, is a hard validation error — see
-            IDENTITY.md). A subset with no `sections` is one implicit section (today's
-            behavior). NOTE: a section is a structural block, distinct from a per-card
-            ATTRIBUTE (rookie, team-leader, short-print), which is multi-valued and a
-            separate (tcapi-side) feature — not modeled here.
-          items:
-            type: object
-            required: [id, name]
+      $ref: "#/$defs/baseSet"
+
+$defs:
+
+  baseSet:
+    type: object
+    required: [id, name, uuid]
+    additionalProperties: false
+    description: A root checklist unit of the product. Its rows live in checklists/<id>.yaml.
+    properties:
+      id:
+        type: string
+        pattern: "^[a-z0-9]+(-[a-z0-9]+)*$"
+        description: 'Slug, UNIQUE across the whole manifest. Row identities live in checklists/<id>.yaml.'
+      name:
+        type: string
+        description: 'Human name (e.g. "Bowman", "Bowman Chrome Prospects").'
+      uuid:
+        type: string
+        format: uuid
+        description: >
+          Committed identity anchor for this base set, minted by tcapi. set.yaml carries
+          the PRODUCT (umbrella) uuid; each base set carries its own. Stable forever.
+      declared_card_count:
+        type: integer
+        minimum: 1
+        description: Producer-declared size of THIS base set's checklist (rows only, not parallels). A review-report check.
+      sections:
+        type: array
+        minItems: 1
+        description: Optional singular partition of this checklist. See $defs/section.
+        items: { $ref: "#/$defs/section" }
+      parallels:
+        type: array
+        description: Parallels of this checklist. See $defs/parallel.
+        items: { $ref: "#/$defs/parallel" }
+      subsets:
+        type: array
+        minItems: 1
+        description: Child subsets (recursive), each nested under this node.
+        items: { $ref: "#/$defs/subset" }
+
+  subset:
+    type: object
+    required: [id, name, uuid, type]
+    additionalProperties: false
+    description: >
+      A non-base checklist unit — the same shape as a base set, PLUS `type`, nested under
+      a base set or another subset. A subset can itself contain subsets and/or parallels.
+    properties:
+      id:
+        type: string
+        pattern: "^[a-z0-9]+(-[a-z0-9]+)*$"
+        description: 'Slug, UNIQUE across the whole manifest. Row identities live in checklists/<id>.yaml.'
+      name:
+        type: string
+        description: 'Human name (e.g. "Chrome Prospect Autographs").'
+      uuid:
+        type: string
+        format: uuid
+        description: Committed identity anchor for this subset, minted by tcapi. Stable forever.
+      type:
+        type: string
+        enum: [insert, autograph, relic, variation]
+        description: >
+          Subset type. Absorbs the old per-card flags: an `autograph` subset means every
+          row is an auto, etc. (A base set has no `type`; it lives in base_sets[].)
+      declared_card_count:
+        type: integer
+        minimum: 1
+        description: Producer-declared size of THIS subset's checklist (rows only, not parallels). A review-report check.
+      sections:
+        type: array
+        minItems: 1
+        items: { $ref: "#/$defs/section" }
+      parallels:
+        type: array
+        items: { $ref: "#/$defs/parallel" }
+      subsets:
+        type: array
+        minItems: 1
+        description: Nested subsets (recursive, same shape).
+        items: { $ref: "#/$defs/subset" }
+
+  section:
+    type: object
+    required: [id, name]
+    additionalProperties: false
+    description: >
+      A SINGULAR editorial block of the parent checklist (e.g. "Veterans", "Rookies"):
+      every row belongs to exactly one section. Membership is declared here and DERIVED
+      onto rows at consume time (rows carry no section field). If a node declares
+      sections, they MUST partition its checklist exactly — every row in exactly one
+      (zero or 2+ = hard error, see IDENTITY.md). A node with no `sections` is one
+      implicit section. NOTE: a section is a structural block, distinct from a per-card
+      ATTRIBUTE (rookie, team-leader, short-print), which is multi-valued and a separate
+      (tcapi-side) feature — not modeled here.
+    properties:
+      id:
+        type: string
+        pattern: "^[a-z0-9]+(-[a-z0-9]+)*$"
+        description: Section slug, UNIQUE within the parent node. Referenced by parallels' applies_to.sections.
+      name:
+        type: string
+        description: 'Human name of the section (e.g. "Veterans", "Rookies").'
+      declared_card_count:
+        type: integer
+        minimum: 1
+        description: Producer-declared section size — a review-report check against matched rows.
+      range:
+        type: object
+        required: [from, to]
+        additionalProperties: false
+        description: >
+          Contiguous membership for sequential numbering. A row matches iff its `number`
+          shares this range's literal non-digit prefix and its trailing integer is within
+          [from, to] inclusive. Handles "1"–"100" and "US1"–"US25"; NOT mixed-prefix or
+          arbitrary numbering (use `numbers`). Gaps are fine — matches whichever rows exist.
+        properties:
+          from: { type: string }
+          to:   { type: string }
+      numbers:
+        type: array
+        minItems: 1
+        items: { type: string }
+        description: >
+          Explicit membership for non-sequential / interleaved / mixed-prefix numbering.
+          Lists the exact card numbers in this section.
+    oneOf:
+      - { required: [range] }
+      - { required: [numbers] }
+
+  parallel:
+    type: object
+    required: [name]
+    additionalProperties: false
+    properties:
+      name:
+        type: string
+        description: >
+          Canonical parallel name (e.g. "Black", "Gold Pattern", "Superfractor"). UNIQUE
+          within its node. Used verbatim as the UUID-derivation input (see IDENTITY.md) —
+          renaming is a breaking identity change.
+      print_run:
+        type: integer
+        minimum: 0
+        description: Serial-numbering print run, when known (e.g. 10, 50, 1). Per-parallel constant.
+      serial_numbered:
+        type: boolean
+        default: false
+      applies_to:
+        description: >
+          Which rows of the parent checklist this parallel covers. Default "all". Three
+          partial forms, mutually exclusive: `numbers` (ONLY these rows), `except` (all
+          rows EXCEPT these — e.g. a parallel that skips one card the others carry), and
+          `sections` (all rows in the named declared section(s) — e.g. a rookies-only
+          parallel). Prefer `sections`/`except` over `numbers`: they stay correct as the
+          checklist grows, whereas a `numbers` list is a snapshot. Every referenced number
+          MUST exist in the parent checklist, and every referenced section MUST be a
+          declared section id (hard validation errors — see IDENTITY.md). Ranges are
+          intentionally omitted here (card numbers are strings; use a section for a range).
+          This filter selects which rows produce a derived parallel card; it never affects
+          the derived UUID.
+        oneOf:
+          - { type: string, enum: [all] }
+          - type: object
+            required: [numbers]
             additionalProperties: false
             properties:
-              id:
-                type: string
-                pattern: "^[a-z0-9]+(-[a-z0-9]+)*$"
-                description: Section slug. UNIQUE within the subset. Referenced by parallels' applies_to.sections.
-              name:
-                type: string
-                description: 'Human name of the section (e.g. "Veterans", "Rookies").'
-              declared_card_count:
-                type: integer
-                minimum: 1
-                description: Producer-declared size of this section — a review-report check against matched rows.
-              range:
-                type: object
-                required: [from, to]
-                additionalProperties: false
-                description: >
-                  Contiguous membership for sequential numbering. A row matches iff its
-                  `number` shares this range's literal non-digit prefix and its trailing
-                  integer is within [from, to] inclusive. Handles "1"–"100" and
-                  "US1"–"US25"; NOT mixed-prefix or arbitrary numbering (use `numbers`).
-                  Gaps are fine — the range matches whichever rows exist.
-                properties:
-                  from: { type: string }
-                  to:   { type: string }
-              numbers:
-                type: array
-                minItems: 1
-                items: { type: string }
-                description: >
-                  Explicit membership for non-sequential / interleaved / mixed-prefix
-                  numbering. Lists the exact card numbers in this section.
-            oneOf:
-              - { required: [range] }
-              - { required: [numbers] }
-        parallels:
-          type: array
-          description: Parallel definitions for this subset. Each expands the subset's checklist by (rows that match applies_to).
-          items:
-            type: object
-            required: [name]
+              numbers: { type: array, minItems: 1, items: { type: string } }
+          - type: object
+            required: [except]
             additionalProperties: false
             properties:
-              name:
-                type: string
-                description: >
-                  Canonical parallel name (e.g. "Black", "Gold Pattern", "Superfractor").
-                  UNIQUE within a subset. Used verbatim as the UUID-derivation input
-                  (see IDENTITY.md) — renaming is a breaking identity change.
-              print_run:
-                type: integer
-                minimum: 0
-                description: Serial-numbering print run, when known (e.g. 10, 50, 1). Per-parallel constant.
-              serial_numbered:
-                type: boolean
-                default: false
-              applies_to:
-                description: >
-                  Which base rows this parallel covers. Default "all". Three partial
-                  forms, mutually exclusive: `numbers` (ONLY these rows), `except` (all
-                  base rows EXCEPT these — e.g. a parallel that skips one card the
-                  others carry), and `sections` (all rows in the named declared
-                  section(s) — e.g. a rookies-only parallel). Prefer `sections` or
-                  `except` over `numbers` when applicable: they stay correct as the
-                  base checklist grows, whereas a `numbers` list is a snapshot. Every
-                  referenced number MUST exist in the subset's base checklist, and every
-                  referenced section MUST be a declared section id (hard validation
-                  errors — see IDENTITY.md). Ranges are intentionally omitted here
-                  (card numbers are strings, e.g. "US1"; use a section for a range).
-                  This filter selects which rows produce a derived parallel card; it
-                  never affects the derived UUID.
-                oneOf:
-                  - { type: string, enum: [all] }
-                  - type: object
-                    required: [numbers]
-                    additionalProperties: false
-                    properties:
-                      numbers:
-                        type: array
-                        minItems: 1
-                        items: { type: string }
-                  - type: object
-                    required: [except]
-                    additionalProperties: false
-                    properties:
-                      except:
-                        type: array
-                        minItems: 1
-                        items: { type: string }
-                  - type: object
-                    required: [sections]
-                    additionalProperties: false
-                    properties:
-                      sections:
-                        type: array
-                        minItems: 1
-                        items: { type: string }
-                default: all
+              except: { type: array, minItems: 1, items: { type: string } }
+          - type: object
+            required: [sections]
+            additionalProperties: false
+            properties:
+              sections: { type: array, minItems: 1, items: { type: string } }
+        default: all

--- a/proposals/v0.3-manifest-form/schemas/manifest.v0.1.schema.yaml
+++ b/proposals/v0.3-manifest-form/schemas/manifest.v0.1.schema.yaml
@@ -1,5 +1,5 @@
 $schema_version: "0.1"
-description: "Manifest schema for the Open Checklist Project — the compact generating structure. A product (set.yaml) holds ONE OR MORE base sets; a base set and a subset are the same recursive node (own checklist + parallels + sections + child subsets), differing only in role: base sets are the roots and carry no `type`; subsets are nested and carry a `type`. The per-card explosion is derived from this + checklists/, never committed."
+description: "Manifest schema for the Open Checklist Project — the compact generating structure. A product (set.yaml) holds ONE OR MORE base sets, plus optional product-level subsets (inserts not tied to a base set). A base set and a subset are the same recursive node (own checklist + parallels + sections + child subsets), differing only in role: base sets are roots with no `type`; subsets carry a `type` and nest under a base set, another subset, or the product. The per-card explosion is derived from this + checklists/, never committed."
 title: Manifest
 type: object
 required:
@@ -19,6 +19,18 @@ properties:
       has no `type` and is never nested. Each is a recursive node (see $defs/baseSet).
     items:
       $ref: "#/$defs/baseSet"
+  subsets:
+    type: array
+    minItems: 1
+    description: >
+      Optional PRODUCT-LEVEL subsets — inserts (and their own nested subsets) that
+      belong to the product but not to any single base set (e.g. an insert set like
+      "Anime" or "Patchwork"). Same recursive node shape as a base-set's child subsets;
+      each carries a `type`. A subset that IS tied to one base set (a variation/auto of
+      it) nests under that base set instead; a subset tied to an insert nests under that
+      insert. Only genuinely product-wide inserts live here.
+    items:
+      $ref: "#/$defs/subset"
 
 $defs:
 

--- a/proposals/v0.3-manifest-form/schemas/set.v0.3.schema.yaml
+++ b/proposals/v0.3-manifest-form/schemas/set.v0.3.schema.yaml
@@ -14,7 +14,10 @@ properties:
   uuid:
     type: string
     format: uuid
-    description: "Canonical set identity (UUIDv4), minted by tcapi and published here. Stable forever."
+    description: >
+      Canonical identity (UUIDv4) of the PRODUCT / umbrella, minted by tcapi and published
+      here. Stable forever. A product holds one or more base sets; each base set carries
+      its OWN uuid in manifest.yaml (see baseSet.uuid) — this is the umbrella above them.
   set_id:
     type: string
     pattern: "^[a-z0-9]+(-[a-z0-9]+)*$"

--- a/proposals/v0.3-manifest-form/schemas/set.v0.3.schema.yaml
+++ b/proposals/v0.3-manifest-form/schemas/set.v0.3.schema.yaml
@@ -1,0 +1,80 @@
+$schema_version: "0.3"
+description: "Set object schema for the Open Checklist Project (manifest form). Descriptive metadata only — subsets/parallels live in manifest.yaml, identities in checklists/."
+title: Set
+type: object
+required:
+  - uuid
+  - set_id
+  - name
+  - genre
+  - category
+  - source
+additionalProperties: false
+properties:
+  uuid:
+    type: string
+    format: uuid
+    description: "Canonical set identity (UUIDv4), minted by tcapi and published here. Stable forever."
+  set_id:
+    type: string
+    pattern: "^[a-z0-9]+(-[a-z0-9]+)*$"
+    description: 'Stable slug for the set (e.g. "2026-bowman"). Matches the data directory name.'
+  name:
+    type: string
+    description: Official name of the set.
+  genre:
+    type: string
+    enum: [Sports, TCG, Non-Sport]
+  category:
+    type: array
+    items: { type: string }
+    minItems: 1
+    description: 'Subject/franchise/league (e.g. ["MLB"], ["Pokemon"]).'
+  sports:
+    type: array
+    items:
+      type: string
+      enum: [Baseball, Basketball, Football, Hockey, Soccer, Golf, Boxing, Wrestling,
+             Tennis, Racing, MMA, Olympics, Cricket, Lacrosse, Pickleball, Bowling]
+    description: Specific sports (when genre is Sports).
+  season:
+    type: string
+    description: 'Official season designation (e.g. "2021-22", "2026").'
+  years:
+    type: array
+    items: { type: integer, minimum: 1800, maximum: 2100 }
+  series:
+    type: string
+    description: 'Umbrella grouping (e.g. "2026 Bowman Baseball").'
+  series_number:
+    type: integer
+    minimum: 1
+  manufacturer:
+    type: string
+  release_date:
+    type: string
+    format: date
+  description:
+    type: string
+  image_url:
+    type: string
+    format: uri
+    description: Optional set logo / representative image (real URL only — never a fabricated placeholder).
+  source:
+    type: object
+    description: Source attribution — where this checklist came from. Required.
+    required: [name, url]
+    additionalProperties: false
+    properties:
+      name: { type: string }
+      url: { type: string, format: uri }
+      file: { type: string, description: Optional original import filename. }
+  metadata:
+    type: object
+    additionalProperties: true
+    description: Optional freeform metadata. NOTE — subset declarations no longer live here; they are first-class in manifest.yaml.
+
+# Removed vs v0.2 (now expressed elsewhere or derived):
+#   parallel / insert / autograph / relic / base_set / subset  -> manifest.yaml subsets[].kind + parallels[]
+#   card_count                                                  -> derived at expansion; checked by the review report
+#   print_run (set-level)                                       -> per-parallel in manifest.yaml

--- a/proposals/v0.3-manifest-form/schemas/set.v0.3.schema.yaml
+++ b/proposals/v0.3-manifest-form/schemas/set.v0.3.schema.yaml
@@ -15,7 +15,7 @@ properties:
     type: string
     format: uuid
     description: >
-      Canonical identity (UUIDv4) of the PRODUCT / umbrella, minted by tcapi and published
+      Canonical identity (UUIDv4) of the PRODUCT / umbrella, committed here
       here. Stable forever. A product holds one or more base sets; each base set carries
       its OWN uuid in manifest.yaml (see baseSet.uuid) — this is the umbrella above them.
   set_id:


### PR DESCRIPTION
## What this is

A **design proposal** (not a migration) for the v0.3 "manifest form" — the compact generating representation that replaces the exploded one-file-per-card layout. Everything lives under `proposals/v0.3-manifest-form/` and **does not touch** the live v0.2 schemas or `validate.py`. Review it as a diff; nothing is wired up yet.

## Why

The v0.2 layout commits every parallel of every card as its own file. Real evidence from this repo: **2026 Bowman (#19) = 17,928 card files**, where all variants of a card are identical except `uuid`, a per-parallel-constant `print_run`/`serial_numbered`, and templated `card_name`/`description`/`image_url` (17,928 *fabricated* placeholder image URLs). That is unreviewable.

v0.3 commits the **compact generating form** and derives the explosion at consume time. Bowman collapses from **17,928 files → ~4 readable ones**.

## The shape

Three file roles per set:

- `set.yaml` — descriptive metadata only (what it *is*). Drops the vestigial v0.2 fields.
- `manifest.yaml` — **recursive subsets** (base / insert / autograph / …), each with its `parallels`. The generating structure.
- `checklists/<subset>.yaml` — committed row identities (`number → subjects`, each with a **committed `uuid`**).

**Store anchors, derive the explosion.** Base rows carry a committed `uuid`; each parallel card's uuid is derived and never committed:

```
parallel_card.uuid = uuidv5(namespace = base_row.uuid, name = parallel.name)
```

Both inputs are OCP-published canonical values, so every consumer computes the identical id — idempotent re-sync, no duplicates. Frozen rules in `IDENTITY.md`.

## Contents

- `README.md` — format overview, committed-vs-derived table, consume-time expansion pseudocode
- `IDENTITY.md` — the frozen UUID-derivation spec + validation invariants
- `schemas/set.v0.3.schema.yaml`, `manifest.v0.1.schema.yaml`, `checklist.v0.1.schema.yaml`
- `example/2026-bowman/` — a folded, abbreviated worked example using real #19 data

## Open questions for review

1. **Breaking `set` fields.** v0.3 drops `parallel` / `insert` / `base_set` / exploded `card_count`. Anything consuming these needs a migration sequence.
2. **Insert vs base-parallel.** The importer behind #16–23 folded inserts (e.g. "Bowman Scouts Top 100") as *base parallels*. v0.3 models them correctly as their own insert subsets — a fix to carry into the consume-time expander, not the old behavior.
3. **Not yet built (intentionally):** `validate.py` still targets v0.2; no CHANGELOGs; `subject.ref` resolution is a separate (API-side) workstream; per-card print-run overrides and `applies_to` ranges are deliberately omitted.

## Not in scope

Entity identity/resolution (players/teams) — owned by tcapi as a separate workstream. This proposal only *references* entity UUIDs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)