### PR TITLE
feat(data): 2026 Bowman in v0.3 manifest form (converted from #19)

### DIFF
--- a/data/baseball/2026-bowman/checklists/anime-kanji-variations.yaml
+++ b/data/baseball/2026-bowman/checklists/anime-kanji-variations.yaml
@@ -1,0 +1,70 @@
+- number: BA-1
+  uuid: 0450ccd4-0652-4ef5-8d6f-ae1e1c7475d0
+  subjects:
+  - entities:
+    - role: player
+      name: Sadaharu Oh
+      ref: 
+    - role: team
+      name: Yomiuri Giants
+      ref: 
+- number: BA-3
+  uuid: 9fbf9209-9dae-4475-8b7f-9614d1d891de
+  subjects:
+  - entities:
+    - role: player
+      name: Munetaka Murakami
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: BA-8
+  uuid: e0d77d8e-55c6-4ef6-9268-5f5dcc338a1b
+  subjects:
+  - entities:
+    - role: player
+      name: Tatsuya Imai
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: BA-9
+  uuid: 7346f3e5-aa78-4a60-b3d0-d7c2c2ab9ab3
+  subjects:
+  - entities:
+    - role: player
+      name: Shotaro Morii
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: BA-16
+  uuid: 495951e4-ea15-429d-ac3c-dbc288d79b52
+  subjects:
+  - entities:
+    - role: player
+      name: Hideo Nomo
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: BA-17
+  uuid: e02f50de-25a9-4c7a-9957-116461ddbe0f
+  subjects:
+  - entities:
+    - role: player
+      name: Kazuma Okamoto
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: BA-26
+  uuid: 1764473a-1c14-4f97-8425-a8d176a5b73f
+  subjects:
+  - entities:
+    - role: player
+      name: Shohei Ohtani
+      ref: 
+    - role: team
+      name: Japan
+      ref: 

--- a/data/baseball/2026-bowman/checklists/anime.yaml
+++ b/data/baseball/2026-bowman/checklists/anime.yaml
@@ -1,0 +1,290 @@
+- number: BA-1
+  uuid: 3457277b-12c8-4678-a2bb-8bcaaf2c0cae
+  subjects:
+  - entities:
+    - role: player
+      name: Sadaharu Oh
+      ref: 
+    - role: team
+      name: Yomiuri Giants
+      ref: 
+- number: BA-2
+  uuid: 55aacc11-baa8-4724-bbd3-627c6cc775f6
+  subjects:
+  - entities:
+    - role: player
+      name: Cal Raleigh
+      ref: 
+    - role: team
+      name: USA
+      ref: 
+- number: BA-3
+  uuid: f2217a1f-ac8d-4705-bf3c-4ecb20938cdf
+  subjects:
+  - entities:
+    - role: player
+      name: Munetaka Murakami
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: BA-4
+  uuid: 3f235c4e-7316-42f8-917b-cf429046f06b
+  subjects:
+  - entities:
+    - role: player
+      name: Aaron Judge
+      ref: 
+    - role: team
+      name: USA
+      ref: 
+- number: BA-5
+  uuid: 7e6a98e4-3a43-419f-ab3d-21936ba99a86
+  subjects:
+  - entities:
+    - role: player
+      name: Bobby Witt Jr.
+      ref: 
+    - role: team
+      name: USA
+      ref: 
+- number: BA-6
+  uuid: cfebc8ea-6222-47a1-a027-a6a67029cf37
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Kurtz
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: BA-7
+  uuid: 7e9ce235-a577-4542-9695-4e881bf031e9
+  subjects:
+  - entities:
+    - role: player
+      name: Ethan Holliday
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: BA-8
+  uuid: 359d1b0d-17e6-401c-ba51-1c99387fe04b
+  subjects:
+  - entities:
+    - role: player
+      name: Tatsuya Imai
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: BA-9
+  uuid: 75f00869-c6ff-4721-b550-58471c57328d
+  subjects:
+  - entities:
+    - role: player
+      name: Shotaro Morii
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: BA-10
+  uuid: 3a247352-3bfc-41ac-bc34-1b5f06cba062
+  subjects:
+  - entities:
+    - role: player
+      name: Manny Ramirez
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: BA-11
+  uuid: c0db3024-851e-4c2c-b17b-2b2d13577ea2
+  subjects:
+  - entities:
+    - role: player
+      name: Sammy Sosa
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: BA-12
+  uuid: c34a9c16-4954-4114-be4b-9c157d92d20e
+  subjects:
+  - entities:
+    - role: player
+      name: Ken Griffey Jr.
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: BA-13
+  uuid: 188143f6-bc8e-45fb-9ae4-ba33663b6ece
+  subjects:
+  - entities:
+    - role: player
+      name: Roman Anthony
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: BA-14
+  uuid: eb22b610-2abc-41e5-9af6-f696f230e8ff
+  subjects:
+  - entities:
+    - role: player
+      name: Eli Willits
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: BA-15
+  uuid: db60b354-ae84-42a4-97eb-bdcdbcc23602
+  subjects:
+  - entities:
+    - role: player
+      name: Jesus Made
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: BA-16
+  uuid: dc370016-d30e-42bf-aafd-d903dc55bf6b
+  subjects:
+  - entities:
+    - role: player
+      name: Hideo Nomo
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: BA-17
+  uuid: 3546db89-a642-4878-bc23-3a45161c7155
+  subjects:
+  - entities:
+    - role: player
+      name: Kazuma Okamoto
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: BA-18
+  uuid: 3d060417-bd5d-473f-8591-1e7075b3d148
+  subjects:
+  - entities:
+    - role: player
+      name: Konnor Griffin
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: BA-19
+  uuid: 7f04db9b-bc1b-4c99-908c-322498edaeb2
+  subjects:
+  - entities:
+    - role: player
+      name: Jackie Robinson
+      ref: 
+    - role: team
+      name: Brooklyn Dodgers
+      ref: 
+- number: BA-20
+  uuid: 83a628cf-b18d-413e-999e-a23ea173ccc6
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Misiorowski
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: BA-21
+  uuid: 918c3aa5-7571-43a9-99ba-8165ee0e7185
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: Dominican Republic
+      ref: 
+- number: BA-22
+  uuid: 8a7288ee-6181-4fb4-95af-534b64cdad63
+  subjects:
+  - entities:
+    - role: player
+      name: Bo Jackson
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: BA-23
+  uuid: d25277d6-0ced-41a9-8fb9-0531c4392645
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Trout
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: BA-24
+  uuid: 20e207ea-d93d-4b73-92a9-8b67c9e25b95
+  subjects:
+  - entities:
+    - role: player
+      name: Paul Skenes
+      ref: 
+    - role: team
+      name: USA
+      ref: 
+- number: BA-25
+  uuid: dbb887dd-29e8-4109-ad2b-648e71932565
+  subjects:
+  - entities:
+    - role: player
+      name: Samuel Basallo
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: BA-26
+  uuid: a729df88-7704-4325-9580-c087e51eb917
+  subjects:
+  - entities:
+    - role: player
+      name: Shohei Ohtani
+      ref: 
+    - role: team
+      name: Japan
+      ref: 
+- number: BA-27
+  uuid: 525200a9-758f-4e7f-b66d-7ac210ecda38
+  subjects:
+  - entities:
+    - role: player
+      name: Jac Caglianone
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: BA-28
+  uuid: e1c5ce92-9983-45cf-a824-e5243437614b
+  subjects:
+  - entities:
+    - role: player
+      name: Joey Votto
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: BA-29
+  uuid: 6536fd93-864d-48e4-bf99-462945a1d158
+  subjects:
+  - entities:
+    - role: player
+      name: Rickey Henderson
+      ref: 
+    - role: team
+      name: Oakland Athletics
+      ref: 

--- a/data/baseball/2026-bowman/checklists/anime.yaml
+++ b/data/baseball/2026-bowman/checklists/anime.yaml
@@ -143,7 +143,7 @@
   subjects:
   - entities:
     - role: player
-      name: Jesus Made
+      name: Jesús Made
       ref: 
     - role: team
       name: Milwaukee Brewers
@@ -286,5 +286,5 @@
       name: Rickey Henderson
       ref: 
     - role: team
-      name: Oakland Athletics
+      name: Athletics
       ref: 

--- a/data/baseball/2026-bowman/checklists/base-etched-in-glass-variations.yaml
+++ b/data/baseball/2026-bowman/checklists/base-etched-in-glass-variations.yaml
@@ -1,0 +1,120 @@
+- number: '3'
+  uuid: 41be710f-a2f6-4a12-b878-f0a7fbf2757f
+  subjects:
+  - entities:
+    - role: player
+      name: Chase Burns
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '18'
+  uuid: a968c3e0-10e8-4863-bef5-0cc377a3b956
+  subjects:
+  - entities:
+    - role: player
+      name: Roman Anthony
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '35'
+  uuid: c7a27719-4e71-469f-829b-ad0bdb059a2f
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Misiorowski
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: '39'
+  uuid: a4e77168-0701-4a5a-9f14-5bf2cdb5797c
+  subjects:
+  - entities:
+    - role: player
+      name: Carson Williams
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: '58'
+  uuid: 856543f1-5901-47cf-bf00-882299657461
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Eldridge
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '68'
+  uuid: c2ea64ae-1cb6-4326-a8f4-2c1ebde71831
+  subjects:
+  - entities:
+    - role: player
+      name: Colson Montgomery
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: '75'
+  uuid: 5417e891-eadb-4c8c-a010-6b333b4004b7
+  subjects:
+  - entities:
+    - role: player
+      name: Jac Caglianone
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: '83'
+  uuid: 84271102-ed4a-4a7c-9682-5aa090abce32
+  subjects:
+  - entities:
+    - role: player
+      name: Bubba Chandler
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '84'
+  uuid: 4179b05b-2a51-4e03-ac3e-950239238319
+  subjects:
+  - entities:
+    - role: player
+      name: Harry Ford
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: '85'
+  uuid: 71bdea56-f84a-4a09-8277-8a9834490c90
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan McLean
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '93'
+  uuid: 96834040-0970-4056-b29e-a0cf40f905a7
+  subjects:
+  - entities:
+    - role: player
+      name: Samuel Basallo
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '99'
+  uuid: e06419c7-a682-4b2d-af0b-dd18c7893178
+  subjects:
+  - entities:
+    - role: player
+      name: Christian Moore
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 

--- a/data/baseball/2026-bowman/checklists/base-prospect-retail-autographs.yaml
+++ b/data/baseball/2026-bowman/checklists/base-prospect-retail-autographs.yaml
@@ -1,0 +1,310 @@
+- number: BPA-AA
+  uuid: e0c0de25-2277-4464-a47c-d8c7e7d479c2
+  subjects:
+  - entities:
+    - role: player
+      name: Aiva Arquette
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: BPA-AF
+  uuid: 285d870a-f385-481d-81bc-bafa0f22137d
+  subjects:
+  - entities:
+    - role: player
+      name: Andrew Fischer
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: BPA-AG
+  uuid: f2b396c3-0e0a-4f59-86cf-9571676da638
+  subjects:
+  - entities:
+    - role: player
+      name: Angel Guzman
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: BPA-AL
+  uuid: fe425381-5e15-4955-84df-1a29394312a9
+  subjects:
+  - entities:
+    - role: player
+      name: Arnaldo Lantigua
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: BPA-BM
+  uuid: fbf1660d-8edf-4956-8045-ea8e5edc34b0
+  subjects:
+  - entities:
+    - role: player
+      name: Blake Mitchell
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: BPA-CB
+  uuid: e2749a3b-61bb-42e9-9fbf-e75e6b1a10ba
+  subjects:
+  - entities:
+    - role: player
+      name: Caleb Bonemer
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: BPA-CBE
+  uuid: ddb4600d-13bd-42f9-ace2-e932d8ebf5f1
+  subjects:
+  - entities:
+    - role: player
+      name: Carson Benge
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: BPA-CE
+  uuid: b24ff2d7-3ff2-4861-b9ed-11c90dc2fa3e
+  subjects:
+  - entities:
+    - role: player
+      name: Colt Emerson
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: BPA-CJ
+  uuid: 8f96e441-93a1-4980-a768-56ae657d2a76
+  subjects:
+  - entities:
+    - role: player
+      name: Coy James
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: BPA-DP
+  uuid: ec89f1a5-0f3f-48f7-96b9-6d9fcabe8516
+  subjects:
+  - entities:
+    - role: player
+      name: Daniel Pierce
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: BPA-DT
+  uuid: 31d1b410-6e48-4fd1-b50f-0a1d8dbcfaa0
+  subjects:
+  - entities:
+    - role: player
+      name: Diego Tornes
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: BPA-EC
+  uuid: 97d18124-bc88-4928-ba60-aaef35e09eb7
+  subjects:
+  - entities:
+    - role: player
+      name: Ethan Conrad
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: BPA-EF
+  uuid: 1de22a81-a0f5-4f1e-86ad-cf7d29577743
+  subjects:
+  - entities:
+    - role: player
+      name: Edward Florentino
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: BPA-EH
+  uuid: 72ab1b23-d64c-4cca-bf03-eb1c4d950369
+  subjects:
+  - entities:
+    - role: player
+      name: Ethan Holliday
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: BPA-GS
+  uuid: ff435996-58e3-4f84-9a9a-0c2168a6c633
+  subjects:
+  - entities:
+    - role: player
+      name: Grant Shepardson
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: BPA-GT
+  uuid: d60495de-7f25-496a-bdd1-e39deee0d8af
+  subjects:
+  - entities:
+    - role: player
+      name: Gavin Turley
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: BPA-JP
+  uuid: 7bb24294-7c34-438e-906a-f458c626b4e7
+  subjects:
+  - entities:
+    - role: player
+      name: Jose Perdomo
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: BPA-JT
+  uuid: 03ddd95d-1d8d-47e2-9b2d-ad1446b5aab4
+  subjects:
+  - entities:
+    - role: player
+      name: James Tibbs III
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: BPA-KC
+  uuid: 5ea5c0e4-e751-4fd9-9556-2922b3a302e7
+  subjects:
+  - entities:
+    - role: player
+      name: Kaelen Culpepper
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: BPA-KD
+  uuid: 8f932cb3-86b2-4de7-a226-17157f8fa790
+  subjects:
+  - entities:
+    - role: player
+      name: Korbyn Dickerson
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: BPA-KG
+  uuid: 4c5aa1c9-9627-457a-8366-3904c0df3f1d
+  subjects:
+  - entities:
+    - role: player
+      name: Konnor Griffin
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: BPA-LP
+  uuid: ac492775-9de4-423c-864a-4353e794fd63
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Peña
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: BPA-MH
+  uuid: ab02e576-be79-4b6a-869c-960f2a7ebdca
+  subjects:
+  - entities:
+    - role: player
+      name: Marek Houston
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: BPA-PM
+  uuid: 6b5a32f2-c751-4019-be32-df41287dd42c
+  subjects:
+  - entities:
+    - role: player
+      name: PJ Morlando
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: BPA-QM
+  uuid: ec7bf71b-4161-4823-b907-ac541656dec4
+  subjects:
+  - entities:
+    - role: player
+      name: Quinn Mathews
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: BPA-SH
+  uuid: c4cf0abe-7573-4dae-ba9d-d64a96453c7e
+  subjects:
+  - entities:
+    - role: player
+      name: Steele Hall
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: BPA-SKI
+  uuid: fa6f6715-cb3b-4a61-aaa4-5616fcd37aa4
+  subjects:
+  - entities:
+    - role: player
+      name: Seaver King
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: BPA-SM
+  uuid: 85574c21-72d7-4d60-9665-e9ce7ef35f8f
+  subjects:
+  - entities:
+    - role: player
+      name: Shotaro Morii
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: BPA-WA
+  uuid: b77bf272-6639-4f5d-ab92-5ae0d9bb86a4
+  subjects:
+  - entities:
+    - role: player
+      name: Wehiwa Aloy
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: BPA-WJ
+  uuid: bdba83ca-fcc9-4696-bab0-8dadc5d4458d
+  subjects:
+  - entities:
+    - role: player
+      name: Walker Jenkins
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: BPA-ZE
+  uuid: 8cdc2564-7699-4c60-ab29-6003597dc453
+  subjects:
+  - entities:
+    - role: player
+      name: Zach Ehrhard
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 

--- a/data/baseball/2026-bowman/checklists/base-prospects.yaml
+++ b/data/baseball/2026-bowman/checklists/base-prospects.yaml
@@ -1,0 +1,1500 @@
+- number: BP-1
+  uuid: 371d2e1c-5b6b-4ad0-987f-9d0893067694
+  subjects:
+  - entities:
+    - role: player
+      name: Ethan Holliday
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: BP-2
+  uuid: 0b0ccb6d-ee8e-468c-b134-058174c6f7c9
+  subjects:
+  - entities:
+    - role: player
+      name: Max Clark
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: BP-3
+  uuid: 8f2233fa-3816-47c7-b293-0fddc07d5320
+  subjects:
+  - entities:
+    - role: player
+      name: Yojancel Cabrera
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: BP-4
+  uuid: 276deaa4-79de-4ae0-830c-3f4876b5814c
+  subjects:
+  - entities:
+    - role: player
+      name: James Quinn-Irons
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: BP-5
+  uuid: f19f5ddb-d833-4721-a4e3-6faf43462879
+  subjects:
+  - entities:
+    - role: player
+      name: Tyson Lewis
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: BP-6
+  uuid: ef604731-0391-4ec0-85a8-5848e64c7cd7
+  subjects:
+  - entities:
+    - role: player
+      name: Jared Jones
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: BP-7
+  uuid: a2e328ef-aec5-4393-a969-a21de7962118
+  subjects:
+  - entities:
+    - role: player
+      name: Kendry Chourio
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: BP-8
+  uuid: f03038f1-30bb-460c-96fb-18d28ff03fb2
+  subjects:
+  - entities:
+    - role: player
+      name: Anderson Araujo
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: BP-9
+  uuid: 3f386115-1134-4110-8616-60d8c41ea360
+  subjects:
+  - entities:
+    - role: player
+      name: Tyler Bremner
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: BP-10
+  uuid: bdbf0113-ad0b-4a50-81c0-171a8ae58e7b
+  subjects:
+  - entities:
+    - role: player
+      name: Liam Doyle
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: BP-11
+  uuid: f76617e5-4396-4c8e-a43b-6637a45a8760
+  subjects:
+  - entities:
+    - role: player
+      name: David Shields
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: BP-12
+  uuid: bbd796fe-f643-45a6-bfa6-f2cf1b48d7e3
+  subjects:
+  - entities:
+    - role: player
+      name: Jase Mitchell
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: BP-13
+  uuid: f7bcbe56-4d8b-4840-9a0e-d02c2968dbaa
+  subjects:
+  - entities:
+    - role: player
+      name: Blake Mitchell
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: BP-14
+  uuid: 3781e959-c5c7-406c-9c5f-b9f017ae09bd
+  subjects:
+  - entities:
+    - role: player
+      name: Carlos Gutierrez
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: BP-15
+  uuid: 43a32196-0cfa-4f0e-b995-09bd003c8448
+  subjects:
+  - entities:
+    - role: player
+      name: Gage Jump
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: BP-16
+  uuid: 51e4a017-ad0d-4442-8fa4-fdb49d160055
+  subjects:
+  - entities:
+    - role: player
+      name: Marek Houston
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: BP-17
+  uuid: baf49d5a-4a95-4b62-961c-4d7430807f0a
+  subjects:
+  - entities:
+    - role: player
+      name: Caden Scarborough
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: BP-18
+  uuid: 696b0c25-1688-4d85-96bf-f032c571ab41
+  subjects:
+  - entities:
+    - role: player
+      name: Blaine Bullard
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: BP-19
+  uuid: 71ee873f-ba61-4478-b3a7-3ba290af708e
+  subjects:
+  - entities:
+    - role: player
+      name: Kade Anderson
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: BP-20
+  uuid: 27fd5169-8311-4d91-bd4e-44b957939cc7
+  subjects:
+  - entities:
+    - role: player
+      name: Theo Gillen
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: BP-21
+  uuid: 14fc88f9-999a-4b61-a70a-ddc5d2d248f4
+  subjects:
+  - entities:
+    - role: player
+      name: Roldy Brito
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: BP-22
+  uuid: ee26b603-ccfe-4e3e-ad74-05aaead4f9ec
+  subjects:
+  - entities:
+    - role: player
+      name: Deniel Ortiz
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: BP-23
+  uuid: 7ed0905c-9208-486c-8345-92072a7bd7e6
+  subjects:
+  - entities:
+    - role: player
+      name: Enddy Azocar
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: BP-24
+  uuid: 9d47eb9b-b37a-434b-97fe-5849021b71c0
+  subjects:
+  - entities:
+    - role: player
+      name: Edward Duran
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: BP-25
+  uuid: 9fb9aab5-8d29-4c89-b08f-52421e192c83
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Sanchez
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: BP-26
+  uuid: 958b5272-2f38-4601-88b2-3799349390be
+  subjects:
+  - entities:
+    - role: player
+      name: Sean Paul Liñan
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: BP-27
+  uuid: 2ab5eb32-7783-4921-825e-e3de4566dd5d
+  subjects:
+  - entities:
+    - role: player
+      name: Franklin Arias
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: BP-28
+  uuid: 5aabfea8-5287-41ac-95d2-c09e80be9d53
+  subjects:
+  - entities:
+    - role: player
+      name: Carlos Virahonda
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: BP-29
+  uuid: d14dcadd-cd1c-41bf-ab09-17ef10c71e1d
+  subjects:
+  - entities:
+    - role: player
+      name: Victor Arias
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: BP-30
+  uuid: 41739991-71b9-472d-8114-ddcd226eeabf
+  subjects:
+  - entities:
+    - role: player
+      name: Alimber Santa
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: BP-31
+  uuid: 438b3880-2e2d-4b9f-98de-2775fdd63269
+  subjects:
+  - entities:
+    - role: player
+      name: Brent Iredale
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: BP-32
+  uuid: '0581f1d8-fa24-40fd-a9aa-2b1d8758e3b7'
+  subjects:
+  - entities:
+    - role: player
+      name: Breyson Guedez
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: BP-33
+  uuid: b4d1dbd7-b8f8-45c7-bc72-08887b10d673
+  subjects:
+  - entities:
+    - role: player
+      name: Coy James
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: BP-34
+  uuid: 74f4d57d-4abe-4961-9191-354a4b9475d0
+  subjects:
+  - entities:
+    - role: player
+      name: Cristopher Polanco
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: BP-35
+  uuid: 8a2bf855-1862-4f88-9883-456aebe509c8
+  subjects:
+  - entities:
+    - role: player
+      name: Travis Bazzana
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: BP-36
+  uuid: 359784e8-392d-488f-bbad-cfab6c83349d
+  subjects:
+  - entities:
+    - role: player
+      name: Moisés Chace
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: BP-37
+  uuid: 8cde86e0-e6ee-4cd1-b3bd-80720df5843c
+  subjects:
+  - entities:
+    - role: player
+      name: Gage Stanifer
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: BP-38
+  uuid: b94e00ed-14cc-402f-87d5-93e1390964ec
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Cova
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: BP-39
+  uuid: da4f16af-ef7e-4bc5-a8e4-b49e4fde8c68
+  subjects:
+  - entities:
+    - role: player
+      name: Ryan Waldschmidt
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: BP-40
+  uuid: 4af69bd7-d30b-4bd9-b935-000b857e34d1
+  subjects:
+  - entities:
+    - role: player
+      name: Aiva Arquette
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: BP-41
+  uuid: 65ad29f7-0620-443c-a527-a93445d92ac3
+  subjects:
+  - entities:
+    - role: player
+      name: Brailyn Antunez
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: BP-42
+  uuid: d9b2a246-f4e3-4155-93f8-792d8486dd85
+  subjects:
+  - entities:
+    - role: player
+      name: David Davalillo
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: BP-43
+  uuid: bd7d95eb-f026-482f-b4a8-7f4816dc91ed
+  subjects:
+  - entities:
+    - role: player
+      name: Parks Harber
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: BP-44
+  uuid: 9d4194d3-a35b-4360-a92d-345047cb559d
+  subjects:
+  - entities:
+    - role: player
+      name: Billy Carlson
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: BP-45
+  uuid: daacf2de-5a34-4189-8cd0-300861e2a3ad
+  subjects:
+  - entities:
+    - role: player
+      name: Seong-Jun Kim
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: BP-46
+  uuid: 0e163594-0336-478f-9a76-e88064d2dd2f
+  subjects:
+  - entities:
+    - role: player
+      name: Charlie Condon
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: BP-47
+  uuid: 926625a5-3030-40eb-8e56-07a57fe9c6a8
+  subjects:
+  - entities:
+    - role: player
+      name: Handelfry Encarnacion
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: BP-48
+  uuid: d2267ed2-e7ca-4cad-ae0b-c8306102e4e7
+  subjects:
+  - entities:
+    - role: player
+      name: Shotaro Morii
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: BP-49
+  uuid: 826b8fff-e765-4a41-8cfe-4f31cdc47acd
+  subjects:
+  - entities:
+    - role: player
+      name: Aidan Miller
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: BP-50
+  uuid: ed2ed8c5-b612-4818-a0a9-53e62e8eb81d
+  subjects:
+  - entities:
+    - role: player
+      name: Daniel Dickinson
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: BP-51
+  uuid: 050a66eb-c3d4-442d-8352-d894b018d4ac
+  subjects:
+  - entities:
+    - role: player
+      name: Sebastian Walcott
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: BP-52
+  uuid: 4fd6328a-0a96-4a40-b24e-251544636ee5
+  subjects:
+  - entities:
+    - role: player
+      name: Ethan Dorchies
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: BP-53
+  uuid: 3591db47-4dc5-4ba5-af99-b1c9fab6d3ef
+  subjects:
+  - entities:
+    - role: player
+      name: Braden Montgomery
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: BP-54
+  uuid: 11bb6b38-882a-4d22-9b7b-5a3dd6c9311b
+  subjects:
+  - entities:
+    - role: player
+      name: Rainiel Rodriguez
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: BP-55
+  uuid: 39231f03-7e58-4b5a-8d97-d7883755ddc8
+  subjects:
+  - entities:
+    - role: player
+      name: Andrew Salas
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: BP-56
+  uuid: 2616cf95-d981-4c2b-84a5-2e3ea81c3cc4
+  subjects:
+  - entities:
+    - role: player
+      name: Josuar Gonzalez
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: BP-57
+  uuid: 53175daa-3b77-4753-9eeb-0b14d0e9ca76
+  subjects:
+  - entities:
+    - role: player
+      name: Felnin Celesten
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: BP-58
+  uuid: cbb6ce34-6d43-46e0-9944-15947a1be5a7
+  subjects:
+  - entities:
+    - role: player
+      name: Jude Warwick
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: BP-59
+  uuid: aa2c675d-d241-4153-b187-4277de81d6d0
+  subjects:
+  - entities:
+    - role: player
+      name: Brendan Tunink
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: BP-60
+  uuid: 6edc5ebc-de0c-4853-83d2-faf8ba03c347
+  subjects:
+  - entities:
+    - role: player
+      name: Isaiah Jackson
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: BP-61
+  uuid: e99b1448-57a3-4c4e-a083-99cc4e13f299
+  subjects:
+  - entities:
+    - role: player
+      name: Chris Arroyo
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: BP-62
+  uuid: 4b01ba30-5a57-4955-b284-9223bf445415
+  subjects:
+  - entities:
+    - role: player
+      name: Josh Owens
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: BP-63
+  uuid: d7d079c1-5e6b-4683-91cb-84cfb8fdf36e
+  subjects:
+  - entities:
+    - role: player
+      name: Leo De Vries
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: BP-64
+  uuid: f87d6e2e-1ca0-4cba-89ab-0564b7e73db7
+  subjects:
+  - entities:
+    - role: player
+      name: George Lombard Jr.
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: BP-65
+  uuid: 5fd6cc26-9c87-4a3f-aa6d-0ee8ffc8d1a0
+  subjects:
+  - entities:
+    - role: player
+      name: Nelly Taylor
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: BP-66
+  uuid: f02e0f42-dccd-494b-8ec1-d82ac5643583
+  subjects:
+  - entities:
+    - role: player
+      name: Wyatt Sanford
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: BP-67
+  uuid: 0a1c0f16-4382-4428-b845-5094f8303eb0
+  subjects:
+  - entities:
+    - role: player
+      name: Arjun Nimmala
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: BP-68
+  uuid: 45592fcd-28ab-4cbb-a2d7-6c65b5f6103f
+  subjects:
+  - entities:
+    - role: player
+      name: Ike Irish
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: BP-69
+  uuid: 7981ea10-5ca4-4d66-80c3-fb6aa984d11d
+  subjects:
+  - entities:
+    - role: player
+      name: Owen Carey
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: BP-70
+  uuid: 82ba7e6e-852d-4c07-a2d7-0bfcee25e1fe
+  subjects:
+  - entities:
+    - role: player
+      name: Kash Mayfield
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: BP-71
+  uuid: 141e3b2c-f047-4da6-8733-19565e57f770
+  subjects:
+  - entities:
+    - role: player
+      name: Enyervert Perez
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: BP-72
+  uuid: 8515e02c-73e1-4f30-b370-30729314976e
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Arana
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: BP-73
+  uuid: 9789b44b-8917-4f42-ae12-11c0434bfdc7
+  subjects:
+  - entities:
+    - role: player
+      name: Charles Davalan
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: BP-74
+  uuid: 927c8c57-1b4c-4060-a5be-21d59d1696df
+  subjects:
+  - entities:
+    - role: player
+      name: Jack Wheeler
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: BP-75
+  uuid: 837dbb90-6253-4a6d-9f7b-4c1124ea7dda
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Torres
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: BP-76
+  uuid: 481686cb-07f7-4171-9a42-d0a437443d1c
+  subjects:
+  - entities:
+    - role: player
+      name: Esmerlyn Valdez
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: BP-77
+  uuid: 0e45c312-efff-4f82-adf3-cc5903499e26
+  subjects:
+  - entities:
+    - role: player
+      name: Daniel Pierce
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: BP-78
+  uuid: 88428ec8-7db6-4e34-942c-fb5477b380d8
+  subjects:
+  - entities:
+    - role: player
+      name: Dax Kilby
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: BP-79
+  uuid: 6739f6cc-ab87-4202-8852-0f05da49ad46
+  subjects:
+  - entities:
+    - role: player
+      name: Esteban Mejia
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: BP-80
+  uuid: 79a5c4b8-8040-43b3-b1ae-ec6ea9d9a461
+  subjects:
+  - entities:
+    - role: player
+      name: Thomas White
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: BP-81
+  uuid: b2ded471-b718-4594-9553-f61428f3553f
+  subjects:
+  - entities:
+    - role: player
+      name: Jose Urbina
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: BP-82
+  uuid: a48957b5-b4ed-48e0-8b37-77859cc8414d
+  subjects:
+  - entities:
+    - role: player
+      name: Edward Florentino
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: BP-83
+  uuid: dcecf053-8de7-4901-8a83-dbfef9e62088
+  subjects:
+  - entities:
+    - role: player
+      name: Josue De Paula
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: BP-84
+  uuid: 6702d353-771d-42d0-9a52-5e0219aacc9f
+  subjects:
+  - entities:
+    - role: player
+      name: David Hagaman
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: BP-85
+  uuid: 51d5dbb8-05cc-45a2-a2d1-3e88f184e931
+  subjects:
+  - entities:
+    - role: player
+      name: Anthony Frobose
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: BP-86
+  uuid: 5f707dc6-2d6c-4f0d-bfb1-a2ee4087900a
+  subjects:
+  - entities:
+    - role: player
+      name: Zyhir Hope
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: BP-87
+  uuid: 06cb0e9e-d000-4ef7-8853-eab01b723d54
+  subjects:
+  - entities:
+    - role: player
+      name: Jean Carlos Sio
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: BP-88
+  uuid: '098e0e46-5750-4083-b66e-23a20033dd39'
+  subjects:
+  - entities:
+    - role: player
+      name: Dasan Hill
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: BP-89
+  uuid: 9fe69067-b23b-42fb-8afb-1a30c1fa72f6
+  subjects:
+  - entities:
+    - role: player
+      name: Kendry Martinez
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: BP-90
+  uuid: 82c1ae06-aaf9-41d5-b7b9-f2b4dfb5f407
+  subjects:
+  - entities:
+    - role: player
+      name: Andrew Tess
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: BP-91
+  uuid: 186f86d8-49bd-4d1e-b7c7-70c4d5ad188d
+  subjects:
+  - entities:
+    - role: player
+      name: Elian Peña
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: BP-92
+  uuid: 7530e30b-211a-421a-a15d-9fe98ea9ba02
+  subjects:
+  - entities:
+    - role: player
+      name: Konnor Griffin
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: BP-93
+  uuid: 58f2661c-7df6-44d2-8089-a782e3f9c22d
+  subjects:
+  - entities:
+    - role: player
+      name: Jorge Quintana
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: BP-94
+  uuid: 26f3e0e1-4dcd-49e3-aa49-6d1bcf59fc20
+  subjects:
+  - entities:
+    - role: player
+      name: Ricardo Cova
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: BP-95
+  uuid: 423ecc79-5b36-4c91-b695-271ae7f7a4c1
+  subjects:
+  - entities:
+    - role: player
+      name: Eli Willits
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: BP-96
+  uuid: ffc47ac2-cc06-4c62-9d81-f1024ded142c
+  subjects:
+  - entities:
+    - role: player
+      name: Jesús Made
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: BP-97
+  uuid: 970572d3-1840-407e-8469-b3a10e69d56d
+  subjects:
+  - entities:
+    - role: player
+      name: Daniel Hernandez
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: BP-98
+  uuid: d9d4f183-17e5-4f19-9619-204cc5ad6c21
+  subjects:
+  - entities:
+    - role: player
+      name: Walker Jenkins
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: BP-99
+  uuid: 3ff81753-9fac-4fc4-aa99-37f1c61bd647
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Rainer
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: BP-100
+  uuid: 9ba9aa66-49ad-4240-8b69-3ee87eaec8ca
+  subjects:
+  - entities:
+    - role: player
+      name: Marconi German
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: BP-101
+  uuid: cfef789c-86b6-4eb2-9ae8-157439f1d289
+  subjects:
+  - entities:
+    - role: player
+      name: Kehden Hettiger
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: BP-102
+  uuid: f8784a96-059b-4b46-98f9-a5f61712a327
+  subjects:
+  - entities:
+    - role: player
+      name: Eric Hartman
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: BP-103
+  uuid: 28a38c0c-9080-4604-957d-aba85c5c3bb6
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Monistere
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: BP-104
+  uuid: ccb5e5e6-a5a6-4366-8eaf-19d9074dd610
+  subjects:
+  - entities:
+    - role: player
+      name: Henry Lalane
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: BP-105
+  uuid: 3b5234e5-92d2-4733-b44c-d7cad0447eae
+  subjects:
+  - entities:
+    - role: player
+      name: Kade Snell
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: BP-106
+  uuid: 8d6fca52-6d9a-4d82-94ff-a4c8c162da51
+  subjects:
+  - entities:
+    - role: player
+      name: Francisco Espinoza
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: BP-107
+  uuid: 17842516-f180-4013-93b1-d41913d543c4
+  subjects:
+  - entities:
+    - role: player
+      name: Miguel Mendez
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: BP-108
+  uuid: f3450df5-27d6-4f97-813f-27b3368b0650
+  subjects:
+  - entities:
+    - role: player
+      name: Colt Emerson
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: BP-109
+  uuid: 1a91aa7f-3efe-4e58-a080-00274b993f43
+  subjects:
+  - entities:
+    - role: player
+      name: Truitt Madonna
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: BP-110
+  uuid: fb059f31-c1b3-4b77-8413-2499820fc4fb
+  subjects:
+  - entities:
+    - role: player
+      name: Matthew Ferrara
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: BP-111
+  uuid: 8ab5785a-b8ed-4182-9d5f-3caae63fea12
+  subjects:
+  - entities:
+    - role: player
+      name: Carson Benge
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: BP-112
+  uuid: 17cb6af6-6e0d-4cd1-b578-31aab4b785b2
+  subjects:
+  - entities:
+    - role: player
+      name: Jamie Arnold
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: BP-113
+  uuid: 57da5c3f-f580-4e2d-806d-165087b8898c
+  subjects:
+  - entities:
+    - role: player
+      name: Josh Knoth
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: BP-114
+  uuid: 18887529-0368-47f2-9882-776a754f4810
+  subjects:
+  - entities:
+    - role: player
+      name: Argenis Cayama
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: BP-115
+  uuid: 226b4c3e-07d0-4c2a-b4af-fd70835d779f
+  subjects:
+  - entities:
+    - role: player
+      name: JJ Wetherholt
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: BP-116
+  uuid: 07efa84d-efe7-4f2b-83f0-88798410b975
+  subjects:
+  - entities:
+    - role: player
+      name: Dauri Fernandez
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: BP-117
+  uuid: 36be34fb-4b9c-4586-9290-0621ab4c250b
+  subjects:
+  - entities:
+    - role: player
+      name: Victor Figueroa
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: BP-118
+  uuid: 81f15ac4-bd0b-4e77-9c17-947006f53bac
+  subjects:
+  - entities:
+    - role: player
+      name: Gabriel Rodriguez
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: BP-119
+  uuid: a23ee46e-123c-4bb6-b746-ebb8ca71a33a
+  subjects:
+  - entities:
+    - role: player
+      name: Mathias Lacombe
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: BP-120
+  uuid: caa31e06-e39e-4975-b0ac-9b8cdb56be8a
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Peña
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: BP-121
+  uuid: d5cc45fb-5740-4080-a568-ee336d633fe1
+  subjects:
+  - entities:
+    - role: player
+      name: Keaton Anthony
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: BP-122
+  uuid: 15b15cbc-a969-4b61-87c2-6d623d60fe87
+  subjects:
+  - entities:
+    - role: player
+      name: Sam Petersen
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: BP-123
+  uuid: bda6b39f-4b8f-426e-809c-f100611d3348
+  subjects:
+  - entities:
+    - role: player
+      name: JR Ritchie
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: BP-124
+  uuid: 9a90b54d-dc5a-450f-b1d0-de1ea915e9ef
+  subjects:
+  - entities:
+    - role: player
+      name: Riley Nelson
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: BP-125
+  uuid: aed9c90a-aa8f-4be8-b7d8-31e914cf861f
+  subjects:
+  - entities:
+    - role: player
+      name: Wei-En Lin
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: BP-126
+  uuid: a1c5f877-6666-4cec-a199-b4c6319ba844
+  subjects:
+  - entities:
+    - role: player
+      name: Gavin Fien
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: BP-127
+  uuid: 10245204-6856-4cf8-bed9-2fa4f6228a08
+  subjects:
+  - entities:
+    - role: player
+      name: Seojun Moon
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: BP-128
+  uuid: e8e4f4bf-5608-4232-8974-f6fe16a1458d
+  subjects:
+  - entities:
+    - role: player
+      name: Hector Ramos
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: BP-129
+  uuid: 95886e8e-c69a-47c7-9c5f-801c5758cd23
+  subjects:
+  - entities:
+    - role: player
+      name: Seaver King
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: BP-130
+  uuid: e3e47f46-bd05-4d70-b1cc-27c30fb85829
+  subjects:
+  - entities:
+    - role: player
+      name: Kenly Hunter
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: BP-131
+  uuid: 071551da-0624-4153-88d6-77839dcbfe28
+  subjects:
+  - entities:
+    - role: player
+      name: Walker Janek
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: BP-132
+  uuid: ec031748-3a6b-4bc0-acb0-07a20a075006
+  subjects:
+  - entities:
+    - role: player
+      name: Keyner Martinez
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: BP-133
+  uuid: 1c6a181a-8f07-4dda-a379-c2b27180e3f7
+  subjects:
+  - entities:
+    - role: player
+      name: Xavier Neyens
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: BP-134
+  uuid: 58b64190-ba00-4a6a-8b08-eac8636e443e
+  subjects:
+  - entities:
+    - role: player
+      name: T.J. Rumfield
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: BP-135
+  uuid: 175444ad-64d3-4b12-a8e4-974d742c052f
+  subjects:
+  - entities:
+    - role: player
+      name: Wehiwa Aloy
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: BP-136
+  uuid: eb3ce3cd-ca75-4108-9d43-ea65a6ac930a
+  subjects:
+  - entities:
+    - role: player
+      name: Gavin Kilen
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: BP-137
+  uuid: ca5fb876-40ba-4c29-92fb-a9f18ae6ddfd
+  subjects:
+  - entities:
+    - role: player
+      name: Braden Nett
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: BP-138
+  uuid: 6f68d779-3d27-4829-ba00-95322c85a7df
+  subjects:
+  - entities:
+    - role: player
+      name: Patrick Copen
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: BP-139
+  uuid: 335ba3ce-31ce-4304-bacc-3e04ce7cd1b4
+  subjects:
+  - entities:
+    - role: player
+      name: Edgar Montero
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: BP-140
+  uuid: 9f4a7e5d-1330-431d-8b61-657d89a02d24
+  subjects:
+  - entities:
+    - role: player
+      name: Pedro Ibarguen
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: BP-141
+  uuid: 3eed9a59-3521-4bb5-abb8-0a5cae356bbb
+  subjects:
+  - entities:
+    - role: player
+      name: Justin Gonzales
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: BP-142
+  uuid: c5214d6e-2c33-46fa-b15d-9a10dacac017
+  subjects:
+  - entities:
+    - role: player
+      name: Brady Ebel
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: BP-143
+  uuid: 1807abc3-d029-45b4-8d3f-bab4866653b7
+  subjects:
+  - entities:
+    - role: player
+      name: Kaelen Culpepper
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: BP-144
+  uuid: 074afde9-9977-4874-8e48-fb675c93bc70
+  subjects:
+  - entities:
+    - role: player
+      name: Colby Shelton
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: BP-145
+  uuid: 91889dc9-3ce0-4ea9-add3-6c96564933d3
+  subjects:
+  - entities:
+    - role: player
+      name: Kevin McGonigle
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: BP-146
+  uuid: 053c42a2-a813-42ca-b12f-eb4c6d5b9add
+  subjects:
+  - entities:
+    - role: player
+      name: Matt Klein
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: BP-147
+  uuid: 91890d81-2d43-4f93-9ed8-6aca7ca707b0
+  subjects:
+  - entities:
+    - role: player
+      name: JoJo Parker
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: BP-148
+  uuid: cbddcac4-14ec-4653-85e2-69fdeff96c26
+  subjects:
+  - entities:
+    - role: player
+      name: Dillon Lewis
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: BP-149
+  uuid: 113ede74-7834-44a5-88ee-2a280c314798
+  subjects:
+  - entities:
+    - role: player
+      name: Andrew Fischer
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: BP-150
+  uuid: 8c1ad7ce-2e5e-43a9-b581-9b501a157f69
+  subjects:
+  - entities:
+    - role: player
+      name: Wilder Dalis
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 

--- a/data/baseball/2026-bowman/checklists/base-red-rc-variations.yaml
+++ b/data/baseball/2026-bowman/checklists/base-red-rc-variations.yaml
@@ -1,0 +1,400 @@
+- number: '3'
+  uuid: fd7a47e3-b483-4783-be5e-92fa729be3d2
+  subjects:
+  - entities:
+    - role: player
+      name: Chase Burns
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '6'
+  uuid: 2bf1bf68-0349-424c-8c16-843440f30c80
+  subjects:
+  - entities:
+    - role: player
+      name: Sal Stewart
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '9'
+  uuid: 473948e5-f86c-405d-b1dd-2585fc332fd0
+  subjects:
+  - entities:
+    - role: player
+      name: Munetaka Murakami
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: '12'
+  uuid: 81dd49bb-55e5-408f-bffc-87433a9b8127
+  subjects:
+  - entities:
+    - role: player
+      name: Jhostynxon Garcia
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '16'
+  uuid: 9d4bbee9-7543-439d-8adf-f38495d882e5
+  subjects:
+  - entities:
+    - role: player
+      name: Carson Whisenhunt
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '18'
+  uuid: 21e254fa-8923-41e9-9cd9-ec9e039c0d0d
+  subjects:
+  - entities:
+    - role: player
+      name: Roman Anthony
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '19'
+  uuid: 0e430407-1fa2-4f73-9ea9-659e35425e73
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Teel
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: '26'
+  uuid: db1c4715-b4bc-4458-8390-6c752d1a41b6
+  subjects:
+  - entities:
+    - role: player
+      name: Payton Tolle
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '28'
+  uuid: 723e59cb-7f03-4011-be9d-1184a0d5d883
+  subjects:
+  - entities:
+    - role: player
+      name: Kazuma Okamoto
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '33'
+  uuid: 5a45a2d3-c40b-40ac-bc27-ed3a1eafa893
+  subjects:
+  - entities:
+    - role: player
+      name: Brandon Sproat
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '35'
+  uuid: 3e5d7ec3-fa4d-491f-ae9e-850869cc019a
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Misiorowski
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: '36'
+  uuid: 9fd9ba8c-4265-4155-b6fa-8063a61cd48e
+  subjects:
+  - entities:
+    - role: player
+      name: Jimmy Crooks
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: '37'
+  uuid: 7ad7a3ec-f34f-466b-a061-b96d0794d869
+  subjects:
+  - entities:
+    - role: player
+      name: Chase DeLauter
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '39'
+  uuid: 7b9bd33e-7677-428b-8948-906b1c377548
+  subjects:
+  - entities:
+    - role: player
+      name: Carson Williams
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: '40'
+  uuid: a5c96aa6-5384-4c26-afe1-d17dcddb7c69
+  subjects:
+  - entities:
+    - role: player
+      name: Drew Gilbert
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '41'
+  uuid: bf111651-b7f4-4285-964d-c3e193438ff0
+  subjects:
+  - entities:
+    - role: player
+      name: Trey Yesavage
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '45'
+  uuid: e8644260-766b-4dbd-a449-f25d7d933fc8
+  subjects:
+  - entities:
+    - role: player
+      name: Connelly Early
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '49'
+  uuid: c091326c-066e-41c3-aa42-543900fe22da
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Morales
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: '53'
+  uuid: 8ef4bce9-b9d0-40dc-8fd0-9a064894c2f5
+  subjects:
+  - entities:
+    - role: player
+      name: Cam Schlittler
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '56'
+  uuid: 8e445eb9-44ba-4b23-be9e-d723ea6474d3
+  subjects:
+  - entities:
+    - role: player
+      name: Brice Matthews
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '58'
+  uuid: 959b99e7-d9e6-49d6-a0b4-1c947cd77c14
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Eldridge
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '62'
+  uuid: b2785919-efde-44f9-8e62-5cfb7f99fcce
+  subjects:
+  - entities:
+    - role: player
+      name: Owen Caissie
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '65'
+  uuid: 95f021b6-91e9-4848-8583-2d224f42a660
+  subjects:
+  - entities:
+    - role: player
+      name: Jonah Tong
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '66'
+  uuid: afd7cfe7-e402-40ae-8ccb-003d86ce996e
+  subjects:
+  - entities:
+    - role: player
+      name: Carter Jensen
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: '68'
+  uuid: 6b6e2860-bca5-4b1b-a775-c95c8cec5cac
+  subjects:
+  - entities:
+    - role: player
+      name: Colson Montgomery
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: '69'
+  uuid: 2d336307-dc6b-4d7f-b95f-dd280e0e9da2
+  subjects:
+  - entities:
+    - role: player
+      name: Dylan Beavers
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '70'
+  uuid: b106b390-a93e-4b56-962e-72c3248dfa52
+  subjects:
+  - entities:
+    - role: player
+      name: Alex Freeland
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '74'
+  uuid: d762b4d3-c4ee-405b-8aa4-74990e69ae43
+  subjects:
+  - entities:
+    - role: player
+      name: Tatsuya Imai
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '75'
+  uuid: b3e35782-5055-4b64-8308-0e707b1c9282
+  subjects:
+  - entities:
+    - role: player
+      name: Jac Caglianone
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: '78'
+  uuid: 834beb5c-bde9-4eb4-ae0a-5b504b09cc30
+  subjects:
+  - entities:
+    - role: player
+      name: Cole Young
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: '83'
+  uuid: 30f84423-ec94-47f3-a500-854fe5944275
+  subjects:
+  - entities:
+    - role: player
+      name: Bubba Chandler
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '84'
+  uuid: d6ee76d6-1d8f-4e26-ba90-0883e8805c1d
+  subjects:
+  - entities:
+    - role: player
+      name: Harry Ford
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: '85'
+  uuid: 2e477e6f-bbf9-4f27-b577-41c5447b81aa
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan McLean
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '86'
+  uuid: e277b10f-297f-4342-bb9f-1a89b6e8058b
+  subjects:
+  - entities:
+    - role: player
+      name: Jakob Marsee
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: '87'
+  uuid: e914e6cc-8bf8-4ed9-9f22-728ddf1615ca
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Melton
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: '91'
+  uuid: 1c6898f9-0255-4709-a9ae-f6b71c1e264f
+  subjects:
+  - entities:
+    - role: player
+      name: Yanquiel Fernández
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: '92'
+  uuid: fad85a90-2359-4570-9a76-8056015e1934
+  subjects:
+  - entities:
+    - role: player
+      name: Brady House
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: '93'
+  uuid: 8f3883c2-17e5-402f-9d38-30c75f84165a
+  subjects:
+  - entities:
+    - role: player
+      name: Samuel Basallo
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '98'
+  uuid: 7d84fc40-228d-420c-8e86-c6669b746c5f
+  subjects:
+  - entities:
+    - role: player
+      name: C.J. Kayfus
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '99'
+  uuid: 15c76c8b-0fa3-4693-8626-ccfa50c0872d
+  subjects:
+  - entities:
+    - role: player
+      name: Christian Moore
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 

--- a/data/baseball/2026-bowman/checklists/base-rookie-and-veteran-retail-autographs.yaml
+++ b/data/baseball/2026-bowman/checklists/base-rookie-and-veteran-retail-autographs.yaml
@@ -1,0 +1,350 @@
+- number: PRV-AF
+  uuid: 5156c1f3-82f2-4ab0-a7e3-f87639073cf1
+  subjects:
+  - entities:
+    - role: player
+      name: Alex Freeland
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: PRV-AR
+  uuid: de29cac4-33c7-40a0-95b2-1ceffa168c4f
+  subjects:
+  - entities:
+    - role: player
+      name: Adley Rutschman
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: PRV-AS
+  uuid: 464906b0-0e7b-456a-a3a5-3e5e366c917e
+  subjects:
+  - entities:
+    - role: player
+      name: AJ Smith-Shawver
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: PRV-BC
+  uuid: 377a6a17-d2ba-460e-87e9-0ea5c98cdb12
+  subjects:
+  - entities:
+    - role: player
+      name: Bubba Chandler
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: PRV-BE
+  uuid: e00e4a30-1e5a-474d-a0d9-f46efa569d49
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Eldridge
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: PRV-CC
+  uuid: 5ed83a41-a6c7-4cb9-b9ef-38b526ba37ab
+  subjects:
+  - entities:
+    - role: player
+      name: Corbin Carroll
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: PRV-CE
+  uuid: a51180b3-69ab-4922-bd9d-6306dd5c92c2
+  subjects:
+  - entities:
+    - role: player
+      name: Connelly Early
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: PRV-CF
+  uuid: c0ab4556-b85c-442c-8d69-7a358124bfa6
+  subjects:
+  - entities:
+    - role: player
+      name: Cody Freeman
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: PRV-CM
+  uuid: 0cebee29-3d9b-42cb-997f-8fbf58ed38c0
+  subjects:
+  - entities:
+    - role: player
+      name: Colson Montgomery
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: PRV-CS
+  uuid: 6c552982-1771-4165-a687-4cf39091d02f
+  subjects:
+  - entities:
+    - role: player
+      name: Cam Schlittler
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: PRV-CW
+  uuid: 043ea130-4e93-49ad-a4af-2df14f9821b8
+  subjects:
+  - entities:
+    - role: player
+      name: Carson Williams
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: PRV-DBE
+  uuid: 7f644551-28cf-4ef7-8d70-2853364d04e8
+  subjects:
+  - entities:
+    - role: player
+      name: David Bednar
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: PRV-DF
+  uuid: b7d068c3-8677-4273-9375-ab3f770bdad6
+  subjects:
+  - entities:
+    - role: player
+      name: Didier Fuentes
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: PRV-FT
+  uuid: 16ca842d-fd82-4ae5-bbb9-caa6ba971641
+  subjects:
+  - entities:
+    - role: player
+      name: Fernando Tatis Jr.
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: PRV-HF
+  uuid: 30e39084-b72c-4163-9a56-7c60cd27da96
+  subjects:
+  - entities:
+    - role: player
+      name: Harry Ford
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: PRV-HG
+  uuid: 95e5a6f7-98ef-482a-9c1c-f90246dbc29e
+  subjects:
+  - entities:
+    - role: player
+      name: Hunter Goodman
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: PRV-JC
+  uuid: eca10cfe-e5da-498b-8cd3-4a0c0c127824
+  subjects:
+  - entities:
+    - role: player
+      name: Jac Caglianone
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: PRV-JD
+  uuid: c26f9e07-81cf-402f-b9a0-38fa31584965
+  subjects:
+  - entities:
+    - role: player
+      name: Justin Dean
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: PRV-JM
+  uuid: d330a916-e371-41ec-b7c5-06634e9d50d3
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Misiorowski
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: PRV-JMA
+  uuid: 16dad648-46a1-408a-8805-8e80a3494635
+  subjects:
+  - entities:
+    - role: player
+      name: Jakob Marsee
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: PRV-KB
+  uuid: 2873fdd1-d625-4326-9693-49c23a601196
+  subjects:
+  - entities:
+    - role: player
+      name: Kris Bryant
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: PRV-KK
+  uuid: 81f0039f-a301-484c-a817-a3876e1008b3
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Karros
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: PRV-KT
+  uuid: b8cf761c-a1fc-47a8-a5cc-5c4c2da0e107
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Teel
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: PRV-MT
+  uuid: 054b6c22-7a0d-4559-a79a-dd660ae1cce2
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Trout
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: PRV-NK
+  uuid: b0be5737-cdfc-4991-a655-183cc9de9dad
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Kurtz
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: PRV-NL
+  uuid: 76a31961-63e3-4f77-82f8-6a01ec314889
+  subjects:
+  - entities:
+    - role: player
+      name: Nathan Lukes
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: PRV-NM
+  uuid: 8c6065b6-bf0b-480c-9d36-347869c932bd
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan McLean
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: PRV-PT
+  uuid: 61ea2fa3-955c-45b0-b8ad-8aaa057dde57
+  subjects:
+  - entities:
+    - role: player
+      name: Payton Tolle
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: PRV-RA
+  uuid: d9ee328c-0eee-4528-ade1-19e4e31aee6f
+  subjects:
+  - entities:
+    - role: player
+      name: Roman Anthony
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: PRV-RAC
+  uuid: 6f4678f7-bf9d-4392-a305-6259e0e93d92
+  subjects:
+  - entities:
+    - role: player
+      name: Ronald Acuña Jr.
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: PRV-SB
+  uuid: f9f12e2d-1ac7-42e3-a92b-3776a30a0b52
+  subjects:
+  - entities:
+    - role: player
+      name: Samuel Basallo
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: PRV-TY
+  uuid: 2529b822-ced1-4533-9aa1-7ff0d00795ab
+  subjects:
+  - entities:
+    - role: player
+      name: Trey Yesavage
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: PRV-VG
+  uuid: ad1d176e-5fad-4256-8212-a4f75b0e6f8b
+  subjects:
+  - entities:
+    - role: player
+      name: Vladimir Guerrero Jr.
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: PRV-WB
+  uuid: 7cb38abe-42ef-456d-8d2a-2ae89e373bb5
+  subjects:
+  - entities:
+    - role: player
+      name: Walker Buehler
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: PRV-WK
+  uuid: 3a979056-6fed-4b27-88b3-5f3693acc734
+  subjects:
+  - entities:
+    - role: player
+      name: Will Klein
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 

--- a/data/baseball/2026-bowman/checklists/base-set.yaml
+++ b/data/baseball/2026-bowman/checklists/base-set.yaml
@@ -1,0 +1,1040 @@
+- number: '1'
+  uuid: bda5d046-236d-4d09-97b2-77a77e47d1ea
+  subjects:
+  - entities:
+    - role: player
+      name: Aaron Judge
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '2'
+  uuid: d18e10bb-f3ab-4f73-8959-ce50aeefdbb8
+  subjects:
+  - entities:
+    - role: player
+      name: Yoshinobu Yamamoto
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '3'
+  uuid: 1f32611a-ff99-4d55-9d08-7a3f443e7f5d
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Chase Burns
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '4'
+  uuid: c5988a3b-9599-48a8-83f6-c85e1b1398ed
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Chourio
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: '5'
+  uuid: 83027e9c-e12b-4380-83c2-4db1cc91c879
+  subjects:
+  - entities:
+    - role: player
+      name: Julio Rodríguez
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: '6'
+  uuid: e3197010-ee77-475f-9240-5188859592aa
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Sal Stewart
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '7'
+  uuid: de3f1bbe-531f-4e1c-93bb-a54da2754342
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Harper
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: '8'
+  uuid: a11a027a-872e-496a-999d-c0cb8a87d11a
+  subjects:
+  - entities:
+    - role: player
+      name: Ernie Clement
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '9'
+  uuid: ef729c24-9750-41a8-adef-16c3dbca6c38
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Munetaka Murakami
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: '10'
+  uuid: ed6c0d26-6426-43e2-87cd-aa4dab924c84
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Kurtz
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: '11'
+  uuid: 4205b48b-cbcd-44f1-b347-9c8dc9bdd98e
+  subjects:
+  - entities:
+    - role: player
+      name: Corey Seager
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: '12'
+  uuid: e8a1eab6-af10-4e1c-a6fa-4397e0ae12eb
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Jhostynxon Garcia
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '13'
+  uuid: b44a4ee9-58af-4f61-8c96-62e605d17a9f
+  subjects:
+  - entities:
+    - role: player
+      name: Cal Raleigh
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: '14'
+  uuid: 909cf467-a374-4877-b63e-0bd08ae82e7d
+  subjects:
+  - entities:
+    - role: player
+      name: Drake Baldwin
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: '15'
+  uuid: 0ee6c545-02be-42c5-a906-88104c722e15
+  subjects:
+  - entities:
+    - role: player
+      name: Max Fried
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '16'
+  uuid: 4b0e433a-f21d-4b62-9ad5-120c7d784ce8
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Carson Whisenhunt
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '17'
+  uuid: db9773da-7ef3-4e92-b703-851e70284fbb
+  subjects:
+  - entities:
+    - role: player
+      name: Francisco Lindor
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '18'
+  uuid: 723f0a98-1444-4d98-8d5c-08dbcbb7783f
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Roman Anthony
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '19'
+  uuid: 06030c11-6d3f-49b6-923a-afe9f205b7a1
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Teel
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: '20'
+  uuid: 8f6d82da-7943-48bb-9205-b275bb4094cd
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Schwarber
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: '21'
+  uuid: d9613e4c-d0a7-4e3a-bd1a-72d9e884c321
+  subjects:
+  - entities:
+    - role: player
+      name: Michael Harris II
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: '22'
+  uuid: 383bc58a-46f4-45c2-8f09-078249e2d59f
+  subjects:
+  - entities:
+    - role: player
+      name: Andrew McCutchen
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '23'
+  uuid: 032adffb-4b81-4d75-b3c6-f67aa02cc241
+  subjects:
+  - entities:
+    - role: player
+      name: Ronald Acuña Jr.
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: '24'
+  uuid: 4a457a93-3dfe-44cf-880b-cdb0c95a8d74
+  subjects:
+  - entities:
+    - role: player
+      name: Will Smith
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '25'
+  uuid: 8c43f9ca-a1d3-4e43-a430-6ef5934563e9
+  subjects:
+  - entities:
+    - role: player
+      name: Bobby Witt Jr.
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: '26'
+  uuid: cab54eb5-b705-4074-811e-ed11a93a3b2f
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Payton Tolle
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '27'
+  uuid: 02d858dd-1f68-46bd-947c-6e8733f3672f
+  subjects:
+  - entities:
+    - role: player
+      name: Bo Bichette
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '28'
+  uuid: 2c47d5e1-9d14-4b1d-9529-115787ffd24a
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Kazuma Okamoto
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '29'
+  uuid: 9ceaa83d-8135-44df-91ce-9d71f9276fe0
+  subjects:
+  - entities:
+    - role: player
+      name: Geraldo Perdomo
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: '30'
+  uuid: 22c7cbd2-7c2b-4522-8c7c-d0a3f6a5ccaa
+  subjects:
+  - entities:
+    - role: player
+      name: Brice Turang
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: '31'
+  uuid: f1c20947-4f6a-4747-8006-f20d560c2353
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Crow-Armstrong
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '32'
+  uuid: c8f7a818-c4ee-4489-8b58-ce22008e2280
+  subjects:
+  - entities:
+    - role: player
+      name: Ketel Marte
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: '33'
+  uuid: 670dc478-7017-4541-8f3c-1020c763fd7f
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Brandon Sproat
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '34'
+  uuid: d9846c7b-bd71-4ab5-b064-b7053857b282
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Stowers
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: '35'
+  uuid: 7a3c57e0-bcb3-48a6-8964-d7008e232943
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Misiorowski
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: '36'
+  uuid: bac841ab-c52c-42ff-a11b-34246371e482
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Jimmy Crooks
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: '37'
+  uuid: 263d34b5-fc28-4774-affd-31b67ed467b3
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Chase DeLauter
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '38'
+  uuid: 55cc143e-4599-499e-b6d1-1977b81f3add
+  subjects:
+  - entities:
+    - role: player
+      name: Matt Olson
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: '39'
+  uuid: 51d362bc-bf8d-4b8c-ba43-90d55218aae3
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Carson Williams
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: '40'
+  uuid: 58d5a1bd-a06c-44c8-a811-1fdbb709f6d6
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Drew Gilbert
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '41'
+  uuid: d4ddd9b9-4f65-4c5e-9a84-21b19be3c55c
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Trey Yesavage
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '42'
+  uuid: 49f96afa-7132-4139-a8bc-6e136720e1ec
+  subjects:
+  - entities:
+    - role: player
+      name: Zach Neto
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: '43'
+  uuid: e01475cb-7d15-4c06-89f0-2a1f81954ed1
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Holliday
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '44'
+  uuid: f20b784a-fb76-48da-a3f6-c0fbfb7343d5
+  subjects:
+  - entities:
+    - role: player
+      name: Elly De La Cruz
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '45'
+  uuid: 47ecfd50-3681-4c4c-b634-890035f44d14
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Connelly Early
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '46'
+  uuid: 4361d54d-23db-4262-a3fd-5cca52b416c8
+  subjects:
+  - entities:
+    - role: player
+      name: Freddie Freeman
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '47'
+  uuid: '018512a8-1eb5-41af-87ad-79fc9136bef5'
+  subjects:
+  - entities:
+    - role: player
+      name: Fernando Tatis Jr.
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: '48'
+  uuid: e69cf749-91b7-4b1b-a955-98d753d6515f
+  subjects:
+  - entities:
+    - role: player
+      name: Riley Greene
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '49'
+  uuid: 448302db-8d5f-46e8-bd74-840bc96cd0c4
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Morales
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: '50'
+  uuid: 19741a5c-5f28-4eb1-a4a1-8b1063131aa4
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Merrill
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: '51'
+  uuid: a7661882-917a-452b-a37e-10f715366b28
+  subjects:
+  - entities:
+    - role: player
+      name: Garrett Crochet
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '52'
+  uuid: 9edbef51-a8c6-46ae-9d92-407402e90b75
+  subjects:
+  - entities:
+    - role: player
+      name: Shohei Ohtani
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '53'
+  uuid: 5652c6f2-77c6-4d9b-8bf1-4602aeac5670
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Cam Schlittler
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '54'
+  uuid: 3e5b8060-2737-4bcd-b8a7-ce13107e0197
+  subjects:
+  - entities:
+    - role: player
+      name: Dylan Crews
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: '55'
+  uuid: 0c055bdf-ceda-4dbd-bcdb-fb072cf2ce49
+  subjects:
+  - entities:
+    - role: player
+      name: Cristopher Sánchez
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: '56'
+  uuid: e26ded3f-8dab-493e-926d-290ba745890a
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Brice Matthews
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '57'
+  uuid: 15de6316-0055-43f0-84a0-07ce981f305b
+  subjects:
+  - entities:
+    - role: player
+      name: Luke Keaschall
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: '58'
+  uuid: 48ede7bb-9448-45bb-a65d-108fe29d6be6
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Eldridge
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '59'
+  uuid: ece17eee-d94d-416e-b7a8-ef6c0479c0b0
+  subjects:
+  - entities:
+    - role: player
+      name: Junior Caminero
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: '60'
+  uuid: 8202c151-6b45-496b-b04e-0e2db118f584
+  subjects:
+  - entities:
+    - role: player
+      name: Manny Machado
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: '61'
+  uuid: 70304dea-e1f1-486b-8f05-e87910267888
+  subjects:
+  - entities:
+    - role: player
+      name: Vladimir Guerrero Jr.
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '62'
+  uuid: f1d14ac3-6858-4ed6-b700-9e7eab95893b
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Owen Caissie
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '63'
+  uuid: 30d0ca88-0a2b-47c0-8fa8-792c2e1771ea
+  subjects:
+  - entities:
+    - role: player
+      name: Roki Sasaki
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '64'
+  uuid: 1c0c7737-8dc6-4643-a5e9-6bc7c7cffe35
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob deGrom
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: '65'
+  uuid: 2951cd55-db58-423a-940c-d66ba2d6bb24
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Jonah Tong
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '66'
+  uuid: 4fb8bd67-d17f-4f1c-b792-8abed8bbd710
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Carter Jensen
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: '67'
+  uuid: 31abe0b2-709c-433a-aa05-c341afd47431
+  subjects:
+  - entities:
+    - role: player
+      name: Yordan Alvarez
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '68'
+  uuid: cfb2530c-3cd1-49eb-aa4f-acd97a950336
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Colson Montgomery
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: '69'
+  uuid: c9dda347-0788-4c43-9e7e-b355528c6d8b
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Dylan Beavers
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '70'
+  uuid: a7e7946e-c1a9-40a9-af5f-10bb0400bde0
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Alex Freeland
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '71'
+  uuid: 508531e6-6ccc-4c00-bb48-22d5d24fa377
+  subjects:
+  - entities:
+    - role: player
+      name: Trea Turner
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: '72'
+  uuid: 1baa3037-f159-43e5-83dd-1c8cec84b3e5
+  subjects:
+  - entities:
+    - role: player
+      name: Masyn Winn
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: '73'
+  uuid: 34ad040e-01ec-4c67-80ca-c12aadc4d315
+  subjects:
+  - entities:
+    - role: player
+      name: Gunnar Henderson
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '74'
+  uuid: 3f1d3121-abf4-4780-a0a4-585ea5d90586
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Tatsuya Imai
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '75'
+  uuid: f4f7a1e1-a646-46f9-bdc8-2652f922283b
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Jac Caglianone
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: '76'
+  uuid: 1ba4b64e-346a-48c1-95d0-b58cc3ad112d
+  subjects:
+  - entities:
+    - role: player
+      name: Tarik Skubal
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '77'
+  uuid: eba1fc86-9fe5-43f2-be84-299ea87d5679
+  subjects:
+  - entities:
+    - role: player
+      name: José Ramírez
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '78'
+  uuid: 8237d839-5a16-4c51-a5f5-d29f34c62c99
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Cole Young
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: '79'
+  uuid: 509dd34f-efc8-4d30-a522-00f68ca62c51
+  subjects:
+  - entities:
+    - role: player
+      name: James Wood
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: '80'
+  uuid: 57bbd8eb-3af1-4d48-8a39-f8f8acf2302a
+  subjects:
+  - entities:
+    - role: player
+      name: Corbin Carroll
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: '81'
+  uuid: 9fb886c9-e6c8-4b9d-8489-4566cc58cfae
+  subjects:
+  - entities:
+    - role: player
+      name: Mookie Betts
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '82'
+  uuid: e1490a0f-4b8d-443b-9ce7-67a01d8ba833
+  subjects:
+  - entities:
+    - role: player
+      name: Hunter Goodman
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: '83'
+  uuid: c978746f-5a2c-46d4-8585-d6d1ec0c4a1a
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Bubba Chandler
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '84'
+  uuid: 516ed0ac-5cbc-4a66-8516-38c6fad3ebdb
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Harry Ford
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: '85'
+  uuid: d3993666-3bbf-466c-b3de-e9fa3a5fb10c
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan McLean
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '86'
+  uuid: 51401125-bde4-4fab-abf9-71bb160922a2
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Jakob Marsee
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: '87'
+  uuid: 0064c6b8-a840-4ab2-9912-96bce00f9e16
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Melton
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: '88'
+  uuid: b8e5ced7-a39b-433f-bade-a7e59e2691fc
+  subjects:
+  - entities:
+    - role: player
+      name: Wyatt Langford
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: '89'
+  uuid: 2a9d331e-0eb8-4853-b41d-4482458afbb6
+  subjects:
+  - entities:
+    - role: player
+      name: Rafael Devers
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '90'
+  uuid: ccaadcb9-617c-4d5a-a934-429e1b05d53d
+  subjects:
+  - entities:
+    - role: player
+      name: Marcelo Mayer
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '91'
+  uuid: e2a8a133-1ca0-457a-b409-8be99c761189
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Yanquiel Fernández
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: '92'
+  uuid: eed06a02-2522-43fd-806a-e9de9807fcc4
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Brady House
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: '93'
+  uuid: f408085f-32e0-40fd-b8d3-456fd385e4ba
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Samuel Basallo
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '94'
+  uuid: 31b8a3ea-b706-4bcd-befe-c7a790e1f46e
+  subjects:
+  - entities:
+    - role: player
+      name: Byron Buxton
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: '95'
+  uuid: 348a7424-5345-4cab-b141-25c3f699dcaa
+  subjects:
+  - entities:
+    - role: player
+      name: George Springer
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '96'
+  uuid: ffdf9b70-3bde-453b-841c-ea4c80192ba5
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Wilson
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: '97'
+  uuid: 3e6ea74d-a8e0-4faf-904a-ba8c40b98c88
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '98'
+  uuid: e8caa3d0-7c1d-4d41-8e1f-a995c149c4f7
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: C.J. Kayfus
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '99'
+  uuid: e1107754-8e95-41d3-813e-65f54e052f46
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Christian Moore
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: '100'
+  uuid: 4bd8e93b-bddb-4b1e-ac28-59361049a575
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Trout
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 

--- a/data/baseball/2026-bowman/checklists/bowman-scouts-top-100.yaml
+++ b/data/baseball/2026-bowman/checklists/bowman-scouts-top-100.yaml
@@ -1,0 +1,1000 @@
+- number: BTP-1
+  uuid: 647300ab-e6fb-4e1e-9c18-5e869bad797b
+  subjects:
+  - entities:
+    - role: player
+      name: Konnor Griffin
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: BTP-2
+  uuid: 31e38e43-e43b-465d-a4ad-48a4c9f4767c
+  subjects:
+  - entities:
+    - role: player
+      name: Kevin McGonigle
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: BTP-3
+  uuid: 5141260a-0cd4-4a07-866d-ae2a4105774c
+  subjects:
+  - entities:
+    - role: player
+      name: Leo De Vries
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: BTP-4
+  uuid: 8baf788f-3843-4a86-87a9-bed082a60866
+  subjects:
+  - entities:
+    - role: player
+      name: Jesús Made
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: BTP-5
+  uuid: 6da5053e-6974-4792-b303-0e73b09cf9f9
+  subjects:
+  - entities:
+    - role: player
+      name: JJ Wetherholt
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: BTP-6
+  uuid: 1d2a4744-e066-4660-8c14-b5acbec1fbf1
+  subjects:
+  - entities:
+    - role: player
+      name: Sebastian Walcott
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: BTP-7
+  uuid: 0f2f090a-7050-44a2-9a4a-94f8752c1d09
+  subjects:
+  - entities:
+    - role: player
+      name: Max Clark
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: BTP-8
+  uuid: 985a5ed5-52e6-454b-b5d9-f48f9526b22b
+  subjects:
+  - entities:
+    - role: player
+      name: Walker Jenkins
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: BTP-9
+  uuid: a4278e33-8a69-47d3-9833-ca46c0fa8808
+  subjects:
+  - entities:
+    - role: player
+      name: Josue De Paula
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: BTP-10
+  uuid: 61a22e37-1bab-4ab6-8d30-99fc705d8b63
+  subjects:
+  - entities:
+    - role: player
+      name: Ethan Holliday
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: BTP-11
+  uuid: 52106606-542b-4476-94f9-b67b4ba5f5c7
+  subjects:
+  - entities:
+    - role: player
+      name: Eli Willits
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: BTP-12
+  uuid: 7f974323-3659-4ac3-9d79-ab1aeec7a8ff
+  subjects:
+  - entities:
+    - role: player
+      name: Colt Emerson
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: BTP-13
+  uuid: ef23e3b2-1acb-4100-8c8a-4d8243cf86db
+  subjects:
+  - entities:
+    - role: player
+      name: Travis Bazzana
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: BTP-14
+  uuid: 6ffc209a-d3fa-44d3-ba6e-9d1a50ea090a
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Peña
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: BTP-15
+  uuid: 9ec5ca1b-7e7c-4a02-9538-bfc0421ab828
+  subjects:
+  - entities:
+    - role: player
+      name: Zyhir Hope
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: BTP-16
+  uuid: 331c6b92-98fb-47d7-be8d-76e4f72976ab
+  subjects:
+  - entities:
+    - role: player
+      name: Andrew Painter
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: BTP-17
+  uuid: 1c353891-8732-4544-a942-c453474f5ae5
+  subjects:
+  - entities:
+    - role: player
+      name: George Lombard Jr.
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: BTP-18
+  uuid: a365a284-f8c0-4d9b-beee-4074fdaa95db
+  subjects:
+  - entities:
+    - role: player
+      name: Aiva Arquette
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: BTP-19
+  uuid: e0bcafdc-334e-40cb-bb66-6c87fb662005
+  subjects:
+  - entities:
+    - role: player
+      name: Thomas White
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: BTP-20
+  uuid: 256c2875-30ce-49bb-a481-91d0723fff46
+  subjects:
+  - entities:
+    - role: player
+      name: Carson Benge
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: BTP-21
+  uuid: a6119a9d-2520-4392-8bd4-21777e4e7c25
+  subjects:
+  - entities:
+    - role: player
+      name: Kade Anderson
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: BTP-22
+  uuid: 02c60b22-3311-4837-9cfb-96d8b0cad92e
+  subjects:
+  - entities:
+    - role: player
+      name: Seth Hernandez
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: BTP-23
+  uuid: 6629b3e6-d5f9-414c-bb6f-1ff7f494f905
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Rainer
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: BTP-24
+  uuid: 399612c8-8c2a-4353-94fd-d20cb720ab94
+  subjects:
+  - entities:
+    - role: player
+      name: Aidan Miller
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: BTP-25
+  uuid: 8e5ae0dd-68c6-4e08-aa1f-58759b079b5e
+  subjects:
+  - entities:
+    - role: player
+      name: Edward Florentino
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: BTP-26
+  uuid: b0fdb2b1-4cca-4f0f-a8cd-555a3a8825af
+  subjects:
+  - entities:
+    - role: player
+      name: Franklin Arias
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: BTP-27
+  uuid: 5b7f74ce-80fe-4aa1-b168-0a8fd354cf2d
+  subjects:
+  - entities:
+    - role: player
+      name: Josuar Gonzalez
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: BTP-28
+  uuid: b0cf9c11-ab66-46d7-814d-ae30bef973e3
+  subjects:
+  - entities:
+    - role: player
+      name: Lazaro Montes
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: BTP-29
+  uuid: 9171a08e-4506-4eb1-92cd-76dabcb4d912
+  subjects:
+  - entities:
+    - role: player
+      name: Josue Briceño
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: BTP-30
+  uuid: cfce277d-3dd9-467c-b79a-f8a9e4e36865
+  subjects:
+  - entities:
+    - role: player
+      name: Liam Doyle
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: BTP-31
+  uuid: 558faf02-bcbb-447f-b34c-1e2578814ad1
+  subjects:
+  - entities:
+    - role: player
+      name: Jamie Arnold
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: BTP-32
+  uuid: d85c6d6b-c5e1-4d0d-977a-74cfdb8ab58c
+  subjects:
+  - entities:
+    - role: player
+      name: Arjun Nimmala
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: BTP-33
+  uuid: 1fcb2e96-c0e0-4beb-8ba7-ad8d27d8fa9c
+  subjects:
+  - entities:
+    - role: player
+      name: Wehiwa Aloy
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: BTP-34
+  uuid: 402c9112-9322-4096-8d64-1c2e0fd997ad
+  subjects:
+  - entities:
+    - role: player
+      name: Eduardo Quintero
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: BTP-35
+  uuid: baf8a8c8-2b7c-4d3d-855c-105b6b463c21
+  subjects:
+  - entities:
+    - role: player
+      name: JoJo Parker
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: BTP-36
+  uuid: 26b305c3-fdf4-4067-8a43-727e3bc03380
+  subjects:
+  - entities:
+    - role: player
+      name: Charlie Condon
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: BTP-37
+  uuid: 03be02eb-a7e8-40a5-99e3-95185512dbe6
+  subjects:
+  - entities:
+    - role: player
+      name: Elian Peña
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: BTP-38
+  uuid: 6486cf72-8692-4e60-8f09-ea8ed5410d7a
+  subjects:
+  - entities:
+    - role: player
+      name: Rainiel Rodriguez
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: BTP-39
+  uuid: 23d4c16e-8daf-450c-9bc0-26c39a8f258f
+  subjects:
+  - entities:
+    - role: player
+      name: Braden Montgomery
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: BTP-40
+  uuid: 7411b5ee-5d07-4619-b61e-1d9f0f29d11f
+  subjects:
+  - entities:
+    - role: player
+      name: Cooper Pratt
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: BTP-41
+  uuid: 5eed74ae-87a4-43c7-b642-b0d6874951c9
+  subjects:
+  - entities:
+    - role: player
+      name: Kaelen Culpepper
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: BTP-42
+  uuid: b74978d6-250b-4327-a49f-bc0241ea27f7
+  subjects:
+  - entities:
+    - role: player
+      name: Robby Snelling
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: BTP-43
+  uuid: 34451f92-f8b5-465d-be3b-aa3e3d92baa1
+  subjects:
+  - entities:
+    - role: player
+      name: Justin Crawford
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: BTP-44
+  uuid: 3267b494-33d1-4af8-8f4a-e16106011675
+  subjects:
+  - entities:
+    - role: player
+      name: Eduardo Tait
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: BTP-45
+  uuid: 1f881f1f-8cd7-431e-b17c-109ceaa98ffe
+  subjects:
+  - entities:
+    - role: player
+      name: Billy Carlson
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: BTP-46
+  uuid: ca3dc8a2-42f8-4c93-8fda-b8d4ecf62d60
+  subjects:
+  - entities:
+    - role: player
+      name: Caleb Bonemer
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: BTP-47
+  uuid: 4a3bef6a-c809-4f5f-a206-cc6ac7970346
+  subjects:
+  - entities:
+    - role: player
+      name: Daniel Pierce
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: BTP-48
+  uuid: ccc2be8c-8af0-4014-844b-47a4c430a04a
+  subjects:
+  - entities:
+    - role: player
+      name: Jonny Farmelo
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: BTP-49
+  uuid: f4dbd763-039d-4b95-9191-9afe522bb1da
+  subjects:
+  - entities:
+    - role: player
+      name: Noah Schultz
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: BTP-50
+  uuid: 95b97af2-9d3c-4d89-9dee-d83bbaaf4576
+  subjects:
+  - entities:
+    - role: player
+      name: Xavier Neyens
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: BTP-51
+  uuid: bdfdef8d-d1f6-4965-8ce0-10fdc58f24df
+  subjects:
+  - entities:
+    - role: player
+      name: Alfredo Duno
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: BTP-52
+  uuid: b9cafd7f-42d2-4b97-a400-76365dfe1b12
+  subjects:
+  - entities:
+    - role: player
+      name: Nate George
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: BTP-53
+  uuid: beaba6d4-0a64-4ed7-9170-18a9be724c78
+  subjects:
+  - entities:
+    - role: player
+      name: Marek Houston
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: BTP-54
+  uuid: b731c2ea-5be6-4c24-bda2-96f4bdb45cf4
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Sirota
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: BTP-55
+  uuid: ee8d80ec-a8b7-44b3-948d-a5563e2f9b3c
+  subjects:
+  - entities:
+    - role: player
+      name: Ryan Waldschmidt
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: BTP-56
+  uuid: c65e2b6f-7558-4b8d-9c54-bd54e4303ce7
+  subjects:
+  - entities:
+    - role: player
+      name: Blake Mitchell
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: BTP-57
+  uuid: bebc0e98-33fb-4c41-8c96-89da02b5bfb9
+  subjects:
+  - entities:
+    - role: player
+      name: Ryan Sloan
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: BTP-58
+  uuid: 82a47712-7af5-4485-bde7-8d42467e18de
+  subjects:
+  - entities:
+    - role: player
+      name: Angel Genao
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: BTP-59
+  uuid: 1bd0e717-9b69-4e2a-b5ac-00584ac2b708
+  subjects:
+  - entities:
+    - role: player
+      name: Steele Hall
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: BTP-60
+  uuid: ccded6fc-4c9a-4612-833f-9742d403210d
+  subjects:
+  - entities:
+    - role: player
+      name: Gavin Kilen
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: BTP-61
+  uuid: b3d18b2b-98c3-4f4d-889e-f1c047bb8faa
+  subjects:
+  - entities:
+    - role: player
+      name: Emil Morales
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: BTP-62
+  uuid: a29e59a0-0d9f-4508-8f8c-f76fc6d519f0
+  subjects:
+  - entities:
+    - role: player
+      name: Travis Sykora
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: BTP-63
+  uuid: c189a727-721e-4e95-9110-7978e5f67b98
+  subjects:
+  - entities:
+    - role: player
+      name: Kyson Witherspoon
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: BTP-64
+  uuid: daeaec82-ca5a-4e4b-a4c5-910915af7d26
+  subjects:
+  - entities:
+    - role: player
+      name: Michael Arroyo
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: BTP-65
+  uuid: 1da00750-c22b-46dd-b381-f6cede58d6d8
+  subjects:
+  - entities:
+    - role: player
+      name: Gavin Fien
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: BTP-66
+  uuid: 1e3717d2-3426-4757-a7c3-a8bd34dc2f53
+  subjects:
+  - entities:
+    - role: player
+      name: Tyler Bremner
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: BTP-67
+  uuid: 4f1b8b8c-4310-4e2a-a59c-cf06a35b3b4f
+  subjects:
+  - entities:
+    - role: player
+      name: Cam Caminiti
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: BTP-68
+  uuid: d6c35763-1fe8-4c7a-8f1c-de65f68d4ed2
+  subjects:
+  - entities:
+    - role: player
+      name: Tyson Lewis
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: BTP-69
+  uuid: b152b6f1-c27e-4aac-ad71-0a401b7bff40
+  subjects:
+  - entities:
+    - role: player
+      name: Theo Gillen
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: BTP-70
+  uuid: 0dd97d0a-4f41-4f2b-a712-fce7e2002309
+  subjects:
+  - entities:
+    - role: player
+      name: Hagen Smith
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: BTP-71
+  uuid: 0c4f78db-f4be-4941-a76c-2a0816996e58
+  subjects:
+  - entities:
+    - role: player
+      name: Andrew Fischer
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: BTP-72
+  uuid: 24dd0906-46c6-4c8a-90e3-f615ca364470
+  subjects:
+  - entities:
+    - role: player
+      name: Jaxon Wiggins
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: BTP-73
+  uuid: d82dcff8-0703-4113-8097-65d3f5534fb5
+  subjects:
+  - entities:
+    - role: player
+      name: JR Ritchie
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: BTP-74
+  uuid: 56e3367f-929c-4f12-b4c2-d924d389f1b0
+  subjects:
+  - entities:
+    - role: player
+      name: Jarlin Susana
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: BTP-75
+  uuid: ec3a11cc-3fc2-4823-badb-a179fe477cda
+  subjects:
+  - entities:
+    - role: player
+      name: Shotaro Morii
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: BTP-76
+  uuid: 2b3b83c4-8a1b-4045-872e-55a9e0b19c5c
+  subjects:
+  - entities:
+    - role: player
+      name: Jhonny Level
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: BTP-77
+  uuid: 0e31a4f6-22d7-4bac-8301-c79a89318c3a
+  subjects:
+  - entities:
+    - role: player
+      name: Felnin Celesten
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: BTP-78
+  uuid: ec5fba9f-30c9-4722-a488-7213b71d2fcd
+  subjects:
+  - entities:
+    - role: player
+      name: Dax Kilby
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: BTP-79
+  uuid: a9c21f04-0aee-48e6-b540-e0c60d87d5c1
+  subjects:
+  - entities:
+    - role: player
+      name: Kayson Cunningham
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: BTP-80
+  uuid: 8ab18d05-de44-4a7f-b45c-a47d537955f5
+  subjects:
+  - entities:
+    - role: player
+      name: Bo Davidson
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: BTP-81
+  uuid: 9c6def5e-7679-437d-943f-ad38c94850e3
+  subjects:
+  - entities:
+    - role: player
+      name: Slade Caldwell
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: BTP-82
+  uuid: b9c502ce-4c27-404e-8bfe-2b9681647087
+  subjects:
+  - entities:
+    - role: player
+      name: Andrew Salas
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: BTP-83
+  uuid: bbc07603-4d86-413a-af1c-98b25f011ca3
+  subjects:
+  - entities:
+    - role: player
+      name: Spencer Jones
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: BTP-84
+  uuid: b64025c8-dd21-4a00-ab27-d6e6988ffa19
+  subjects:
+  - entities:
+    - role: player
+      name: Ike Irish
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: BTP-85
+  uuid: 924e312c-7c85-4e5b-b02d-efe7030c0959
+  subjects:
+  - entities:
+    - role: player
+      name: Cris Rodriguez
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: BTP-86
+  uuid: c6e1cf6a-f3c0-47e6-ad22-78a8accf84ec
+  subjects:
+  - entities:
+    - role: player
+      name: Roldy Brito
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: BTP-87
+  uuid: 220dbd81-f4b5-4a3a-8501-d00596ee39f6
+  subjects:
+  - entities:
+    - role: player
+      name: Carlos Lagrange
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: BTP-88
+  uuid: 81986e21-1f8e-4d7c-91d6-dbd7d64817a5
+  subjects:
+  - entities:
+    - role: player
+      name: Robert Calaz
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: BTP-89
+  uuid: cdc02069-e380-4684-a4e8-e85570b43921
+  subjects:
+  - entities:
+    - role: player
+      name: Gage Jump
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: BTP-90
+  uuid: 19471392-7054-4d0a-95f8-0b8358a48417
+  subjects:
+  - entities:
+    - role: player
+      name: Ching-Hsien Ko
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: BTP-91
+  uuid: 501134b7-4b3d-45b0-b4d5-bab975e2a7e8
+  subjects:
+  - entities:
+    - role: player
+      name: Dakota Jordan
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: BTP-92
+  uuid: a5f7f5f4-e7fa-40b0-b127-a457605a7ea6
+  subjects:
+  - entities:
+    - role: player
+      name: Tommy Troy
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: BTP-93
+  uuid: a44c6d01-3d96-451d-9e43-7736c26c26cc
+  subjects:
+  - entities:
+    - role: player
+      name: Wei-En Lin
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: BTP-94
+  uuid: aa30d590-8eef-4715-91a4-3e15f91ef020
+  subjects:
+  - entities:
+    - role: player
+      name: Kellon Lindsey
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: BTP-95
+  uuid: 554c39bc-cec0-44a4-82d4-270e8422603f
+  subjects:
+  - entities:
+    - role: player
+      name: Cam Collier
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: BTP-96
+  uuid: 6ecd4cdd-b9ee-4bf1-867e-df753abf7862
+  subjects:
+  - entities:
+    - role: player
+      name: Esteban Mejia
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: BTP-97
+  uuid: 2c979430-fcab-481e-ba1b-0769e9dae8e4
+  subjects:
+  - entities:
+    - role: player
+      name: Leonardo Bernal
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: BTP-98
+  uuid: 826e9358-ff64-42f5-af44-648b4ade0572
+  subjects:
+  - entities:
+    - role: player
+      name: Elmer Rodriguez-Cruz
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: BTP-99
+  uuid: '08226d34-3e46-46ac-886e-4371f09aa4a2'
+  subjects:
+  - entities:
+    - role: player
+      name: Enrique Bradfield Jr.
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: BTP-100
+  uuid: e102b424-fdea-489d-8eba-2cbcce98bbcc
+  subjects:
+  - entities:
+    - role: player
+      name: Gage Wood
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 

--- a/data/baseball/2026-bowman/checklists/bowman-spotlights.yaml
+++ b/data/baseball/2026-bowman/checklists/bowman-spotlights.yaml
@@ -1,0 +1,150 @@
+- number: BS-1
+  uuid: ac469c35-0993-4eed-b558-75b0e41c556c
+  subjects:
+  - entities:
+    - role: player
+      name: Colson Montgomery
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: BS-2
+  uuid: b23bdebd-9e58-4875-af67-7aa4b5e844aa
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan McLean
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: BS-3
+  uuid: 95fa778f-934f-4648-b16c-a30b7c4003f9
+  subjects:
+  - entities:
+    - role: player
+      name: Samuel Basallo
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: BS-4
+  uuid: 84ec5149-6fd6-4707-bc2b-e7a69d4e304f
+  subjects:
+  - entities:
+    - role: player
+      name: Jac Caglianone
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: BS-5
+  uuid: d7442444-08d6-4e14-a3e4-a90a0a25b2b0
+  subjects:
+  - entities:
+    - role: player
+      name: Cam Schlittler
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: BS-6
+  uuid: 15003b7b-915c-4b00-a314-39ec5a0d6a1a
+  subjects:
+  - entities:
+    - role: player
+      name: Roman Anthony
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: BS-7
+  uuid: fc85cfd6-cc79-45d9-99aa-fbd135eee87d
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Eldridge
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: BS-8
+  uuid: 63261490-6f5e-405e-b8e8-f36d4b73d9de
+  subjects:
+  - entities:
+    - role: player
+      name: Chase Burns
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: BS-9
+  uuid: 2e077bcd-b74d-4925-982e-18db08215763
+  subjects:
+  - entities:
+    - role: player
+      name: Aiva Arquette
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: BS-10
+  uuid: b3042b4b-19a3-49e9-9496-385bb4fc72ff
+  subjects:
+  - entities:
+    - role: player
+      name: Edward Florentino
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: BS-11
+  uuid: bc541fa2-8382-4ad4-a091-5057bfcdaa09
+  subjects:
+  - entities:
+    - role: player
+      name: Wehiwa Aloy
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: BS-12
+  uuid: 7a4d0386-e47b-464e-8132-958d5ab98233
+  subjects:
+  - entities:
+    - role: player
+      name: Bubba Chandler
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: BS-13
+  uuid: 368f12cf-8427-48e4-9b8e-cf7db0b59379
+  subjects:
+  - entities:
+    - role: player
+      name: Ethan Holliday
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: BS-14
+  uuid: a2544a54-1483-428c-b963-ee7f29a9ef4c
+  subjects:
+  - entities:
+    - role: player
+      name: Trey Yesavage
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: BS-15
+  uuid: e6c6dc12-861e-484e-8423-986b99294040
+  subjects:
+  - entities:
+    - role: player
+      name: Christian Moore
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 

--- a/data/baseball/2026-bowman/checklists/bowman-sterling-autographs.yaml
+++ b/data/baseball/2026-bowman/checklists/bowman-sterling-autographs.yaml
@@ -1,0 +1,100 @@
+- number: BSA-1
+  uuid: 4802b6db-11f2-4d40-86d3-f56a113999f2
+  subjects:
+  - entities:
+    - role: player
+      name: Max Clark
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: BSA-2
+  uuid: a791102a-767b-49ae-99af-258df8a28f88
+  subjects:
+  - entities:
+    - role: player
+      name: Julio Rodríguez
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: BSA-3
+  uuid: b4b67b4c-26c1-4847-9077-159000f296a1
+  subjects:
+  - entities:
+    - role: player
+      name: Konnor Griffin
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: BSA-4
+  uuid: e9e1e9df-171d-4db3-bca8-3d17852cc578
+  subjects:
+  - entities:
+    - role: player
+      name: Freddie Freeman
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: BSA-5
+  uuid: 9de6dfa4-fd92-476c-a62a-7a48fb5cdec9
+  subjects:
+  - entities:
+    - role: player
+      name: Leo De Vries
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: BSA-6
+  uuid: 211bf2b0-c240-4589-9596-7a2a89988b97
+  subjects:
+  - entities:
+    - role: player
+      name: Ethan Holliday
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: BSA-7
+  uuid: 036fa729-3f72-486d-bec7-0718ae6f283f
+  subjects:
+  - entities:
+    - role: player
+      name: Chase Burns
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: BSA-8
+  uuid: fbd763a0-ca69-4af6-8c2a-aac58be069f1
+  subjects:
+  - entities:
+    - role: player
+      name: Jac Caglianone
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: BSA-9
+  uuid: 49092cce-5441-4402-893a-867b7280511d
+  subjects:
+  - entities:
+    - role: player
+      name: Roman Anthony
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: BSA-10
+  uuid: 868a84f1-3d4c-415b-a0e4-9dd27f3d2c1a
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Misiorowski
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 

--- a/data/baseball/2026-bowman/checklists/bowman-sterling.yaml
+++ b/data/baseball/2026-bowman/checklists/bowman-sterling.yaml
@@ -1,0 +1,150 @@
+- number: BST-1
+  uuid: eecc0386-11e8-4ebb-a71b-0c14852a59c1
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Chourio
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: BST-2
+  uuid: b72acb27-5676-4519-b449-3a54cc7ccb06
+  subjects:
+  - entities:
+    - role: player
+      name: Freddie Freeman
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: BST-3
+  uuid: 6e96702c-57c9-4caf-a5bf-370b9aa50bd7
+  subjects:
+  - entities:
+    - role: player
+      name: Julio Rodríguez
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: BST-4
+  uuid: 34e29fb8-1791-47b6-9e72-25a90d4a506e
+  subjects:
+  - entities:
+    - role: player
+      name: Aaron Judge
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: BST-5
+  uuid: 6096f9e8-9bb3-4a0b-911f-e6b03c5eaa33
+  subjects:
+  - entities:
+    - role: player
+      name: Max Clark
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: BST-6
+  uuid: 8e44f895-0fc7-4fb2-9dd8-9646ec753292
+  subjects:
+  - entities:
+    - role: player
+      name: Shohei Ohtani
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: BST-7
+  uuid: b8420a4d-f878-452a-aaef-8d04e56f2952
+  subjects:
+  - entities:
+    - role: player
+      name: Konnor Griffin
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: BST-8
+  uuid: 267c020d-7cff-40b1-b5a9-a27e1adf8543
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan McLean
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: BST-9
+  uuid: d15034fd-3614-4a64-b64b-7c8b7d706a47
+  subjects:
+  - entities:
+    - role: player
+      name: Leo De Vries
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: BST-10
+  uuid: 4de23ad8-1288-4f7d-8686-07250649a419
+  subjects:
+  - entities:
+    - role: player
+      name: Chase Burns
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: BST-11
+  uuid: 04cfabcd-e0df-4a59-8712-65fad2116f1e
+  subjects:
+  - entities:
+    - role: player
+      name: Ethan Holliday
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: BST-12
+  uuid: dac5460e-19a1-4b6f-b2b0-2c316c52ae86
+  subjects:
+  - entities:
+    - role: player
+      name: Roman Anthony
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: BST-13
+  uuid: 2d7ade89-73a0-48e5-a494-ec242fc75605
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Misiorowski
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: BST-14
+  uuid: '068435f7-6ab7-4f2a-ac5c-8165aa52cc63'
+  subjects:
+  - entities:
+    - role: player
+      name: Jac Caglianone
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: BST-15
+  uuid: 620b8cbe-c104-40db-a5b0-ab59db0bced4
+  subjects:
+  - entities:
+    - role: player
+      name: Carson Williams
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 

--- a/data/baseball/2026-bowman/checklists/chrome-prospect-autographs.yaml
+++ b/data/baseball/2026-bowman/checklists/chrome-prospect-autographs.yaml
@@ -1,0 +1,870 @@
+- number: CPA-AA
+  uuid: cc673410-26d3-4a78-8cad-9eaae6f7629b
+  subjects:
+  - entities:
+    - role: player
+      name: Aiva Arquette
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: CPA-AF
+  uuid: 2e96687b-1598-450f-8297-ecc2f7cf9e67
+  subjects:
+  - entities:
+    - role: player
+      name: Andrew Fischer
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: CPA-AFR
+  uuid: f88ddfc0-d042-4a7d-a957-dab3a514a105
+  subjects:
+  - entities:
+    - role: player
+      name: Anthony Frobose
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: CPA-AG
+  uuid: 1e612055-a953-45ac-9790-bd770fb9d278
+  subjects:
+  - entities:
+    - role: player
+      name: Adrian Gil
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: CPA-ANA
+  uuid: 7161da28-a782-4988-8668-e9d7a920f522
+  subjects:
+  - entities:
+    - role: player
+      name: Anderson Araujo
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: CPA-AT
+  uuid: 732d1450-5d3f-49c8-874c-8702a20c458d
+  subjects:
+  - entities:
+    - role: player
+      name: Andrew Tess
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: CPA-BA
+  uuid: cdf764d0-7bcf-4ec0-b48d-f6075290033a
+  subjects:
+  - entities:
+    - role: player
+      name: Brailyn Antunez
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: CPA-BB
+  uuid: d5540cd1-cdde-4088-a83b-78910a1e8fea
+  subjects:
+  - entities:
+    - role: player
+      name: Blaine Bullard
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: CPA-BC
+  uuid: ac3c535f-64e2-4e4d-b2d8-38e0505c2c6c
+  subjects:
+  - entities:
+    - role: player
+      name: Billy Carlson
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: CPA-BG
+  uuid: 3020f630-7093-4bc8-ba55-b31baa20c7d6
+  subjects:
+  - entities:
+    - role: player
+      name: Breyson Guedez
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: CPA-BI
+  uuid: 90426d1f-1406-45d9-8180-e65b34ccb430
+  subjects:
+  - entities:
+    - role: player
+      name: Brent Iredale
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: CPA-BT
+  uuid: 75ac1c0f-e090-46d4-9a14-37b07d4494a2
+  subjects:
+  - entities:
+    - role: player
+      name: Brendan Tunink
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: CPA-CC
+  uuid: 6d1121f1-77b4-4362-b70d-f60c9887aeb4
+  subjects:
+  - entities:
+    - role: player
+      name: Charlie Condon
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: CPA-CGU
+  uuid: eadc8b3f-f693-459a-b17e-d20d91537929
+  subjects:
+  - entities:
+    - role: player
+      name: Carlos Gutierrez
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: CPA-CJ
+  uuid: e2b2d2ad-15e6-4c80-863d-d4cd6dbd1cd2
+  subjects:
+  - entities:
+    - role: player
+      name: Coy James
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: CPA-CSC
+  uuid: 706e962a-7f1a-4f91-82c6-c907f1c43655
+  subjects:
+  - entities:
+    - role: player
+      name: Caden Scarborough
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: CPA-CV
+  uuid: 3449da0e-4ed8-4e31-be85-a98fa88e86c1
+  subjects:
+  - entities:
+    - role: player
+      name: Carlos Virahonda
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: CPA-DD
+  uuid: 8e01fe9b-df40-4348-af2c-38d38173f889
+  subjects:
+  - entities:
+    - role: player
+      name: Daniel Dickinson
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: CPA-DDA
+  uuid: 03efe95f-4c24-4961-92d4-39cae62e1405
+  subjects:
+  - entities:
+    - role: player
+      name: David Davalillo
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: CPA-DF
+  uuid: 60009409-8bda-4106-9ad6-a397657b1cef
+  subjects:
+  - entities:
+    - role: player
+      name: Dauri Fernandez
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: CPA-DH
+  uuid: 103d50ed-ac8a-4983-962a-0676be85ae67
+  subjects:
+  - entities:
+    - role: player
+      name: Dasan Hill
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: CPA-DL
+  uuid: e2fafa00-52bb-4f3f-aa3a-cca33cbddb7f
+  subjects:
+  - entities:
+    - role: player
+      name: Dillon Lewis
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: CPA-DOR
+  uuid: 9fd57ddf-32bf-49eb-9c52-7be5f824380b
+  subjects:
+  - entities:
+    - role: player
+      name: Deniel Ortiz
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: CPA-DP
+  uuid: acbea16f-cde7-4649-994a-694d081379fa
+  subjects:
+  - entities:
+    - role: player
+      name: Daniel Pierce
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: CPA-DSH
+  uuid: 5cc9cf64-4f58-433d-bf6b-7dd912e1b8f0
+  subjects:
+  - entities:
+    - role: player
+      name: David Shields
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: CPA-EDO
+  uuid: 0f13089a-1909-4536-906d-04704292ce63
+  subjects:
+  - entities:
+    - role: player
+      name: Ethan Dorchies
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: CPA-EF
+  uuid: ca3a6cf5-4c8a-40ef-a894-488894de6f62
+  subjects:
+  - entities:
+    - role: player
+      name: Edward Florentino
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: CPA-EH
+  uuid: 4975413a-09e8-4f56-8618-646c55f27a36
+  subjects:
+  - entities:
+    - role: player
+      name: Ethan Holliday
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: CPA-EHA
+  uuid: 6a2082ab-745d-4c5f-89db-83a5d6c76af1
+  subjects:
+  - entities:
+    - role: player
+      name: Eric Hartman
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: CPA-EM
+  uuid: f4913bf7-7ec1-41be-982d-39995d4675a9
+  subjects:
+  - entities:
+    - role: player
+      name: Edgar Montero
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: CPA-EME
+  uuid: 2ea73810-b386-4435-b843-830a372e9b0f
+  subjects:
+  - entities:
+    - role: player
+      name: Esteban Mejia
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: CPA-EW
+  uuid: cf95d351-f54e-4a41-bf25-066ce9fe4e17
+  subjects:
+  - entities:
+    - role: player
+      name: Eli Willits
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: CPA-GJ
+  uuid: ec62569c-b5c4-400c-8182-2a7bf42c1b2f
+  subjects:
+  - entities:
+    - role: player
+      name: Gage Jump
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: CPA-GL
+  uuid: a6fa751c-4475-4984-abb3-c77ffc89907a
+  subjects:
+  - entities:
+    - role: player
+      name: George Lombard Jr.
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: CPA-GR
+  uuid: b9f69b05-7cbd-4449-827d-70b71178f4f5
+  subjects:
+  - entities:
+    - role: player
+      name: Gabriel Rodriguez
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: CPA-GS
+  uuid: 51fec8e1-31d4-470a-8e50-c4bc0c5ef156
+  subjects:
+  - entities:
+    - role: player
+      name: Gage Stanifer
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: CPA-HE
+  uuid: e5d35d0f-ca78-4e02-893d-18e38bba7c34
+  subjects:
+  - entities:
+    - role: player
+      name: Handelfry Encarnacion
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: CPA-HL
+  uuid: 80c1e312-6051-43e1-ab2b-1455c5257685
+  subjects:
+  - entities:
+    - role: player
+      name: Henry Lalane
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: CPA-HR
+  uuid: c299d925-0402-4087-a58a-13242b678789
+  subjects:
+  - entities:
+    - role: player
+      name: Hector Ramos
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: CPA-IJ
+  uuid: '097cc208-19cb-4593-a684-2af0c0cf8c6d'
+  subjects:
+  - entities:
+    - role: player
+      name: Isaiah Jackson
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: CPA-JG
+  uuid: c8013e01-2e8d-4fc7-b9da-872bd7bab1cd
+  subjects:
+  - entities:
+    - role: player
+      name: Justin Gonzales
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: CPA-JJ
+  uuid: 866967ad-d9ef-4b8b-9866-80dc6746c068
+  subjects:
+  - entities:
+    - role: player
+      name: Jared Jones
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: CPA-JK
+  uuid: f3b1e8d1-e3eb-4658-9ec1-7745fc2e7f58
+  subjects:
+  - entities:
+    - role: player
+      name: Josh Knoth
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: CPA-JM
+  uuid: 6aa4a550-f931-478a-a4bd-b1765c1bb918
+  subjects:
+  - entities:
+    - role: player
+      name: Jase Mitchell
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: CPA-JQ
+  uuid: 9fd7cf45-e7cd-4dd7-8966-91f5a15e0a57
+  subjects:
+  - entities:
+    - role: player
+      name: Jorge Quintana
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: CPA-JQU
+  uuid: 605dc5dd-26a6-45ba-8e7b-01991b5989e7
+  subjects:
+  - entities:
+    - role: player
+      name: James Quinn-Irons
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: CPA-JS
+  uuid: 14e18933-1ff3-4587-82b1-0da46679e2ca
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Sanchez
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: CPA-JSL
+  uuid: 83af6a9c-00f4-447d-b916-348bcce185e8
+  subjects:
+  - entities:
+    - role: player
+      name: Jean Carlos Sio
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: CPA-JU
+  uuid: 67223546-b8cf-453c-9bf7-49ca778efbdb
+  subjects:
+  - entities:
+    - role: player
+      name: Jose Urbina
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: CPA-JW
+  uuid: 0246ea0b-5546-4bfc-bdae-273c911716f6
+  subjects:
+  - entities:
+    - role: player
+      name: Jude Warwick
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: CPA-JWH
+  uuid: 320f6eb3-ec2c-463c-ac0f-e6451e958a4e
+  subjects:
+  - entities:
+    - role: player
+      name: Jack Wheeler
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: CPA-KAN
+  uuid: cc05696c-5cbb-4013-a01c-7e6430e0d903
+  subjects:
+  - entities:
+    - role: player
+      name: Kade Anderson
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: CPA-KC
+  uuid: 96527e9c-8f58-4937-948a-26dfadcf0afc
+  subjects:
+  - entities:
+    - role: player
+      name: Kendry Chourio
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: CPA-KG
+  uuid: f58911ec-6b56-44bf-9b5b-bd335e31fa5b
+  subjects:
+  - entities:
+    - role: player
+      name: Konnor Griffin
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: CPA-KH
+  uuid: 96fbca8c-eb02-462f-9a39-dd3c650a76cb
+  subjects:
+  - entities:
+    - role: player
+      name: Kenly Hunter
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: CPA-KHE
+  uuid: f53d3481-9f49-403a-adfc-7aa8f759ec44
+  subjects:
+  - entities:
+    - role: player
+      name: Kehden Hettiger
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: CPA-KMC
+  uuid: bd001327-0a6f-4816-bd6c-6343ed7b68c6
+  subjects:
+  - entities:
+    - role: player
+      name: Kevin McGonigle
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: CPA-KSN
+  uuid: c0910f54-bd17-437a-9a4c-42db8b1cf200
+  subjects:
+  - entities:
+    - role: player
+      name: Kade Snell
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: CPA-LA
+  uuid: b71b4b1d-65ff-4414-914f-7a62bb141988
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Arana
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: CPA-LDE
+  uuid: 54b1d320-23f3-44b1-af00-5885a01f5a55
+  subjects:
+  - entities:
+    - role: player
+      name: Leo De Vries
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: CPA-MC
+  uuid: 6ccbe0ea-f027-4277-be62-f2165ce812c0
+  subjects:
+  - entities:
+    - role: player
+      name: Max Clark
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: CPA-MCH
+  uuid: 68c68282-c473-4c18-a22b-ad70af2dbc9b
+  subjects:
+  - entities:
+    - role: player
+      name: Moisés Chace
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: CPA-MF
+  uuid: 980cc7ad-cf35-4143-907e-83c00750acb4
+  subjects:
+  - entities:
+    - role: player
+      name: Matthew Ferrara
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: CPA-MG
+  uuid: 684990ad-700c-4267-b025-2d048cbd79cd
+  subjects:
+  - entities:
+    - role: player
+      name: Marconi German
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: CPA-MHO
+  uuid: 4dfd63d5-9d6d-47f5-bedf-6ab93427da7f
+  subjects:
+  - entities:
+    - role: player
+      name: Marek Houston
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: CPA-MS
+  uuid: cb4aca63-a7d5-402e-b1b7-d4061a88dfbb
+  subjects:
+  - entities:
+    - role: player
+      name: Seojun Moon
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: CPA-NM
+  uuid: 5a1c979c-9c0b-4078-ae27-b4cb8f492877
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Monistere
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: CPA-NT
+  uuid: 92180762-35fe-4bc6-9076-ddaa0ec73f42
+  subjects:
+  - entities:
+    - role: player
+      name: Nelly Taylor
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: CPA-OC
+  uuid: 2e4c5fa5-f708-4978-a941-59161137cd99
+  subjects:
+  - entities:
+    - role: player
+      name: Owen Carey
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: CPA-PI
+  uuid: 469d3908-74e1-4a0f-8cc1-f8d544341d07
+  subjects:
+  - entities:
+    - role: player
+      name: Pedro Ibarguen
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: CPA-PN
+  uuid: f58eee43-215d-46aa-b442-d285a68cc0ce
+  subjects:
+  - entities:
+    - role: player
+      name: Pablo Nunez
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: CPA-RB
+  uuid: 95e0ae3f-7926-40d9-8ff7-c7df477a9298
+  subjects:
+  - entities:
+    - role: player
+      name: Roldy Brito
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: CPA-RC
+  uuid: 573187ab-e88a-4f8d-995f-d65723f01402
+  subjects:
+  - entities:
+    - role: player
+      name: Ricardo Cova
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: CPA-RN
+  uuid: 828b221f-f589-4c89-acb6-31590fab3401
+  subjects:
+  - entities:
+    - role: player
+      name: Riley Nelson
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: CPA-SK
+  uuid: 7fae85c7-6776-4f2e-bc56-de3fa14daae5
+  subjects:
+  - entities:
+    - role: player
+      name: Seong-Jun Kim
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: CPA-SP
+  uuid: b0ac421a-e391-4087-91ea-08282d99c2e5
+  subjects:
+  - entities:
+    - role: player
+      name: Sam Petersen
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: CPA-TB
+  uuid: 7b20f414-0f80-47df-8c08-83999bf9a421
+  subjects:
+  - entities:
+    - role: player
+      name: Travis Bazzana
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: CPA-TGI
+  uuid: 3800d337-c674-4b34-ac5c-ac30f62cb2ae
+  subjects:
+  - entities:
+    - role: player
+      name: Trey Gibson
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: CPA-TM
+  uuid: fc801338-646d-4ffd-a8f5-9c78ca834b1a
+  subjects:
+  - entities:
+    - role: player
+      name: Truitt Madonna
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: CPA-TR
+  uuid: 32bc20ed-b894-45d9-b618-ef08a5a3e95a
+  subjects:
+  - entities:
+    - role: player
+      name: T.J. Rumfield
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: CPA-TW
+  uuid: 224465f6-b62c-4eac-9213-69a9334f5fb8
+  subjects:
+  - entities:
+    - role: player
+      name: Thomas White
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: CPA-VA
+  uuid: 60604330-c72d-4035-8fb9-5c422d60d6e1
+  subjects:
+  - entities:
+    - role: player
+      name: Victor Arias
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: CPA-VF
+  uuid: 50e06cf1-6d7f-43de-8b08-b609d03849e5
+  subjects:
+  - entities:
+    - role: player
+      name: Victor Figueroa
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: CPA-WA
+  uuid: afe047f2-2c9b-4219-8568-1a591c70b9a4
+  subjects:
+  - entities:
+    - role: player
+      name: Wehiwa Aloy
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: CPA-WL
+  uuid: 6b96d177-ac3c-487e-b55e-527aa8e9faf6
+  subjects:
+  - entities:
+    - role: player
+      name: Wei-En Lin
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: CPA-WS
+  uuid: 62a7aae8-4f3c-4629-9096-d4f17e676b4d
+  subjects:
+  - entities:
+    - role: player
+      name: Wyatt Sanford
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: CPA-YCA
+  uuid: d4507052-bf95-4b5c-a2ed-975e77a224f9
+  subjects:
+  - entities:
+    - role: player
+      name: Yojancel Cabrera
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 

--- a/data/baseball/2026-bowman/checklists/chrome-prospect-gold-ink-autographs.yaml
+++ b/data/baseball/2026-bowman/checklists/chrome-prospect-gold-ink-autographs.yaml
@@ -1,0 +1,470 @@
+- number: CPA-AA
+  uuid: faade55d-61c4-4878-aaff-e576b6c29d37
+  subjects:
+  - entities:
+    - role: player
+      name: Aiva Arquette
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: CPA-AF
+  uuid: b61e4db5-ef94-4442-8bfc-defb4fa68fb8
+  subjects:
+  - entities:
+    - role: player
+      name: Andrew Fischer
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: CPA-ANA
+  uuid: 7c85899c-feef-4d4e-b395-88d6c4e75ec0
+  subjects:
+  - entities:
+    - role: player
+      name: Anderson Araujo
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: CPA-BA
+  uuid: ba03ce23-2e38-4586-84d3-1a306129366d
+  subjects:
+  - entities:
+    - role: player
+      name: Brailyn Antunez
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: CPA-BB
+  uuid: 689eaea8-c97b-4464-ae5f-a91e83fc9fb7
+  subjects:
+  - entities:
+    - role: player
+      name: Blaine Bullard
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: CPA-BG
+  uuid: 20cccdc6-0b6a-46a2-97cb-f5672eed8a38
+  subjects:
+  - entities:
+    - role: player
+      name: Breyson Guedez
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: CPA-BT
+  uuid: 714be5d4-5ff6-48d7-a00d-ec4b46ea03df
+  subjects:
+  - entities:
+    - role: player
+      name: Brendan Tunink
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: CPA-CJ
+  uuid: f38d4d6c-b83e-4e31-95f0-d0183242c1ac
+  subjects:
+  - entities:
+    - role: player
+      name: Coy James
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: CPA-DF
+  uuid: f2b0863e-b897-4435-9742-9dcff3a0dc32
+  subjects:
+  - entities:
+    - role: player
+      name: Dauri Fernandez
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: CPA-DH
+  uuid: 0e0254f8-1fdb-409b-939c-6b933e342f6f
+  subjects:
+  - entities:
+    - role: player
+      name: Dasan Hill
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: CPA-DL
+  uuid: 7e2831bf-10d0-4b0d-a1e2-7e8f3b0e7b61
+  subjects:
+  - entities:
+    - role: player
+      name: Dillon Lewis
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: CPA-DOR
+  uuid: 73557314-809a-4150-b0b0-936f255e89e4
+  subjects:
+  - entities:
+    - role: player
+      name: Deniel Ortiz
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: CPA-DP
+  uuid: 945efb40-6581-449a-ba77-f39cf29760c0
+  subjects:
+  - entities:
+    - role: player
+      name: Daniel Pierce
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: CPA-DSH
+  uuid: 7cedad77-c782-4923-8190-72147310105e
+  subjects:
+  - entities:
+    - role: player
+      name: David Shields
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: CPA-EF
+  uuid: 4b583ca0-b08d-49ec-b66b-9015abca523f
+  subjects:
+  - entities:
+    - role: player
+      name: Edward Florentino
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: CPA-EH
+  uuid: aa691a4b-d949-426e-a3a6-9dfdf0113449
+  subjects:
+  - entities:
+    - role: player
+      name: Ethan Holliday
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: CPA-EM
+  uuid: dd7fddc1-ce86-4915-be05-b0f414910e6b
+  subjects:
+  - entities:
+    - role: player
+      name: Edgar Montero
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: CPA-EME
+  uuid: dfc65dc8-4958-489a-8e7a-581f22cf5b75
+  subjects:
+  - entities:
+    - role: player
+      name: Esteban Mejia
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: CPA-EW
+  uuid: 8bed2abd-b4b8-4eca-b8b8-3ce3e98598d8
+  subjects:
+  - entities:
+    - role: player
+      name: Eli Willits
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: CPA-GJ
+  uuid: 4ec3842e-c744-4b05-83e4-75eeb1ac2985
+  subjects:
+  - entities:
+    - role: player
+      name: Gage Jump
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: CPA-GR
+  uuid: 100bdc56-844b-4ee3-8155-5b560af67b6f
+  subjects:
+  - entities:
+    - role: player
+      name: Gabriel Rodriguez
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: CPA-HE
+  uuid: d5d49b52-df76-4470-a8b0-c8aa93b6bd3e
+  subjects:
+  - entities:
+    - role: player
+      name: Handelfry Encarnacion
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: CPA-HL
+  uuid: 34303434-1407-4b3a-8131-74449aa26897
+  subjects:
+  - entities:
+    - role: player
+      name: Henry Lalane
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: CPA-HR
+  uuid: 6d4bdaea-6351-4357-8f10-e33366a64d95
+  subjects:
+  - entities:
+    - role: player
+      name: Hector Ramos
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: CPA-IJ
+  uuid: 5ed62630-4091-422f-a695-e8223e15d296
+  subjects:
+  - entities:
+    - role: player
+      name: Isaiah Jackson
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: CPA-JG
+  uuid: b4e08be8-2dde-4b4b-a1ef-969c2430d977
+  subjects:
+  - entities:
+    - role: player
+      name: Justin Gonzales
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: CPA-JQ
+  uuid: 5b5933bd-c86d-46b5-ab86-84362a14c798
+  subjects:
+  - entities:
+    - role: player
+      name: Jorge Quintana
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: CPA-JS
+  uuid: 269035c8-ad57-4409-9d77-cc7494f6c3b5
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Sanchez
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: CPA-JW
+  uuid: 29ca2b86-19c2-487b-b8de-f3bd6217bcaa
+  subjects:
+  - entities:
+    - role: player
+      name: Jude Warwick
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: CPA-KC
+  uuid: 9f32a003-cc04-4bd1-a395-8dcf8fb07f8f
+  subjects:
+  - entities:
+    - role: player
+      name: Kendry Chourio
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: CPA-KG
+  uuid: eed4a5c4-d101-44cc-bfbf-2e6fdb3fd08e
+  subjects:
+  - entities:
+    - role: player
+      name: Konnor Griffin
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: CPA-KH
+  uuid: 5bbdb61d-0aed-45a8-bc4b-5120af5b10bb
+  subjects:
+  - entities:
+    - role: player
+      name: Kenly Hunter
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: CPA-KMC
+  uuid: 3497906a-a7b5-47af-9385-3ba033566cf4
+  subjects:
+  - entities:
+    - role: player
+      name: Kevin McGonigle
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: CPA-LA
+  uuid: db9820d7-cf2c-4ee0-80a7-f1bd62658c58
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Arana
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: CPA-LDE
+  uuid: 470d3d6d-2bf6-43c7-9d52-b9381b24a015
+  subjects:
+  - entities:
+    - role: player
+      name: Leo De Vries
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: CPA-MG
+  uuid: 3f10790b-9b33-452e-b1ab-7d6649d8b010
+  subjects:
+  - entities:
+    - role: player
+      name: Marconi German
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: CPA-MHO
+  uuid: 41b064f4-1fbe-4cd2-b32f-b53290a772a4
+  subjects:
+  - entities:
+    - role: player
+      name: Marek Houston
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: CPA-MS
+  uuid: 8e0738d4-a6e8-4025-922e-699e12039854
+  subjects:
+  - entities:
+    - role: player
+      name: Seojun Moon
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: CPA-NT
+  uuid: 254385c0-df1b-4d00-9a51-81b14f80951d
+  subjects:
+  - entities:
+    - role: player
+      name: Nelly Taylor
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: CPA-OC
+  uuid: 06f2ee35-6f0d-451b-b091-fcf67abb5820
+  subjects:
+  - entities:
+    - role: player
+      name: Owen Carey
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: CPA-RB
+  uuid: 14f8212b-d731-4354-b9b9-4b34ca7489f3
+  subjects:
+  - entities:
+    - role: player
+      name: Roldy Brito
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: CPA-SK
+  uuid: 24929a99-b97c-43db-9094-57cff6a4370d
+  subjects:
+  - entities:
+    - role: player
+      name: Seong-Jun Kim
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: CPA-VA
+  uuid: 433ecbe7-24f6-4fb0-a7e3-93a589f5afc5
+  subjects:
+  - entities:
+    - role: player
+      name: Victor Arias
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: CPA-VF
+  uuid: da98b274-454a-443c-8145-ed8429738aa6
+  subjects:
+  - entities:
+    - role: player
+      name: Victor Figueroa
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: CPA-WA
+  uuid: 883039ba-6ea7-4316-a060-e5b1760c9a53
+  subjects:
+  - entities:
+    - role: player
+      name: Wehiwa Aloy
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: CPA-WL
+  uuid: aa052e40-a606-48b6-8f4a-be2548edd2d1
+  subjects:
+  - entities:
+    - role: player
+      name: Wei-En Lin
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: CPA-WS
+  uuid: 3ee35f34-078c-4e11-b89a-bb4f7cdd17ae
+  subjects:
+  - entities:
+    - role: player
+      name: Wyatt Sanford
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 

--- a/data/baseball/2026-bowman/checklists/chrome-prospect-packfractor-autographs.yaml
+++ b/data/baseball/2026-bowman/checklists/chrome-prospect-packfractor-autographs.yaml
@@ -1,0 +1,390 @@
+- number: CPA-AA
+  uuid: 8324498a-cfea-4615-85c2-8146c163c8ff
+  subjects:
+  - entities:
+    - role: player
+      name: Aiva Arquette
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: CPA-AF
+  uuid: dad473a3-a07e-4d18-9e93-1109d5bf9619
+  subjects:
+  - entities:
+    - role: player
+      name: Andrew Fischer
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: CPA-BA
+  uuid: 7ff8676a-67d4-45be-8a5b-f9c343a314de
+  subjects:
+  - entities:
+    - role: player
+      name: Brailyn Antunez
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: CPA-BG
+  uuid: 10d3c677-a249-4cc9-b698-1499896fdb75
+  subjects:
+  - entities:
+    - role: player
+      name: Breyson Guedez
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: CPA-BT
+  uuid: 773fb575-bc4e-46d2-b898-8bcc45711078
+  subjects:
+  - entities:
+    - role: player
+      name: Brendan Tunink
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: CPA-CJ
+  uuid: f94f162b-b27f-454d-89c3-f98368dff512
+  subjects:
+  - entities:
+    - role: player
+      name: Coy James
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: CPA-DF
+  uuid: 12a665e9-ec9f-4bd2-a9cd-6eea67156013
+  subjects:
+  - entities:
+    - role: player
+      name: Dauri Fernandez
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: CPA-DH
+  uuid: 25488f81-ef11-4982-8763-d6b81c68b69c
+  subjects:
+  - entities:
+    - role: player
+      name: Dasan Hill
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: CPA-DOR
+  uuid: e47f9e88-b127-40dd-83cd-86f55e5b3ea1
+  subjects:
+  - entities:
+    - role: player
+      name: Deniel Ortiz
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: CPA-DP
+  uuid: c56ba1a7-a725-4c66-8b16-45167c6539b4
+  subjects:
+  - entities:
+    - role: player
+      name: Daniel Pierce
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: CPA-DSH
+  uuid: b3f3992f-a038-4fe9-82da-e723b43c896b
+  subjects:
+  - entities:
+    - role: player
+      name: David Shields
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: CPA-EF
+  uuid: 18aa2442-4725-434c-bcbd-9b5d835691f4
+  subjects:
+  - entities:
+    - role: player
+      name: Edward Florentino
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: CPA-EH
+  uuid: '090eac0e-2f53-45d3-8f7c-87c507583d86'
+  subjects:
+  - entities:
+    - role: player
+      name: Ethan Holliday
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: CPA-EM
+  uuid: abcbfbcd-18dd-4b41-b338-1d7aea4ad133
+  subjects:
+  - entities:
+    - role: player
+      name: Edgar Montero
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: CPA-EW
+  uuid: c154ee9f-ddd8-4e3e-85ee-20c29c620baa
+  subjects:
+  - entities:
+    - role: player
+      name: Eli Willits
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: CPA-GJ
+  uuid: c906d770-a7e0-456f-829f-315ede481b50
+  subjects:
+  - entities:
+    - role: player
+      name: Gage Jump
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: CPA-GR
+  uuid: fa0378e2-08d8-4ef1-9b0d-56da2a507a46
+  subjects:
+  - entities:
+    - role: player
+      name: Gabriel Rodriguez
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: CPA-HE
+  uuid: dcf0db5f-2a3f-40c7-9c28-88c683305346
+  subjects:
+  - entities:
+    - role: player
+      name: Handelfry Encarnacion
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: CPA-HL
+  uuid: fd20bdea-9c50-4ba5-9a2b-66003158e761
+  subjects:
+  - entities:
+    - role: player
+      name: Henry Lalane
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: CPA-HR
+  uuid: 6a9c633a-f7c6-40f8-a24f-4da869e84b8f
+  subjects:
+  - entities:
+    - role: player
+      name: Hector Ramos
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: CPA-JG
+  uuid: 8afd623e-4d54-4c7c-882f-03fb0d1188ce
+  subjects:
+  - entities:
+    - role: player
+      name: Justin Gonzales
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: CPA-JQ
+  uuid: b6de0a48-5e64-46e4-b928-f5251ba555f3
+  subjects:
+  - entities:
+    - role: player
+      name: Jorge Quintana
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: CPA-JS
+  uuid: e1ff1272-e13a-4fdf-95e5-bceed0a765d1
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Sanchez
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: CPA-JW
+  uuid: e27890c1-2b62-4a3e-a429-dfbe7e22f3c1
+  subjects:
+  - entities:
+    - role: player
+      name: Jude Warwick
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: CPA-KC
+  uuid: 7ec99b22-05c8-4a33-a353-326007d28332
+  subjects:
+  - entities:
+    - role: player
+      name: Kendry Chourio
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: CPA-KG
+  uuid: ffe4cb22-d98b-455a-acdb-492593ac6d75
+  subjects:
+  - entities:
+    - role: player
+      name: Konnor Griffin
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: CPA-KMC
+  uuid: 78615159-f39d-4c23-af12-450a1f755c4e
+  subjects:
+  - entities:
+    - role: player
+      name: Kevin McGonigle
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: CPA-LA
+  uuid: 427fd77c-cc6c-49ec-9699-8309f3850660
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Arana
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: CPA-LDE
+  uuid: 0635766b-eab5-4045-9611-8f92f0d7b216
+  subjects:
+  - entities:
+    - role: player
+      name: Leo De Vries
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: CPA-MG
+  uuid: d79d32d9-a5b7-46a7-ad12-01863ce24940
+  subjects:
+  - entities:
+    - role: player
+      name: Marconi German
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: CPA-MHO
+  uuid: 13836c00-caeb-4fbb-9187-fb3842ba02ef
+  subjects:
+  - entities:
+    - role: player
+      name: Marek Houston
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: CPA-MS
+  uuid: 4172accc-4caf-4bc6-8505-5106f623b6ef
+  subjects:
+  - entities:
+    - role: player
+      name: Seojun Moon
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: CPA-NT
+  uuid: 3611438c-5f6d-49f3-ac27-77525e51e190
+  subjects:
+  - entities:
+    - role: player
+      name: Nelly Taylor
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: CPA-OC
+  uuid: f2e026b2-3eaa-4a53-bf37-f18727f31707
+  subjects:
+  - entities:
+    - role: player
+      name: Owen Carey
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: CPA-RB
+  uuid: 63701fdc-7774-40f1-ac66-4009512a2164
+  subjects:
+  - entities:
+    - role: player
+      name: Roldy Brito
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: CPA-SK
+  uuid: 306c4b55-0f28-4198-961b-2ad1e4802be8
+  subjects:
+  - entities:
+    - role: player
+      name: Seong-Jun Kim
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: CPA-WA
+  uuid: 4281c71a-a436-4329-93d3-90d01a29dfdf
+  subjects:
+  - entities:
+    - role: player
+      name: Wehiwa Aloy
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: CPA-WL
+  uuid: 6f525425-a8b9-4f1c-bd35-a4ab9382867f
+  subjects:
+  - entities:
+    - role: player
+      name: Wei-En Lin
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: CPA-WS
+  uuid: ea40d443-1cf7-483e-bda8-5e8bfc38b44d
+  subjects:
+  - entities:
+    - role: player
+      name: Wyatt Sanford
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 

--- a/data/baseball/2026-bowman/checklists/chrome-prospects-etched-in-glass-variations.yaml
+++ b/data/baseball/2026-bowman/checklists/chrome-prospects-etched-in-glass-variations.yaml
@@ -1,0 +1,110 @@
+- number: BCP-1
+  uuid: a822d5bc-58b1-4949-b095-a93d6240c5e0
+  subjects:
+  - entities:
+    - role: player
+      name: Ethan Holliday
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: BCP-16
+  uuid: 518825c3-4113-4c79-a596-147574645cca
+  subjects:
+  - entities:
+    - role: player
+      name: Marek Houston
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: BCP-25
+  uuid: 4e1c244a-e85d-44c4-853d-af2aa73dfd21
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Sanchez
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: BCP-40
+  uuid: b0f9623d-692c-4bdd-bc94-5b2ac24a4d90
+  subjects:
+  - entities:
+    - role: player
+      name: Aiva Arquette
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: BCP-45
+  uuid: 3617494f-ef9b-418b-84e7-4e3f5a18c661
+  subjects:
+  - entities:
+    - role: player
+      name: Seong-Jun Kim
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: BCP-77
+  uuid: 86c5da2e-81a7-4c96-8889-b82fbe9866d7
+  subjects:
+  - entities:
+    - role: player
+      name: Daniel Pierce
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: BCP-82
+  uuid: c72815a4-9997-46ef-b109-6e0d682c5fa2
+  subjects:
+  - entities:
+    - role: player
+      name: Edward Florentino
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: BCP-100
+  uuid: 4f8c8f5a-d1f4-4389-9862-359dd78d99be
+  subjects:
+  - entities:
+    - role: player
+      name: Marconi German
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: BCP-135
+  uuid: b3a16994-608a-4672-871e-2b4148771c2c
+  subjects:
+  - entities:
+    - role: player
+      name: Wehiwa Aloy
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: BCP-139
+  uuid: cffdae6b-5e0c-4a37-b122-7e402cfb01f4
+  subjects:
+  - entities:
+    - role: player
+      name: Edgar Montero
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: BCP-149
+  uuid: 1c77d234-6712-427b-92f0-8499c2978649
+  subjects:
+  - entities:
+    - role: player
+      name: Andrew Fischer
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 

--- a/data/baseball/2026-bowman/checklists/chrome-prospects-packfractor-variation.yaml
+++ b/data/baseball/2026-bowman/checklists/chrome-prospects-packfractor-variation.yaml
@@ -1,0 +1,1500 @@
+- number: BCP-1
+  uuid: 11b947c3-3339-470c-9d9e-bcbfec0c14d6
+  subjects:
+  - entities:
+    - role: player
+      name: Ethan Holliday
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: BCP-2
+  uuid: bda27889-31c4-4e45-8b3a-f3abdffe76e4
+  subjects:
+  - entities:
+    - role: player
+      name: Max Clark
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: BCP-3
+  uuid: 4317a61d-af5b-4523-980d-aa4bd0fdca19
+  subjects:
+  - entities:
+    - role: player
+      name: Yojancel Cabrera
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: BCP-4
+  uuid: d37f574b-ce4d-4ed2-8507-b8aae266f2d9
+  subjects:
+  - entities:
+    - role: player
+      name: James Quinn-Irons
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: BCP-5
+  uuid: 4271c4d5-9787-48ed-a792-f948e4d2e941
+  subjects:
+  - entities:
+    - role: player
+      name: Tyson Lewis
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: BCP-6
+  uuid: 0d888264-4bfd-44f6-94ec-39871d901fb6
+  subjects:
+  - entities:
+    - role: player
+      name: Jared Jones
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: BCP-7
+  uuid: 01b92340-80ee-433b-9da3-3018438ecbcd
+  subjects:
+  - entities:
+    - role: player
+      name: Kendry Chourio
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: BCP-8
+  uuid: 583cfa99-5fad-49ec-bf8c-a9ce5b23f649
+  subjects:
+  - entities:
+    - role: player
+      name: Anderson Araujo
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: BCP-9
+  uuid: edc11fa4-fd8a-48bf-9952-f6f120b454cf
+  subjects:
+  - entities:
+    - role: player
+      name: Tyler Bremner
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: BCP-10
+  uuid: a643fb0b-de73-481e-88ee-51cf0abc9a33
+  subjects:
+  - entities:
+    - role: player
+      name: Liam Doyle
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: BCP-11
+  uuid: da5846c8-e498-40ee-b74e-3a182e4b7ac5
+  subjects:
+  - entities:
+    - role: player
+      name: David Shields
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: BCP-12
+  uuid: ed99317a-0faf-4537-8005-e9fae25152e4
+  subjects:
+  - entities:
+    - role: player
+      name: Jase Mitchell
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: BCP-13
+  uuid: b7f3567d-a0b8-46ca-8f6b-e2d44f300474
+  subjects:
+  - entities:
+    - role: player
+      name: Blake Mitchell
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: BCP-14
+  uuid: 6eed9155-0d17-4e32-9245-f3140fc408d6
+  subjects:
+  - entities:
+    - role: player
+      name: Carlos Gutierrez
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: BCP-15
+  uuid: 1aa3df72-74be-46d3-a6ce-1e30eb511b61
+  subjects:
+  - entities:
+    - role: player
+      name: Gage Jump
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: BCP-16
+  uuid: c70481b1-78da-4d23-8908-df76749c9227
+  subjects:
+  - entities:
+    - role: player
+      name: Marek Houston
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: BCP-17
+  uuid: 4520e87c-b0da-4eac-93c0-3d4994245260
+  subjects:
+  - entities:
+    - role: player
+      name: Caden Scarborough
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: BCP-18
+  uuid: a650f1a6-fa48-4283-b445-f7df2781c799
+  subjects:
+  - entities:
+    - role: player
+      name: Blaine Bullard
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: BCP-19
+  uuid: 6ee2324e-1368-406f-9a8e-05457b3a4332
+  subjects:
+  - entities:
+    - role: player
+      name: Kade Anderson
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: BCP-20
+  uuid: dd3589f5-22c2-4951-8bd4-35ebcc2614d9
+  subjects:
+  - entities:
+    - role: player
+      name: Theo Gillen
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: BCP-21
+  uuid: 64438f05-c10d-4fe6-971b-33cf0e0c668f
+  subjects:
+  - entities:
+    - role: player
+      name: Roldy Brito
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: BCP-22
+  uuid: dd0ddc6f-4922-4386-b9af-78c34cea7a6f
+  subjects:
+  - entities:
+    - role: player
+      name: Deniel Ortiz
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: BCP-23
+  uuid: 1cd7f72f-74be-4d57-b743-2954fcfc6972
+  subjects:
+  - entities:
+    - role: player
+      name: Enddy Azocar
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: BCP-24
+  uuid: b2bb77e1-f571-4453-b76b-36094e9ab751
+  subjects:
+  - entities:
+    - role: player
+      name: Edward Duran
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: BCP-25
+  uuid: 7816912c-859d-43bf-a729-376263816061
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Sanchez
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: BCP-26
+  uuid: a813b073-9065-4aae-ad0d-21ef9a33d4b4
+  subjects:
+  - entities:
+    - role: player
+      name: Sean Paul Liñan
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: BCP-27
+  uuid: 6491b748-201a-4208-8489-8c44ebdac6a7
+  subjects:
+  - entities:
+    - role: player
+      name: Franklin Arias
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: BCP-28
+  uuid: 26d9d92d-777e-4a61-9083-bf3995436b3c
+  subjects:
+  - entities:
+    - role: player
+      name: Carlos Virahonda
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: BCP-29
+  uuid: 403ce399-250b-4843-87dd-0f9fe84313c0
+  subjects:
+  - entities:
+    - role: player
+      name: Victor Arias
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: BCP-30
+  uuid: '05817e79-865e-455d-9d05-5fb2cf350ffb'
+  subjects:
+  - entities:
+    - role: player
+      name: Alimber Santa
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: BCP-31
+  uuid: ce2b8caf-9c3e-4afb-bd24-75be459e6e9b
+  subjects:
+  - entities:
+    - role: player
+      name: Brent Iredale
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: BCP-32
+  uuid: 9229d424-d874-4507-ae42-c3911026f116
+  subjects:
+  - entities:
+    - role: player
+      name: Breyson Guedez
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: BCP-33
+  uuid: 272c0607-4dac-438f-8dcc-304d990b3583
+  subjects:
+  - entities:
+    - role: player
+      name: Coy James
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: BCP-34
+  uuid: 9f424578-f5cf-4cb0-af7f-684c5ea62eff
+  subjects:
+  - entities:
+    - role: player
+      name: Cristopher Polanco
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: BCP-35
+  uuid: 0f264be8-530d-40f1-9fb1-5e0953c518e8
+  subjects:
+  - entities:
+    - role: player
+      name: Travis Bazzana
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: BCP-36
+  uuid: 36237fde-f5e3-4486-b07f-091a265b192d
+  subjects:
+  - entities:
+    - role: player
+      name: Moisés Chace
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: BCP-37
+  uuid: 1731bf5a-7677-4af4-9ffa-0b0cb8801132
+  subjects:
+  - entities:
+    - role: player
+      name: Gage Stanifer
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: BCP-38
+  uuid: 35dc6a82-1360-466c-996f-ee7e5543ad29
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Cova
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: BCP-39
+  uuid: 94483338-5ea1-4a6d-82c8-68b2e3384c15
+  subjects:
+  - entities:
+    - role: player
+      name: Ryan Waldschmidt
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: BCP-40
+  uuid: ae3da54e-b617-4b86-b330-801032a6e1a7
+  subjects:
+  - entities:
+    - role: player
+      name: Aiva Arquette
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: BCP-41
+  uuid: eda1c571-3618-458c-9d00-8387d7f249b8
+  subjects:
+  - entities:
+    - role: player
+      name: Brailyn Antunez
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: BCP-42
+  uuid: 56fc252a-a414-40ab-826e-3334a527fd95
+  subjects:
+  - entities:
+    - role: player
+      name: David Davalillo
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: BCP-43
+  uuid: 21818fc2-09a7-4284-b1a6-ba126cf25d4d
+  subjects:
+  - entities:
+    - role: player
+      name: Parks Harber
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: BCP-44
+  uuid: 1489f090-be97-426d-b0cc-1c863ccd6068
+  subjects:
+  - entities:
+    - role: player
+      name: Billy Carlson
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: BCP-45
+  uuid: 9018a241-cbfe-4257-aa2b-66d6b6d9d9b2
+  subjects:
+  - entities:
+    - role: player
+      name: Seong-Jun Kim
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: BCP-46
+  uuid: 79463e0f-70d0-4234-b760-e352cb7c3c19
+  subjects:
+  - entities:
+    - role: player
+      name: Charlie Condon
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: BCP-47
+  uuid: fa20e8b5-ff7d-4c4d-ae44-d364df9d2855
+  subjects:
+  - entities:
+    - role: player
+      name: Handelfry Encarnacion
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: BCP-48
+  uuid: 6832bad1-3e81-48fe-bd05-3ae0422948d4
+  subjects:
+  - entities:
+    - role: player
+      name: Shotaro Morii
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: BCP-49
+  uuid: f06c3df9-e327-4878-9399-7a33607f5749
+  subjects:
+  - entities:
+    - role: player
+      name: Aidan Miller
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: BCP-50
+  uuid: 64e74cb4-6d08-4ad9-b892-c2855a04b3c4
+  subjects:
+  - entities:
+    - role: player
+      name: Daniel Dickinson
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: BCP-51
+  uuid: c5ee53c5-6134-4aa9-8ca5-7ee810a00e95
+  subjects:
+  - entities:
+    - role: player
+      name: Sebastian Walcott
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: BCP-52
+  uuid: 7482ac80-f993-4b71-a307-f555673cb82f
+  subjects:
+  - entities:
+    - role: player
+      name: Ethan Dorchies
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: BCP-53
+  uuid: 904ec9aa-b716-4f7e-b470-90e70789da5f
+  subjects:
+  - entities:
+    - role: player
+      name: Braden Montgomery
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: BCP-54
+  uuid: 32f42c99-419a-4abd-82b2-c3baaa73acb5
+  subjects:
+  - entities:
+    - role: player
+      name: Rainiel Rodriguez
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: BCP-55
+  uuid: 2d3d2ab6-2e73-4104-ab6b-2752af931e9c
+  subjects:
+  - entities:
+    - role: player
+      name: Andrew Salas
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: BCP-56
+  uuid: 5136287d-6880-445b-a11a-5177bba3be70
+  subjects:
+  - entities:
+    - role: player
+      name: Josuar Gonzalez
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: BCP-57
+  uuid: bba21ee5-e076-41da-bdd8-f473d6811c57
+  subjects:
+  - entities:
+    - role: player
+      name: Felnin Celesten
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: BCP-58
+  uuid: e26a0f83-75e5-43e0-84b6-2ab007e6c511
+  subjects:
+  - entities:
+    - role: player
+      name: Jude Warwick
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: BCP-59
+  uuid: 9605ae9c-e073-40c6-9072-28df27611772
+  subjects:
+  - entities:
+    - role: player
+      name: Brendan Tunink
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: BCP-60
+  uuid: 61892f7f-bf32-4ae2-97b3-c8fbf65cce42
+  subjects:
+  - entities:
+    - role: player
+      name: Isaiah Jackson
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: BCP-61
+  uuid: 0475106f-3228-41f6-8d3c-a3ae2b6d1109
+  subjects:
+  - entities:
+    - role: player
+      name: Chris Arroyo
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: BCP-62
+  uuid: b10bf0e0-87f0-45fe-a4a5-8348114e5bf0
+  subjects:
+  - entities:
+    - role: player
+      name: Josh Owens
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: BCP-63
+  uuid: 91f24b93-f7cf-4a6a-af4b-ad8666b10163
+  subjects:
+  - entities:
+    - role: player
+      name: Leo De Vries
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: BCP-64
+  uuid: db583e5e-953b-4511-86c4-fbcfd95e9e17
+  subjects:
+  - entities:
+    - role: player
+      name: George Lombard Jr.
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: BCP-65
+  uuid: 84ccc4c5-02ab-4487-b80f-481f6b5bc917
+  subjects:
+  - entities:
+    - role: player
+      name: Nelly Taylor
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: BCP-66
+  uuid: 95182e71-4bdc-42fc-8b8f-e8996d938f71
+  subjects:
+  - entities:
+    - role: player
+      name: Wyatt Sanford
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: BCP-67
+  uuid: ec4e9e8a-8a39-4979-86fa-ff072254347a
+  subjects:
+  - entities:
+    - role: player
+      name: Arjun Nimmala
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: BCP-68
+  uuid: 25750b58-e5ad-4ab4-aa69-fb3834f360aa
+  subjects:
+  - entities:
+    - role: player
+      name: Ike Irish
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: BCP-69
+  uuid: 588ac8fd-979d-4b31-b00f-2bbaaeea18c1
+  subjects:
+  - entities:
+    - role: player
+      name: Owen Carey
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: BCP-70
+  uuid: 1be5e697-bf3c-4eaf-83f5-6b6d9be62869
+  subjects:
+  - entities:
+    - role: player
+      name: Kash Mayfield
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: BCP-71
+  uuid: cdb80504-bf83-4c28-9a0b-7b8366fdfcf7
+  subjects:
+  - entities:
+    - role: player
+      name: Enyervert Perez
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: BCP-72
+  uuid: 8b149611-45a5-44f5-823f-47ce1d6a7767
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Arana
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: BCP-73
+  uuid: 1acac94c-0fab-4209-b388-3dce9a60a7ba
+  subjects:
+  - entities:
+    - role: player
+      name: Charles Davalan
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: BCP-74
+  uuid: 326ddea2-a207-4455-b02d-23f8b04ba3e7
+  subjects:
+  - entities:
+    - role: player
+      name: Jack Wheeler
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: BCP-75
+  uuid: 04725c77-0f6c-496f-8c09-f1350470316a
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Torres
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: BCP-76
+  uuid: e6d08a71-a30c-40c0-ae87-3ca1bf2f07a6
+  subjects:
+  - entities:
+    - role: player
+      name: Esmerlyn Valdez
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: BCP-77
+  uuid: 8e192e9c-2686-4713-8011-e3ee2307cfbc
+  subjects:
+  - entities:
+    - role: player
+      name: Daniel Pierce
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: BCP-78
+  uuid: 860a4761-f531-4339-bf57-9de2e0c564ff
+  subjects:
+  - entities:
+    - role: player
+      name: Dax Kilby
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: BCP-79
+  uuid: 35b1ceb6-2f84-481d-8be2-482532bdd589
+  subjects:
+  - entities:
+    - role: player
+      name: Esteban Mejia
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: BCP-80
+  uuid: d305d4ab-d470-41cd-aba7-88bbfe536a5c
+  subjects:
+  - entities:
+    - role: player
+      name: Thomas White
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: BCP-81
+  uuid: ef6b775e-af45-445f-8525-26d613837538
+  subjects:
+  - entities:
+    - role: player
+      name: Jose Urbina
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: BCP-82
+  uuid: e3816d03-a6fe-4c1d-846f-ffb71365ee6d
+  subjects:
+  - entities:
+    - role: player
+      name: Edward Florentino
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: BCP-83
+  uuid: 11a9c03f-8c61-4c0d-886c-473e677d76bc
+  subjects:
+  - entities:
+    - role: player
+      name: Josue De Paula
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: BCP-84
+  uuid: a3d867e9-4c14-4597-b235-f31a54eba527
+  subjects:
+  - entities:
+    - role: player
+      name: David Hagaman
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: BCP-85
+  uuid: 7c3fa111-70cd-47d0-8077-78ea5ea04604
+  subjects:
+  - entities:
+    - role: player
+      name: Anthony Frobose
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: BCP-86
+  uuid: '08f2e9e8-7f20-42ab-a229-547fadc9db01'
+  subjects:
+  - entities:
+    - role: player
+      name: Zyhir Hope
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: BCP-87
+  uuid: b1c6f666-5049-46db-930c-ce891bf3e327
+  subjects:
+  - entities:
+    - role: player
+      name: Jean Carlos Sio
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: BCP-88
+  uuid: 98adaad6-4863-4aa5-8d4e-4bb7d89d1a3c
+  subjects:
+  - entities:
+    - role: player
+      name: Dasan Hill
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: BCP-89
+  uuid: 68dc9cee-0e44-4c0d-9452-39cde3c62026
+  subjects:
+  - entities:
+    - role: player
+      name: Kendry Martinez
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: BCP-90
+  uuid: c0fa7cb7-41e5-42b8-8163-6cdd9c5e5cfd
+  subjects:
+  - entities:
+    - role: player
+      name: Andrew Tess
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: BCP-91
+  uuid: 99b684da-17c5-4d9f-8c2f-b80fd644e906
+  subjects:
+  - entities:
+    - role: player
+      name: Elian Peña
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: BCP-92
+  uuid: '029bf770-d9ae-4354-aefb-d132b3546586'
+  subjects:
+  - entities:
+    - role: player
+      name: Konnor Griffin
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: BCP-93
+  uuid: 9d861088-a3e1-482b-815c-1fbec3678fb6
+  subjects:
+  - entities:
+    - role: player
+      name: Jorge Quintana
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: BCP-94
+  uuid: 94e96f8d-95e2-4036-80ba-707773386cf6
+  subjects:
+  - entities:
+    - role: player
+      name: Ricardo Cova
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: BCP-95
+  uuid: cc351f81-7605-48a7-8f1c-e7bad07181de
+  subjects:
+  - entities:
+    - role: player
+      name: Eli Willits
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: BCP-96
+  uuid: 1fa2cc68-59bd-4a75-91cc-03136bb80d74
+  subjects:
+  - entities:
+    - role: player
+      name: Jesús Made
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: BCP-97
+  uuid: 6f30b76b-39af-487b-b0d0-696ba6ee14d3
+  subjects:
+  - entities:
+    - role: player
+      name: Daniel Hernandez
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: BCP-98
+  uuid: '0905bc23-a1f8-4c5b-95e3-0a8d895563ae'
+  subjects:
+  - entities:
+    - role: player
+      name: Walker Jenkins
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: BCP-99
+  uuid: c5e7b197-9918-4e55-9dd8-87c99d3a7e76
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Rainer
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: BCP-100
+  uuid: 5aa8af03-6bed-4f6f-bc44-5f6f76ea98a7
+  subjects:
+  - entities:
+    - role: player
+      name: Marconi German
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: BCP-101
+  uuid: 2cd728e6-93ac-4d43-a153-7a059615406b
+  subjects:
+  - entities:
+    - role: player
+      name: Kehden Hettiger
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: BCP-102
+  uuid: 723d9558-25d7-4630-93de-7b3a7d2cbb94
+  subjects:
+  - entities:
+    - role: player
+      name: Eric Hartman
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: BCP-103
+  uuid: a2f5ff37-94ac-46b0-a258-8964cb82cae4
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Monistere
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: BCP-104
+  uuid: ce5c42e0-051d-41e1-abd1-c4da3decca90
+  subjects:
+  - entities:
+    - role: player
+      name: Henry Lalane
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: BCP-105
+  uuid: 797e5724-5b3b-401b-a5be-126c49898750
+  subjects:
+  - entities:
+    - role: player
+      name: Kade Snell
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: BCP-106
+  uuid: 873044b4-4254-4e5e-bfc3-8535f5b9d80d
+  subjects:
+  - entities:
+    - role: player
+      name: Francisco Espinoza
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: BCP-107
+  uuid: bbd8a095-dd9c-40b2-b565-ed696d78312f
+  subjects:
+  - entities:
+    - role: player
+      name: Miguel Mendez
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: BCP-108
+  uuid: 8283652f-436a-4527-a175-581cabd164c1
+  subjects:
+  - entities:
+    - role: player
+      name: Colt Emerson
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: BCP-109
+  uuid: 8e15ddcd-4faf-4d71-9702-81f7f572e371
+  subjects:
+  - entities:
+    - role: player
+      name: Truitt Madonna
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: BCP-110
+  uuid: 11080e26-801c-4dba-9bd1-dbb49e56e085
+  subjects:
+  - entities:
+    - role: player
+      name: Matthew Ferrara
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: BCP-111
+  uuid: 5b92d33c-840c-450c-9c67-df4c269229af
+  subjects:
+  - entities:
+    - role: player
+      name: Carson Benge
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: BCP-112
+  uuid: fd4bbebf-6aac-4e7a-abca-fbfc580015bf
+  subjects:
+  - entities:
+    - role: player
+      name: Jamie Arnold
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: BCP-113
+  uuid: d04bf366-851d-4c78-999f-7aec0955574e
+  subjects:
+  - entities:
+    - role: player
+      name: Josh Knoth
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: BCP-114
+  uuid: b97e6f20-4ada-4a89-9b6f-08d52ff6f120
+  subjects:
+  - entities:
+    - role: player
+      name: Argenis Cayama
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: BCP-115
+  uuid: 17554057-27ac-4573-ae02-dd5a30ab91cf
+  subjects:
+  - entities:
+    - role: player
+      name: JJ Wetherholt
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: BCP-116
+  uuid: b32af8e7-bb9d-437a-9987-bf7826a8a7be
+  subjects:
+  - entities:
+    - role: player
+      name: Dauri Fernandez
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: BCP-117
+  uuid: 26a43727-85b9-4b82-a8b1-4c5161157ae7
+  subjects:
+  - entities:
+    - role: player
+      name: Victor Figueroa
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: BCP-118
+  uuid: 45e9fcad-9176-4df4-902e-1b517a93893f
+  subjects:
+  - entities:
+    - role: player
+      name: Gabriel Rodriguez
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: BCP-119
+  uuid: 29c4abc2-5a7a-43bc-b5ec-0a3695281a48
+  subjects:
+  - entities:
+    - role: player
+      name: Mathias Lacombe
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: BCP-120
+  uuid: 5db35cb4-2159-4f4e-8591-83251924ef93
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Peña
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: BCP-121
+  uuid: 704e068a-f1d5-4634-8de2-c6293083f1fa
+  subjects:
+  - entities:
+    - role: player
+      name: Keaton Anthony
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: BCP-122
+  uuid: a7827300-4020-4803-b75b-61b9404156b6
+  subjects:
+  - entities:
+    - role: player
+      name: Sam Petersen
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: BCP-123
+  uuid: 91ee70be-2d58-4168-9b47-64f7a35976c8
+  subjects:
+  - entities:
+    - role: player
+      name: JR Ritchie
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: BCP-124
+  uuid: 16508032-8f9a-4e07-8d6b-520ea34336ec
+  subjects:
+  - entities:
+    - role: player
+      name: Riley Nelson
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: BCP-125
+  uuid: e3104834-8d89-4323-a5f6-f24a710be58e
+  subjects:
+  - entities:
+    - role: player
+      name: Wei-En Lin
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: BCP-126
+  uuid: 1d69eaee-a460-4cbd-93a4-dd3baddb469c
+  subjects:
+  - entities:
+    - role: player
+      name: Gavin Fien
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: BCP-127
+  uuid: 4bc88afc-f7b6-401f-854c-713cc1c6e735
+  subjects:
+  - entities:
+    - role: player
+      name: Seojun Moon
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: BCP-128
+  uuid: dc4e0744-efe8-4738-89f5-294033344557
+  subjects:
+  - entities:
+    - role: player
+      name: Hector Ramos
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: BCP-129
+  uuid: 69b9898e-4af6-48d8-8cd2-967b2b4bc003
+  subjects:
+  - entities:
+    - role: player
+      name: Seaver King
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: BCP-130
+  uuid: d5de9b4b-d095-4e31-a23b-aa09da80a201
+  subjects:
+  - entities:
+    - role: player
+      name: Kenly Hunter
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: BCP-131
+  uuid: 66ca4f63-e39c-4777-a6d6-d9f5f22fc832
+  subjects:
+  - entities:
+    - role: player
+      name: Walker Janek
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: BCP-132
+  uuid: 9916fa22-1710-4181-87be-844b0bcd18af
+  subjects:
+  - entities:
+    - role: player
+      name: Keyner Martinez
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: BCP-133
+  uuid: 5c9b452a-25f1-4f39-98a0-8daab1e0d2c7
+  subjects:
+  - entities:
+    - role: player
+      name: Xavier Neyens
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: BCP-134
+  uuid: c011a0a4-9044-41b8-bbf0-765afd04da83
+  subjects:
+  - entities:
+    - role: player
+      name: T.J. Rumfield
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: BCP-135
+  uuid: 3cb2a0a9-e00f-469a-8960-d053591f04a4
+  subjects:
+  - entities:
+    - role: player
+      name: Wehiwa Aloy
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: BCP-136
+  uuid: 4da54b54-ff26-41e5-8888-26cbe100f539
+  subjects:
+  - entities:
+    - role: player
+      name: Gavin Kilen
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: BCP-137
+  uuid: 58f9aadb-6e5f-4a0b-aefc-7f06299afcf7
+  subjects:
+  - entities:
+    - role: player
+      name: Braden Nett
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: BCP-138
+  uuid: 4c12f0d1-6693-4dc6-8f8c-442110e93db9
+  subjects:
+  - entities:
+    - role: player
+      name: Patrick Copen
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: BCP-139
+  uuid: f3f5e068-a5ed-4f47-9b7d-cb46037dd147
+  subjects:
+  - entities:
+    - role: player
+      name: Edgar Montero
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: BCP-140
+  uuid: cea72d7e-dc26-4a12-9acd-a1858427afeb
+  subjects:
+  - entities:
+    - role: player
+      name: Pedro Ibarguen
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: BCP-141
+  uuid: 89819786-86bb-4d8b-b877-c2d034293ee9
+  subjects:
+  - entities:
+    - role: player
+      name: Justin Gonzales
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: BCP-142
+  uuid: cac774cc-7c05-4515-aed5-367327a4ae52
+  subjects:
+  - entities:
+    - role: player
+      name: Brady Ebel
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: BCP-143
+  uuid: 6de7384f-6a87-4463-bf7f-9b3984a4f293
+  subjects:
+  - entities:
+    - role: player
+      name: Kaelen Culpepper
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: BCP-144
+  uuid: fed03a82-d9f0-49f6-a121-ad291c96104a
+  subjects:
+  - entities:
+    - role: player
+      name: Colby Shelton
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: BCP-145
+  uuid: 75100506-e01b-4fba-b407-8376438cbb6f
+  subjects:
+  - entities:
+    - role: player
+      name: Kevin McGonigle
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: BCP-146
+  uuid: 0b82dc80-1c31-412e-bb08-86ae383a79db
+  subjects:
+  - entities:
+    - role: player
+      name: Matt Klein
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: BCP-147
+  uuid: 12d7c3a6-d13b-4a54-8bb2-116c6e0c7575
+  subjects:
+  - entities:
+    - role: player
+      name: JoJo Parker
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: BCP-148
+  uuid: 3ecbc31d-8c3a-411f-92b1-956a75dc4848
+  subjects:
+  - entities:
+    - role: player
+      name: Dillon Lewis
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: BCP-149
+  uuid: 9c335a5b-8b37-4702-bc1c-8f3c1668a057
+  subjects:
+  - entities:
+    - role: player
+      name: Andrew Fischer
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: BCP-150
+  uuid: dda6bb61-b6da-4f80-8991-47e36944e18b
+  subjects:
+  - entities:
+    - role: player
+      name: Wilder Dalis
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 

--- a/data/baseball/2026-bowman/checklists/chrome-prospects.yaml
+++ b/data/baseball/2026-bowman/checklists/chrome-prospects.yaml
@@ -1,0 +1,1500 @@
+- number: BCP-1
+  uuid: c6ed81c3-f4a6-4b5e-a684-0ea0ffd79c14
+  subjects:
+  - entities:
+    - role: player
+      name: Ethan Holliday
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: BCP-2
+  uuid: a512d699-54d0-4258-951c-48e57a9e960a
+  subjects:
+  - entities:
+    - role: player
+      name: Max Clark
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: BCP-3
+  uuid: e7353a91-8fb1-48c6-9ec4-55066e59abba
+  subjects:
+  - entities:
+    - role: player
+      name: Yojancel Cabrera
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: BCP-4
+  uuid: b51b7a69-bfb1-4b35-a384-f65ba8c6922e
+  subjects:
+  - entities:
+    - role: player
+      name: James Quinn-Irons
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: BCP-5
+  uuid: 4885a402-7042-4907-88cd-89329e7d2a1d
+  subjects:
+  - entities:
+    - role: player
+      name: Tyson Lewis
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: BCP-6
+  uuid: 958c168c-6017-4f2c-8310-b00d24402a20
+  subjects:
+  - entities:
+    - role: player
+      name: Jared Jones
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: BCP-7
+  uuid: 913565f9-3694-4a5e-a582-70e4254e84d8
+  subjects:
+  - entities:
+    - role: player
+      name: Kendry Chourio
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: BCP-8
+  uuid: 0cdbd4ed-4428-4424-ae89-af44cd1b67b3
+  subjects:
+  - entities:
+    - role: player
+      name: Anderson Araujo
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: BCP-9
+  uuid: b6561bf1-d580-4893-a444-55aa485377c7
+  subjects:
+  - entities:
+    - role: player
+      name: Tyler Bremner
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: BCP-10
+  uuid: 3f23c228-a341-4604-ac16-31c8c99940d1
+  subjects:
+  - entities:
+    - role: player
+      name: Liam Doyle
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: BCP-11
+  uuid: 7e27916d-c713-410c-b86f-7b6be37e27f6
+  subjects:
+  - entities:
+    - role: player
+      name: David Shields
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: BCP-12
+  uuid: c94dbc50-ad4d-4894-8c7f-cc6aa16992cc
+  subjects:
+  - entities:
+    - role: player
+      name: Jase Mitchell
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: BCP-13
+  uuid: 801890bb-3b7e-4aaa-b4d6-6db8f95824fa
+  subjects:
+  - entities:
+    - role: player
+      name: Blake Mitchell
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: BCP-14
+  uuid: b1516314-a978-422a-a4ef-a163fc3582ff
+  subjects:
+  - entities:
+    - role: player
+      name: Carlos Gutierrez
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: BCP-15
+  uuid: 4565f43d-20b9-4550-a00e-81fd9c6782db
+  subjects:
+  - entities:
+    - role: player
+      name: Gage Jump
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: BCP-16
+  uuid: 6a4558c2-05cd-4e00-9347-6ef75b5424bd
+  subjects:
+  - entities:
+    - role: player
+      name: Marek Houston
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: BCP-17
+  uuid: 71c92bec-4e39-4fb7-b57b-a51cbe694e3f
+  subjects:
+  - entities:
+    - role: player
+      name: Caden Scarborough
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: BCP-18
+  uuid: 1e1b4442-7946-4575-a0ff-49be609b0c6a
+  subjects:
+  - entities:
+    - role: player
+      name: Blaine Bullard
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: BCP-19
+  uuid: 7b7ba1de-c123-4d42-ba5f-e9c025ac40fd
+  subjects:
+  - entities:
+    - role: player
+      name: Kade Anderson
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: BCP-20
+  uuid: 25902431-5bf4-4fc6-b412-93d4f41f4dae
+  subjects:
+  - entities:
+    - role: player
+      name: Theo Gillen
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: BCP-21
+  uuid: 4769fe42-78f2-40dc-acfd-999c54a9a805
+  subjects:
+  - entities:
+    - role: player
+      name: Roldy Brito
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: BCP-22
+  uuid: 79f237e8-b989-4866-80e8-9f4d28c3d17e
+  subjects:
+  - entities:
+    - role: player
+      name: Deniel Ortiz
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: BCP-23
+  uuid: b8559b11-58e9-48dc-8e1a-035fd5065365
+  subjects:
+  - entities:
+    - role: player
+      name: Enddy Azocar
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: BCP-24
+  uuid: 21074ca3-3b83-4308-b110-e6ce0268cf26
+  subjects:
+  - entities:
+    - role: player
+      name: Edward Duran
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: BCP-25
+  uuid: 1b25053e-505e-4884-b306-d0c932341049
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Sanchez
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: BCP-26
+  uuid: cc96747f-77e3-4eb1-b555-c51ecdc3ee00
+  subjects:
+  - entities:
+    - role: player
+      name: Sean Paul Liñan
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: BCP-27
+  uuid: '0924abef-cfe3-4958-8b59-839bf4618fde'
+  subjects:
+  - entities:
+    - role: player
+      name: Franklin Arias
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: BCP-28
+  uuid: 101ed8de-5a9f-4dab-9887-8f8a366af355
+  subjects:
+  - entities:
+    - role: player
+      name: Carlos Virahonda
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: BCP-29
+  uuid: 274f39b6-4540-4c91-8d53-0b9db7872e1c
+  subjects:
+  - entities:
+    - role: player
+      name: Victor Arias
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: BCP-30
+  uuid: 044c2ed9-c8e1-4eb5-bbfe-24470c9f1b91
+  subjects:
+  - entities:
+    - role: player
+      name: Alimber Santa
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: BCP-31
+  uuid: 90f93942-3ad0-4c7a-a9d8-b7672ddac2fc
+  subjects:
+  - entities:
+    - role: player
+      name: Brent Iredale
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: BCP-32
+  uuid: f0cb0687-e69e-436c-95af-bd89ca13b245
+  subjects:
+  - entities:
+    - role: player
+      name: Breyson Guedez
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: BCP-33
+  uuid: c2cafbf9-0a9f-4bd7-a8ca-268e6713c21d
+  subjects:
+  - entities:
+    - role: player
+      name: Coy James
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: BCP-34
+  uuid: c51dc7da-3205-468c-a94a-296eb71b7568
+  subjects:
+  - entities:
+    - role: player
+      name: Cristopher Polanco
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: BCP-35
+  uuid: 8ee09560-ea3c-4d5b-9374-f5f5f6cc0a9a
+  subjects:
+  - entities:
+    - role: player
+      name: Travis Bazzana
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: BCP-36
+  uuid: 0dee940d-48d7-4a81-9964-c0aea228d119
+  subjects:
+  - entities:
+    - role: player
+      name: Moisés Chace
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: BCP-37
+  uuid: 529502fe-7492-4a28-b488-58c7ffc87184
+  subjects:
+  - entities:
+    - role: player
+      name: Gage Stanifer
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: BCP-38
+  uuid: 2b9b78b7-612a-4c73-97d9-de8ca26e6382
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Cova
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: BCP-39
+  uuid: 85f52176-4a64-47b3-855d-d064c8554a12
+  subjects:
+  - entities:
+    - role: player
+      name: Ryan Waldschmidt
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: BCP-40
+  uuid: 53eba209-1e34-4d70-ab62-fadde068eb2c
+  subjects:
+  - entities:
+    - role: player
+      name: Aiva Arquette
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: BCP-41
+  uuid: 5d47f5cb-e415-40a7-bf65-867f290a31c9
+  subjects:
+  - entities:
+    - role: player
+      name: Brailyn Antunez
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: BCP-42
+  uuid: b6363145-9c91-4053-bbcc-544d8492925a
+  subjects:
+  - entities:
+    - role: player
+      name: David Davalillo
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: BCP-43
+  uuid: a1daf101-b922-438a-8c1a-e6028cab9941
+  subjects:
+  - entities:
+    - role: player
+      name: Parks Harber
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: BCP-44
+  uuid: 896d009f-a39b-4c64-a85b-9de1d08506ad
+  subjects:
+  - entities:
+    - role: player
+      name: Billy Carlson
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: BCP-45
+  uuid: 98dba598-24e3-498e-9283-d91723220dc3
+  subjects:
+  - entities:
+    - role: player
+      name: Seong-Jun Kim
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: BCP-46
+  uuid: 6cac2899-11a5-472c-99a4-47a2baf88f53
+  subjects:
+  - entities:
+    - role: player
+      name: Charlie Condon
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: BCP-47
+  uuid: 93b4dd90-438b-4ae0-8a89-b69d6a61dca1
+  subjects:
+  - entities:
+    - role: player
+      name: Handelfry Encarnacion
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: BCP-48
+  uuid: f92393f7-ea98-4ca1-a115-58dd928a1bcf
+  subjects:
+  - entities:
+    - role: player
+      name: Shotaro Morii
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: BCP-49
+  uuid: 643a22aa-5ff4-4102-9776-b2ea1cb6311b
+  subjects:
+  - entities:
+    - role: player
+      name: Aidan Miller
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: BCP-50
+  uuid: 3244efd6-b9c3-44f4-81d7-57a83484c66e
+  subjects:
+  - entities:
+    - role: player
+      name: Daniel Dickinson
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: BCP-51
+  uuid: 0a6e58fc-6033-46e9-b2d4-60be4be40a6e
+  subjects:
+  - entities:
+    - role: player
+      name: Sebastian Walcott
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: BCP-52
+  uuid: 6c7589ac-cda7-4eb1-9baa-59f75ff591b9
+  subjects:
+  - entities:
+    - role: player
+      name: Ethan Dorchies
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: BCP-53
+  uuid: 8b619711-2c51-4700-bf69-509e28a53555
+  subjects:
+  - entities:
+    - role: player
+      name: Braden Montgomery
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: BCP-54
+  uuid: '098f1b68-56d4-42ca-bab9-796ff6e8652c'
+  subjects:
+  - entities:
+    - role: player
+      name: Rainiel Rodriguez
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: BCP-55
+  uuid: 48d8debd-9650-42f8-b859-7a34f4ec7036
+  subjects:
+  - entities:
+    - role: player
+      name: Andrew Salas
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: BCP-56
+  uuid: f6c6d9f4-4ba1-4721-8ad7-1287ef7db1ba
+  subjects:
+  - entities:
+    - role: player
+      name: Josuar Gonzalez
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: BCP-57
+  uuid: 61cd664e-2602-4a75-8340-5224bc931faa
+  subjects:
+  - entities:
+    - role: player
+      name: Felnin Celesten
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: BCP-58
+  uuid: 8218e4d8-53d7-487a-b9d6-654d2e0bf539
+  subjects:
+  - entities:
+    - role: player
+      name: Jude Warwick
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: BCP-59
+  uuid: 82bdabb7-76a5-432d-b533-26694df171b1
+  subjects:
+  - entities:
+    - role: player
+      name: Brendan Tunink
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: BCP-60
+  uuid: 27af35ef-b3f8-40be-88a4-cc0b851db530
+  subjects:
+  - entities:
+    - role: player
+      name: Isaiah Jackson
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: BCP-61
+  uuid: 951e2582-6273-40e8-93a7-85a8d6d219d2
+  subjects:
+  - entities:
+    - role: player
+      name: Chris Arroyo
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: BCP-62
+  uuid: 86ca4625-9c38-46bb-9553-eb444d28547c
+  subjects:
+  - entities:
+    - role: player
+      name: Josh Owens
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: BCP-63
+  uuid: f3d0117c-7a8a-47cd-af85-64d253c41fb8
+  subjects:
+  - entities:
+    - role: player
+      name: Leo De Vries
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: BCP-64
+  uuid: c63d3b87-6d7f-4c18-9883-ade1886b4fa2
+  subjects:
+  - entities:
+    - role: player
+      name: George Lombard Jr.
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: BCP-65
+  uuid: 50bb481b-2145-4aaa-ac92-74e2495a0c43
+  subjects:
+  - entities:
+    - role: player
+      name: Nelly Taylor
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: BCP-66
+  uuid: 73b684dc-e8d8-4559-b2c5-4822273627fa
+  subjects:
+  - entities:
+    - role: player
+      name: Wyatt Sanford
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: BCP-67
+  uuid: c7e452ae-966e-4c1f-bab4-9eabb3d789f0
+  subjects:
+  - entities:
+    - role: player
+      name: Arjun Nimmala
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: BCP-68
+  uuid: fb7e3d64-ef73-4b9d-8082-de3cc76ebe92
+  subjects:
+  - entities:
+    - role: player
+      name: Ike Irish
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: BCP-69
+  uuid: '082f8ea3-85c5-419a-b3a9-bb03c9986beb'
+  subjects:
+  - entities:
+    - role: player
+      name: Owen Carey
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: BCP-70
+  uuid: 397e5b62-2101-4fba-ad6d-c8621bc55c09
+  subjects:
+  - entities:
+    - role: player
+      name: Kash Mayfield
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: BCP-71
+  uuid: 3bbd1fab-527c-4b54-8c1d-ff0b01a14dfa
+  subjects:
+  - entities:
+    - role: player
+      name: Enyervert Perez
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: BCP-72
+  uuid: 9a8ce6dd-a33d-4bf3-aeef-3014803b9441
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Arana
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: BCP-73
+  uuid: 9548d649-bc04-4f12-b06c-ad37dc28f9d8
+  subjects:
+  - entities:
+    - role: player
+      name: Charles Davalan
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: BCP-74
+  uuid: ed10c980-0869-4b9c-8eac-197de7df3100
+  subjects:
+  - entities:
+    - role: player
+      name: Jack Wheeler
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: BCP-75
+  uuid: 2b0f87b0-18d2-4b1e-9e4b-a6228e6be394
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Torres
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: BCP-76
+  uuid: bc69f217-1035-40f7-bcdf-0dc2adb1ec14
+  subjects:
+  - entities:
+    - role: player
+      name: Esmerlyn Valdez
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: BCP-77
+  uuid: f969dfe1-c1ab-4a47-8ebf-c9c68aa05981
+  subjects:
+  - entities:
+    - role: player
+      name: Daniel Pierce
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: BCP-78
+  uuid: 84d0c148-569a-4ef6-b219-8a6c95f7a41b
+  subjects:
+  - entities:
+    - role: player
+      name: Dax Kilby
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: BCP-79
+  uuid: dd1ba47f-df9d-42a9-be5e-697744687f88
+  subjects:
+  - entities:
+    - role: player
+      name: Esteban Mejia
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: BCP-80
+  uuid: de749614-907f-4fae-87cd-1624fc99accb
+  subjects:
+  - entities:
+    - role: player
+      name: Thomas White
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: BCP-81
+  uuid: 0d11fe2f-ab00-482e-b4ca-d2ab99686dc9
+  subjects:
+  - entities:
+    - role: player
+      name: Jose Urbina
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: BCP-82
+  uuid: f4848e35-5c41-4e7d-971c-8efc3af6ef2a
+  subjects:
+  - entities:
+    - role: player
+      name: Edward Florentino
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: BCP-83
+  uuid: 0b85532e-ad8a-4d53-8bd8-70f023fc3d4e
+  subjects:
+  - entities:
+    - role: player
+      name: Josue De Paula
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: BCP-84
+  uuid: 521e15b1-5e2f-4461-9e8b-fc4eb0d6ff21
+  subjects:
+  - entities:
+    - role: player
+      name: David Hagaman
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: BCP-85
+  uuid: 6e868cfe-78ad-4767-ae1a-eb35dbfefa21
+  subjects:
+  - entities:
+    - role: player
+      name: Anthony Frobose
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: BCP-86
+  uuid: ae87abd3-dc80-44c7-94f2-0b7f206a332e
+  subjects:
+  - entities:
+    - role: player
+      name: Zyhir Hope
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: BCP-87
+  uuid: 41b41b64-58fd-4aed-9429-169fd2d18abf
+  subjects:
+  - entities:
+    - role: player
+      name: Jean Carlos Sio
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: BCP-88
+  uuid: 0fb3ab96-d25a-44d1-86a3-599f8ee8d129
+  subjects:
+  - entities:
+    - role: player
+      name: Dasan Hill
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: BCP-89
+  uuid: 28aca3a6-806c-42e1-8bd1-1fb9e8637791
+  subjects:
+  - entities:
+    - role: player
+      name: Kendry Martinez
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: BCP-90
+  uuid: f7462c00-72e2-49da-baa3-519fceeb3c04
+  subjects:
+  - entities:
+    - role: player
+      name: Andrew Tess
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: BCP-91
+  uuid: bd10afa1-b607-4721-952b-f462da5dff89
+  subjects:
+  - entities:
+    - role: player
+      name: Elian Peña
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: BCP-92
+  uuid: 0c662390-0355-41b0-947c-3f1b90edf6e9
+  subjects:
+  - entities:
+    - role: player
+      name: Konnor Griffin
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: BCP-93
+  uuid: c7309a55-eafe-46b0-813f-b44134b6f782
+  subjects:
+  - entities:
+    - role: player
+      name: Jorge Quintana
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: BCP-94
+  uuid: becbbfe2-be7e-4a35-9105-2eef937c30e2
+  subjects:
+  - entities:
+    - role: player
+      name: Ricardo Cova
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: BCP-95
+  uuid: 87ae765d-98e5-433e-bb13-696561dc4ccd
+  subjects:
+  - entities:
+    - role: player
+      name: Eli Willits
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: BCP-96
+  uuid: 1ed6c12d-69fa-48ee-89a8-d70022d1682a
+  subjects:
+  - entities:
+    - role: player
+      name: Jesús Made
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: BCP-97
+  uuid: 284a33c4-39cf-4e00-8a26-cea6a92fe56e
+  subjects:
+  - entities:
+    - role: player
+      name: Daniel Hernandez
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: BCP-98
+  uuid: 6bb58b6b-e95d-4230-ac66-62e99010d35c
+  subjects:
+  - entities:
+    - role: player
+      name: Walker Jenkins
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: BCP-99
+  uuid: 2d978fea-d68b-4ae0-94de-a8f2c9ca4fa4
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Rainer
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: BCP-100
+  uuid: a7181863-25a7-4d65-8ce2-401f6aea6a87
+  subjects:
+  - entities:
+    - role: player
+      name: Marconi German
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: BCP-101
+  uuid: 2c00cebc-43b1-4c4f-ab16-42ef66db71bd
+  subjects:
+  - entities:
+    - role: player
+      name: Kehden Hettiger
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: BCP-102
+  uuid: 3f930e4d-7585-4ffb-90a8-bef10b290b1a
+  subjects:
+  - entities:
+    - role: player
+      name: Eric Hartman
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: BCP-103
+  uuid: 39c04d22-8f2e-439f-8148-b1493c76124d
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Monistere
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: BCP-104
+  uuid: 6b595c0d-0cb8-4a55-abbe-0999c558b354
+  subjects:
+  - entities:
+    - role: player
+      name: Henry Lalane
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: BCP-105
+  uuid: 722f4c71-bfaa-4e32-87f3-3cae82e45d95
+  subjects:
+  - entities:
+    - role: player
+      name: Kade Snell
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: BCP-106
+  uuid: 3af69115-3571-4cd4-8ed8-1322b312802f
+  subjects:
+  - entities:
+    - role: player
+      name: Francisco Espinoza
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: BCP-107
+  uuid: 329a3a63-b973-4c3f-a97f-45f6559f39af
+  subjects:
+  - entities:
+    - role: player
+      name: Miguel Mendez
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: BCP-108
+  uuid: 19c217d4-56f3-4fa6-ab3f-3f0f6b16b1e5
+  subjects:
+  - entities:
+    - role: player
+      name: Colt Emerson
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: BCP-109
+  uuid: 3b87a3e1-5a2a-4f5d-bff3-af2658372ea1
+  subjects:
+  - entities:
+    - role: player
+      name: Truitt Madonna
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: BCP-110
+  uuid: 254bef48-2b36-47f7-9918-4fc414dd5b6e
+  subjects:
+  - entities:
+    - role: player
+      name: Matthew Ferrara
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: BCP-111
+  uuid: '0795fc50-cf84-4392-968f-729d3b75dca7'
+  subjects:
+  - entities:
+    - role: player
+      name: Carson Benge
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: BCP-112
+  uuid: 7857e14b-c93f-48d0-a9c9-28a056636afc
+  subjects:
+  - entities:
+    - role: player
+      name: Jamie Arnold
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: BCP-113
+  uuid: 28883a72-7b73-45b4-b66f-4833c2630740
+  subjects:
+  - entities:
+    - role: player
+      name: Josh Knoth
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: BCP-114
+  uuid: d8e5cac8-cec2-4545-b1ac-41d9bbf927c8
+  subjects:
+  - entities:
+    - role: player
+      name: Argenis Cayama
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: BCP-115
+  uuid: db008512-e99a-4d93-924c-4112e66ad606
+  subjects:
+  - entities:
+    - role: player
+      name: JJ Wetherholt
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: BCP-116
+  uuid: 0bbd585d-0711-433a-9387-dd1c85791c32
+  subjects:
+  - entities:
+    - role: player
+      name: Dauri Fernandez
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: BCP-117
+  uuid: 30152254-d241-4b41-a826-4fe99c64ab1f
+  subjects:
+  - entities:
+    - role: player
+      name: Victor Figueroa
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: BCP-118
+  uuid: 3ab1df08-f524-4a61-a7ef-4ccaa460c639
+  subjects:
+  - entities:
+    - role: player
+      name: Gabriel Rodriguez
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: BCP-119
+  uuid: 1e98d173-88a5-414d-948e-cb487136ca43
+  subjects:
+  - entities:
+    - role: player
+      name: Mathias Lacombe
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: BCP-120
+  uuid: 542c3262-f918-49ce-944b-2dc124fe5ebd
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Peña
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: BCP-121
+  uuid: ad1bf7a7-14eb-4e37-b9e1-c38bcd13dec5
+  subjects:
+  - entities:
+    - role: player
+      name: Keaton Anthony
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: BCP-122
+  uuid: 2684143d-1b09-4f88-aa29-292eed26c29c
+  subjects:
+  - entities:
+    - role: player
+      name: Sam Petersen
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: BCP-123
+  uuid: dcf32249-0cf7-4919-b2a5-86b01a4aaa05
+  subjects:
+  - entities:
+    - role: player
+      name: JR Ritchie
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: BCP-124
+  uuid: 0fab6021-5473-496c-bb6c-ad6a5f28ec18
+  subjects:
+  - entities:
+    - role: player
+      name: Riley Nelson
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: BCP-125
+  uuid: cebcfae1-be23-457a-ba6b-03eec7c643fe
+  subjects:
+  - entities:
+    - role: player
+      name: Wei-En Lin
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: BCP-126
+  uuid: c94b17f0-1d15-4651-8061-beff25797f85
+  subjects:
+  - entities:
+    - role: player
+      name: Gavin Fien
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: BCP-127
+  uuid: 356c7600-5601-42e0-af3e-b33ec52dfcaa
+  subjects:
+  - entities:
+    - role: player
+      name: Seojun Moon
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: BCP-128
+  uuid: b89e445a-56be-4612-a9ed-5f56f9778fd5
+  subjects:
+  - entities:
+    - role: player
+      name: Hector Ramos
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: BCP-129
+  uuid: 9c997558-7981-48f9-a790-fc7bcb6952ce
+  subjects:
+  - entities:
+    - role: player
+      name: Seaver King
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: BCP-130
+  uuid: f8abc27a-676f-402d-b735-b841e40308d1
+  subjects:
+  - entities:
+    - role: player
+      name: Kenly Hunter
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: BCP-131
+  uuid: f681a04b-f148-40a7-943e-147cb5a1cace
+  subjects:
+  - entities:
+    - role: player
+      name: Walker Janek
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: BCP-132
+  uuid: 1ad8d0b1-e83d-4fed-bf4e-36d213dfbde7
+  subjects:
+  - entities:
+    - role: player
+      name: Keyner Martinez
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: BCP-133
+  uuid: 89cc550c-0613-42fe-8d57-a1845370ace4
+  subjects:
+  - entities:
+    - role: player
+      name: Xavier Neyens
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: BCP-134
+  uuid: ff9cf022-ce65-41cc-be90-4ad205646b3e
+  subjects:
+  - entities:
+    - role: player
+      name: T.J. Rumfield
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: BCP-135
+  uuid: 8bdc97e0-4d08-4ff4-a40d-918568396509
+  subjects:
+  - entities:
+    - role: player
+      name: Wehiwa Aloy
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: BCP-136
+  uuid: db8b1f5d-09e7-4fc4-8320-13bbafbd0ec5
+  subjects:
+  - entities:
+    - role: player
+      name: Gavin Kilen
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: BCP-137
+  uuid: 3986d9e0-809b-47fd-824f-1d706418c8b4
+  subjects:
+  - entities:
+    - role: player
+      name: Braden Nett
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: BCP-138
+  uuid: e28ba4a8-dd74-47ef-8116-b81b11506e36
+  subjects:
+  - entities:
+    - role: player
+      name: Patrick Copen
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: BCP-139
+  uuid: 2e77e825-5d88-42e8-abde-5d181dc126bc
+  subjects:
+  - entities:
+    - role: player
+      name: Edgar Montero
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: BCP-140
+  uuid: 15ddbcb6-048b-4daa-bf7c-8435f3b66a15
+  subjects:
+  - entities:
+    - role: player
+      name: Pedro Ibarguen
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: BCP-141
+  uuid: 43b5185a-8fb7-4c8f-b581-be4ba0162a6e
+  subjects:
+  - entities:
+    - role: player
+      name: Justin Gonzales
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: BCP-142
+  uuid: 3cce9fc1-f26f-4451-9c77-a014c355e07b
+  subjects:
+  - entities:
+    - role: player
+      name: Brady Ebel
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: BCP-143
+  uuid: e3dfff08-a39d-4a4b-8225-c1152f1c5e1c
+  subjects:
+  - entities:
+    - role: player
+      name: Kaelen Culpepper
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: BCP-144
+  uuid: 4559af4a-1324-4f2b-8cc3-0ebadd353a5e
+  subjects:
+  - entities:
+    - role: player
+      name: Colby Shelton
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: BCP-145
+  uuid: 73224115-99cc-4221-bed2-b4d0349f4712
+  subjects:
+  - entities:
+    - role: player
+      name: Kevin McGonigle
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: BCP-146
+  uuid: a801e14f-4e03-489f-a779-e48afde31036
+  subjects:
+  - entities:
+    - role: player
+      name: Matt Klein
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: BCP-147
+  uuid: 977e1274-12ae-48fe-913c-445b87df0ce4
+  subjects:
+  - entities:
+    - role: player
+      name: JoJo Parker
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: BCP-148
+  uuid: 86685c4d-cd2d-42e4-bf07-d53a0cb739ff
+  subjects:
+  - entities:
+    - role: player
+      name: Dillon Lewis
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: BCP-149
+  uuid: 8c465018-1507-4847-be4d-812ed236d78c
+  subjects:
+  - entities:
+    - role: player
+      name: Andrew Fischer
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: BCP-150
+  uuid: 505f66ed-b09a-462d-aab0-6ea07f352eff
+  subjects:
+  - entities:
+    - role: player
+      name: Wilder Dalis
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 

--- a/data/baseball/2026-bowman/checklists/chrome-rookie-autographs.yaml
+++ b/data/baseball/2026-bowman/checklists/chrome-rookie-autographs.yaml
@@ -1,0 +1,130 @@
+- number: CRA-AF
+  uuid: dd3cce29-00ff-44da-a11c-627978690e25
+  subjects:
+  - entities:
+    - role: player
+      name: Alex Freeland
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: CRA-BH
+  uuid: 1879009a-18ab-41df-bc04-5eea2e68b5c4
+  subjects:
+  - entities:
+    - role: player
+      name: Brady House
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: CRA-CAG
+  uuid: 5c31ed37-6c7d-4266-ad48-307305d7bcc3
+  subjects:
+  - entities:
+    - role: player
+      name: Jac Caglianone
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: CRA-CB
+  uuid: f1c804eb-e47d-470e-ad1d-80106fb2c10e
+  subjects:
+  - entities:
+    - role: player
+      name: Chase Burns
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: CRA-CJ
+  uuid: ce2fa68a-5794-4489-8cc3-0940e8881ff7
+  subjects:
+  - entities:
+    - role: player
+      name: Carter Jensen
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: CRA-CK
+  uuid: a464e83b-3fe1-4dd5-87c7-dac80d397d3c
+  subjects:
+  - entities:
+    - role: player
+      name: C.J. Kayfus
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: CRA-CM
+  uuid: 5dfa7a6d-b412-4ee8-be59-dbfe034e05fd
+  subjects:
+  - entities:
+    - role: player
+      name: Christian Moore
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: CRA-JT
+  uuid: d72141e9-e23d-4f52-815c-a9850a15d276
+  subjects:
+  - entities:
+    - role: player
+      name: Jonah Tong
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: CRA-KO
+  uuid: 9638a46f-5876-4ae9-b862-e3a66d258531
+  subjects:
+  - entities:
+    - role: player
+      name: Kazuma Okamoto
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: CRA-MM
+  uuid: ffb0ce88-e74c-4093-b8b7-96e7e1b50bfd
+  subjects:
+  - entities:
+    - role: player
+      name: Munetaka Murakami
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: CRA-RA
+  uuid: 6fdf66da-e658-446a-8f88-3ad896be320e
+  subjects:
+  - entities:
+    - role: player
+      name: Roman Anthony
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: CRA-SS
+  uuid: dd504827-bce7-4d02-bdf8-88aa33797197
+  subjects:
+  - entities:
+    - role: player
+      name: Sal Stewart
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: CRA-TI
+  uuid: 93afd20c-3662-4917-9dab-c47879a5f4e0
+  subjects:
+  - entities:
+    - role: player
+      name: Tatsuya Imai
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 

--- a/data/baseball/2026-bowman/checklists/crystallized.yaml
+++ b/data/baseball/2026-bowman/checklists/crystallized.yaml
@@ -1,0 +1,200 @@
+- number: BWC-1
+  uuid: f00f2b52-af23-4215-b479-88ca08913631
+  subjects:
+  - entities:
+    - role: player
+      name: Aiva Arquette
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: BWC-2
+  uuid: 5510c28c-071a-495c-b0c4-a07f55832c0a
+  subjects:
+  - entities:
+    - role: player
+      name: Ronald Acuña Jr.
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: BWC-3
+  uuid: 3a8ca17c-b0d0-4e38-bcd0-a270f26674e5
+  subjects:
+  - entities:
+    - role: player
+      name: Marek Houston
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: BWC-4
+  uuid: 71927381-a32d-4893-ab8c-ba415a04d016
+  subjects:
+  - entities:
+    - role: player
+      name: Edward Florentino
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: BWC-5
+  uuid: 01cf23f3-8f5c-4cbb-be52-2dc4df6f5021
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Misiorowski
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: BWC-6
+  uuid: d12faa7b-6f2c-4a56-aff1-1bb1a75ef7da
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Eldridge
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: BWC-7
+  uuid: e1827b42-3e07-4860-8050-7b6617c7fd15
+  subjects:
+  - entities:
+    - role: player
+      name: Bobby Witt Jr.
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: BWC-8
+  uuid: cdc63cb4-d8b8-4c68-a8ed-171962432f54
+  subjects:
+  - entities:
+    - role: player
+      name: Aaron Judge
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: BWC-9
+  uuid: 7011e885-121b-4296-8297-3b0e99c5bd46
+  subjects:
+  - entities:
+    - role: player
+      name: Samuel Basallo
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: BWC-10
+  uuid: 948a1a34-e45c-4243-8680-41ae3756f6bb
+  subjects:
+  - entities:
+    - role: player
+      name: Daniel Pierce
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: BWC-11
+  uuid: f8654a9c-dff8-4b91-b446-222fb3814251
+  subjects:
+  - entities:
+    - role: player
+      name: Sal Stewart
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: BWC-12
+  uuid: 57ae3d0c-385d-464f-bd1f-cdf6cdc3b7a3
+  subjects:
+  - entities:
+    - role: player
+      name: Vladimir Guerrero Jr.
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: BWC-13
+  uuid: 6e353c01-4890-4926-a330-a104c03fdd61
+  subjects:
+  - entities:
+    - role: player
+      name: Jac Caglianone
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: BWC-14
+  uuid: 1d37d32d-ff0f-469f-8b4e-574f33ddc1d9
+  subjects:
+  - entities:
+    - role: player
+      name: Ethan Holliday
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: BWC-15
+  uuid: 7709dcac-889e-44e6-980a-2dadf7949a26
+  subjects:
+  - entities:
+    - role: player
+      name: Bubba Chandler
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: BWC-16
+  uuid: 7e17d817-3cf8-4b7f-972a-6bcc4470bd64
+  subjects:
+  - entities:
+    - role: player
+      name: Paul Skenes
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: BWC-17
+  uuid: 4555e1ec-3868-43c8-a23e-b0cae2e01643
+  subjects:
+  - entities:
+    - role: player
+      name: Colson Montgomery
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: BWC-18
+  uuid: a67c2f0f-3274-4a5d-b240-28fe38ba5d1e
+  subjects:
+  - entities:
+    - role: player
+      name: Roman Anthony
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: BWC-19
+  uuid: e34078d8-8be4-4f4b-9f9e-9b5bd36c0638
+  subjects:
+  - entities:
+    - role: player
+      name: Shohei Ohtani
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: BWC-20
+  uuid: 1d182a1e-e756-49aa-8b87-88942af931d3
+  subjects:
+  - entities:
+    - role: player
+      name: Francisco Lindor
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 

--- a/data/baseball/2026-bowman/checklists/draft-pick-pairings.yaml
+++ b/data/baseball/2026-bowman/checklists/draft-pick-pairings.yaml
@@ -159,7 +159,7 @@
       name: Evan Longoria
       ref: 
     - role: team
-      name: Tampa Bay Devil Rays
+      name: Tampa Bay Rays
       ref: 
   - entities:
     - role: player

--- a/data/baseball/2026-bowman/checklists/draft-pick-pairings.yaml
+++ b/data/baseball/2026-bowman/checklists/draft-pick-pairings.yaml
@@ -1,0 +1,272 @@
+- number: DPPA-BB
+  uuid: 02f7856b-c3a1-4908-85e3-2e5b65eba066
+  subjects:
+  - entities:
+    - role: player
+      name: Byron Buxton
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+  - entities:
+    - role: player
+      name: Kris Bryant
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: DPPA-BBR
+  uuid: cca1978e-cb07-4fe0-8f5b-176404243944
+  subjects:
+  - entities:
+    - role: player
+      name: Chase Burns
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+  - entities:
+    - role: player
+      name: Tyler Bremner
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: DPPA-BC
+  uuid: a68c3cfc-0a18-48da-ae7d-8c27ed023243
+  subjects:
+  - entities:
+    - role: player
+      name: Dylan Crews
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+  - entities:
+    - role: player
+      name: Alex Bregman
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: DPPA-BW
+  uuid: c1e59726-2db7-4769-b897-6012511beee9
+  subjects:
+  - entities:
+    - role: player
+      name: Alex Bregman
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+  - entities:
+    - role: player
+      name: Bobby Witt Jr.
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: DPPA-BWI
+  uuid: 2a005e64-c7b4-4955-a3c8-0e2ad51a78bb
+  subjects:
+  - entities:
+    - role: player
+      name: Travis Bazzana
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+  - entities:
+    - role: player
+      name: Eli Willits
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: DPPA-CA
+  uuid: 45e20b14-da5f-40ce-9051-9f05bd69cc56
+  subjects:
+  - entities:
+    - role: player
+      name: Kade Anderson
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+  - entities:
+    - role: player
+      name: Charlie Condon
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: DPPA-GR
+  uuid: a7c9ae0d-c790-47c1-bb46-b7006bcb50db
+  subjects:
+  - entities:
+    - role: player
+      name: Alex Rodriguez
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+  - entities:
+    - role: player
+      name: Ken Griffey Jr.
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: DPPA-JC
+  uuid: d93c5c2c-7931-47f6-b70f-0fca746dcc19
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Jobe
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+  - entities:
+    - role: player
+      name: Max Clark
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: DPPA-LK
+  uuid: 2e023ba3-65f0-4d54-b99a-1f23e2042a91
+  subjects:
+  - entities:
+    - role: player
+      name: Wyatt Langford
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+  - entities:
+    - role: player
+      name: Nick Kurtz
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: DPPA-LM
+  uuid: dd691a42-5b4c-4fca-a5db-3823e219643b
+  subjects:
+  - entities:
+    - role: player
+      name: Evan Longoria
+      ref: 
+    - role: team
+      name: Tampa Bay Devil Rays
+      ref: 
+  - entities:
+    - role: player
+      name: Manny Machado
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: DPPA-MS
+  uuid: aee34b1d-3626-4a8b-aba4-c9cb5e3e66d4
+  subjects:
+  - entities:
+    - role: player
+      name: Max Scherzer
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+  - entities:
+    - role: player
+      name: Andrew McCutchen
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: DPPA-RH
+  uuid: 549fcc7c-8524-4e22-bc61-2f3e9aade500
+  subjects:
+  - entities:
+    - role: player
+      name: Adley Rutschman
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+  - entities:
+    - role: player
+      name: Jackson Holliday
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: DPPA-SD
+  uuid: aee81b24-4441-4f60-a3f6-d60bf1c00428
+  subjects:
+  - entities:
+    - role: player
+      name: Hagen Smith
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+  - entities:
+    - role: player
+      name: Liam Doyle
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: DPPA-SS
+  uuid: 863b4af0-3668-43e6-994b-193fa8d0b39f
+  subjects:
+  - entities:
+    - role: player
+      name: Stephen Strasburg
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+  - entities:
+    - role: player
+      name: Paul Skenes
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: DPPA-WC
+  uuid: c9ff8790-b558-4f4a-a1d8-0c1dff8eaed6
+  subjects:
+  - entities:
+    - role: player
+      name: Jac Caglianone
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+  - entities:
+    - role: player
+      name: Jacob Wilson
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: DPPA-WL
+  uuid: e4a81101-7d08-4c96-821c-efab0e1c998d
+  subjects:
+  - entities:
+    - role: player
+      name: Dave Winfield
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+  - entities:
+    - role: player
+      name: Barry Larkin
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 

--- a/data/baseball/2026-bowman/checklists/electric-sluggers-autographs.yaml
+++ b/data/baseball/2026-bowman/checklists/electric-sluggers-autographs.yaml
@@ -1,0 +1,140 @@
+- number: ESA-1
+  uuid: 4112c992-5fd4-4c7e-93a8-5c74c70f5634
+  subjects:
+  - entities:
+    - role: player
+      name: Samuel Basallo
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: ESA-2
+  uuid: 4ee3a6f8-19a5-4d26-b807-43f65a84bd07
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Eldridge
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: ESA-3
+  uuid: c2a2b817-b7f8-41d1-a3a4-3fd5fdc00efc
+  subjects:
+  - entities:
+    - role: player
+      name: Ethan Holliday
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: ESA-4
+  uuid: 1e94951c-494b-4f16-95fd-b21c61ac0f07
+  subjects:
+  - entities:
+    - role: player
+      name: Konnor Griffin
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: ESA-5
+  uuid: bbc7e521-1433-4f95-90a5-f1dade5718c5
+  subjects:
+  - entities:
+    - role: player
+      name: Jesús Made
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: ESA-6
+  uuid: '09cc3432-a6c6-4f71-92e1-03a19762b5c1'
+  subjects:
+  - entities:
+    - role: player
+      name: JJ Wetherholt
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: ESA-7
+  uuid: a3b908c0-7959-4c49-84ed-b2c232e5a0cc
+  subjects:
+  - entities:
+    - role: player
+      name: Roman Anthony
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: ESA-8
+  uuid: 8887da8f-45af-451d-8f76-b4e2774d2096
+  subjects:
+  - entities:
+    - role: player
+      name: Jac Caglianone
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: ESA-9
+  uuid: 1b3e7a65-f56a-4797-8fc8-1cdaee6ca68a
+  subjects:
+  - entities:
+    - role: player
+      name: Vladimir Guerrero Jr.
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: ESA-10
+  uuid: e36b8c1a-e469-4282-ae4f-ed86f3817afd
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: ESA-11
+  uuid: 2b764453-c9e0-42e9-ac51-1425fd1043af
+  subjects:
+  - entities:
+    - role: player
+      name: Ronald Acuña Jr.
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: ESA-12
+  uuid: 76077660-dd86-4afb-92f4-f21bfd63c465
+  subjects:
+  - entities:
+    - role: player
+      name: Cal Raleigh
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: ESA-13
+  uuid: 48d74a95-1415-4dbb-b36a-8932a48c0a84
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Kurtz
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: ESA-14
+  uuid: 3c406d43-920f-45c4-8136-c7fca4a1d42b
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Trout
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 

--- a/data/baseball/2026-bowman/checklists/electric-sluggers.yaml
+++ b/data/baseball/2026-bowman/checklists/electric-sluggers.yaml
@@ -1,0 +1,250 @@
+- number: ES-1
+  uuid: 0fe06f7f-a8c4-4d39-a70c-4aa5304b9bf0
+  subjects:
+  - entities:
+    - role: player
+      name: Francisco Lindor
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: ES-2
+  uuid: bbf001d0-a4f0-4496-a41b-ce770cefe60d
+  subjects:
+  - entities:
+    - role: player
+      name: Vladimir Guerrero Jr.
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: ES-3
+  uuid: fd429ec4-73d9-4821-a4b4-a47980208a93
+  subjects:
+  - entities:
+    - role: player
+      name: Fernando Tatis Jr.
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: ES-4
+  uuid: a58b00a0-4573-4dcc-b8a7-226850e1da32
+  subjects:
+  - entities:
+    - role: player
+      name: Junior Caminero
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: ES-5
+  uuid: b391608f-5896-4669-afdb-d250a274b065
+  subjects:
+  - entities:
+    - role: player
+      name: Mookie Betts
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: ES-6
+  uuid: 16503891-fc9c-4e1f-904c-c605339ff147
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Harper
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: ES-7
+  uuid: 3be84a88-42a0-41d9-9542-346aa6189f67
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: ES-8
+  uuid: 8075aa0c-9db7-4a26-a8c5-4fb50d1c330b
+  subjects:
+  - entities:
+    - role: player
+      name: Ronald Acuña Jr.
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: ES-9
+  uuid: b455b777-744b-4029-8681-f102ee5a421a
+  subjects:
+  - entities:
+    - role: player
+      name: Elly De La Cruz
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: ES-10
+  uuid: 6d7b005e-b835-46d5-bcf7-faace1627bf9
+  subjects:
+  - entities:
+    - role: player
+      name: Samuel Basallo
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: ES-11
+  uuid: f0eff619-cb12-442d-ad28-7f96c7fcf296
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Eldridge
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: ES-12
+  uuid: d3b1126a-f385-485c-abdd-53e0c96cf8d6
+  subjects:
+  - entities:
+    - role: player
+      name: JJ Wetherholt
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: ES-13
+  uuid: e3b2a065-8c05-4a36-af39-a3b13274816b
+  subjects:
+  - entities:
+    - role: player
+      name: Ethan Holliday
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: ES-14
+  uuid: 3d4c7c1e-acb8-449e-9ef3-f150858deec3
+  subjects:
+  - entities:
+    - role: player
+      name: Cal Raleigh
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: ES-15
+  uuid: 4dcc6b76-8a02-45ce-aa27-3febcc05be2e
+  subjects:
+  - entities:
+    - role: player
+      name: Aaron Judge
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: ES-16
+  uuid: de70ddc6-f527-440e-a2a4-f8a5ffac9932
+  subjects:
+  - entities:
+    - role: player
+      name: Roman Anthony
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: ES-17
+  uuid: '0595937a-cae8-4b4d-a1fa-0b55d7364909'
+  subjects:
+  - entities:
+    - role: player
+      name: Konnor Griffin
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: ES-18
+  uuid: be7a1e31-5d71-4761-b15f-fd70b7e75653
+  subjects:
+  - entities:
+    - role: player
+      name: Shohei Ohtani
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: ES-19
+  uuid: 5ab21daa-6777-4a2e-b2d9-a3b70f393e0a
+  subjects:
+  - entities:
+    - role: player
+      name: Bobby Witt Jr.
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: ES-20
+  uuid: 1dd25bca-03e9-47c8-8b51-72e146184341
+  subjects:
+  - entities:
+    - role: player
+      name: Jesús Made
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: ES-21
+  uuid: 78e5ab6d-013a-4610-9f33-d63e47fc2c95
+  subjects:
+  - entities:
+    - role: player
+      name: Aiva Arquette
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: ES-22
+  uuid: fc3b2b5c-b715-43af-afa0-a1d6a3de03a2
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Kurtz
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: ES-23
+  uuid: 9ab6b087-3f88-4a38-8ee2-cfd026296cba
+  subjects:
+  - entities:
+    - role: player
+      name: Jac Caglianone
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: ES-24
+  uuid: f67660d7-20e3-4d64-8a21-5936db27dba0
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Crow-Armstrong
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: ES-25
+  uuid: 7a97c1cd-abf7-4bfb-b494-93d234ff9cd6
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Trout
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 

--- a/data/baseball/2026-bowman/checklists/final-draft.yaml
+++ b/data/baseball/2026-bowman/checklists/final-draft.yaml
@@ -1,0 +1,200 @@
+- number: FD-1
+  uuid: 1659ec9a-ce6f-4aa7-9b6d-f52035fc002b
+  subjects:
+  - entities:
+    - role: player
+      name: Derek Jeter
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: FD-2
+  uuid: 39ede2f2-0226-405e-a60c-affe2ccba94b
+  subjects:
+  - entities:
+    - role: player
+      name: Ken Griffey Jr.
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: FD-3
+  uuid: dc174c89-45e4-4e0b-88b5-b9152543d0ff
+  subjects:
+  - entities:
+    - role: player
+      name: Ethan Holliday
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: FD-4
+  uuid: 3f429b43-b26e-462e-9ff4-2aa07dcc36b3
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Eldridge
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: FD-5
+  uuid: bfed29b0-3d0b-4048-a315-7cbaed73ddee
+  subjects:
+  - entities:
+    - role: player
+      name: Munetaka Murakami
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: FD-6
+  uuid: 1bef75b3-b403-4975-b9a4-6debb452d376
+  subjects:
+  - entities:
+    - role: player
+      name: Ronald Acuña Jr.
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: FD-7
+  uuid: d7bc6a67-eaee-4a46-8559-f365f40e28a2
+  subjects:
+  - entities:
+    - role: player
+      name: Samuel Basallo
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: FD-8
+  uuid: fac4cc51-4a1d-4e25-bf76-3658a5aaee0e
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Misiorowski
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: FD-9
+  uuid: 388d34f8-4c22-478a-95a5-cf5e51d99cf1
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: FD-10
+  uuid: 370462c8-4b95-488d-ad24-e73b4a2eb2ec
+  subjects:
+  - entities:
+    - role: player
+      name: Jac Caglianone
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: FD-11
+  uuid: d84895e5-30e5-40e1-ae34-395fb0054a84
+  subjects:
+  - entities:
+    - role: player
+      name: Shohei Ohtani
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: FD-12
+  uuid: 7ea72bd2-46b9-4c05-9b48-05a90ac211e8
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Kurtz
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: FD-13
+  uuid: a383b9d9-0d0b-426c-ae6f-31035b98ee6e
+  subjects:
+  - entities:
+    - role: player
+      name: Roman Anthony
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: FD-14
+  uuid: ff32f4fc-c09d-4ad8-9b36-7f5bd54f51e4
+  subjects:
+  - entities:
+    - role: player
+      name: Paul Skenes
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: FD-15
+  uuid: f5b1eccb-fdf0-4133-81b3-2357c6b4d29c
+  subjects:
+  - entities:
+    - role: player
+      name: Manny Ramirez
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: FD-16
+  uuid: 846a18ee-3ac7-4982-b84f-f735c3a703b6
+  subjects:
+  - entities:
+    - role: player
+      name: Mark McGwire
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: FD-17
+  uuid: aea3db4b-5146-465b-bb85-9d84f95ef95b
+  subjects:
+  - entities:
+    - role: player
+      name: Elly De La Cruz
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: FD-18
+  uuid: 4b81ce51-cf0c-4027-b3cd-ec79c0c6cd44
+  subjects:
+  - entities:
+    - role: player
+      name: Konnor Griffin
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: FD-19
+  uuid: d0c5129f-ad58-4429-b0d7-3c84b629c4b8
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Harper
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: FD-20
+  uuid: c4277ba8-62c1-44e3-a39b-4ba3b8b4a8ce
+  subjects:
+  - entities:
+    - role: player
+      name: Cal Raleigh
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 

--- a/data/baseball/2026-bowman/checklists/patchwork.yaml
+++ b/data/baseball/2026-bowman/checklists/patchwork.yaml
@@ -1,0 +1,300 @@
+- number: P-1
+  uuid: 9daa894c-e4e8-4847-b0b8-72d867b5e8af
+  subjects:
+  - entities:
+    - role: player
+      name: Ceddanne Rafaela
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: P-2
+  uuid: 874db8da-5af4-469c-b4eb-490dd6bf9a52
+  subjects:
+  - entities:
+    - role: player
+      name: Josue De Paula
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: P-3
+  uuid: 58c7365a-5855-4fa9-ad82-e834512c0691
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Chourio
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: P-4
+  uuid: 9ee799c2-bf39-4d3b-bd49-3b02bf23ecdc
+  subjects:
+  - entities:
+    - role: player
+      name: Colson Montgomery
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: P-5
+  uuid: b2b1c153-286c-45fe-882c-aa8b48f09606
+  subjects:
+  - entities:
+    - role: player
+      name: Konnor Griffin
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: P-6
+  uuid: 0e35c6f4-d17d-4f52-8928-6bdb34dddaff
+  subjects:
+  - entities:
+    - role: player
+      name: Francisco Lindor
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: P-7
+  uuid: 65542ace-bce5-4d72-86c5-11b3659be9ad
+  subjects:
+  - entities:
+    - role: player
+      name: Shohei Ohtani
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: P-8
+  uuid: 610e8978-bc6e-4ff3-9984-6e38789cfa51
+  subjects:
+  - entities:
+    - role: player
+      name: Sebastian Walcott
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: P-9
+  uuid: 29777457-e31d-4749-996d-9e2c31d6fb07
+  subjects:
+  - entities:
+    - role: player
+      name: Vladimir Guerrero Jr.
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: P-10
+  uuid: 6fd53a09-abb2-490e-83e8-6dbef2b8724c
+  subjects:
+  - entities:
+    - role: player
+      name: Yoshinobu Yamamoto
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: P-11
+  uuid: e46132a3-d61e-43e4-8ec1-03d3b49113ba
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Eldridge
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: P-12
+  uuid: 5444ab11-edb4-45be-8f87-308522504fd6
+  subjects:
+  - entities:
+    - role: player
+      name: Ichiro
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: P-13
+  uuid: 8bd1ad67-bb4f-4768-93fe-849c70d6936b
+  subjects:
+  - entities:
+    - role: player
+      name: Cal Ripken Jr.
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: P-14
+  uuid: 6bb18138-5adc-4334-8e78-45b455487490
+  subjects:
+  - entities:
+    - role: player
+      name: Andrew Mccutchen
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: P-15
+  uuid: 9d8e16b1-e573-4dfa-ae2b-416cc9b9507d
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: P-16
+  uuid: 2b12ab48-7c81-412b-aa73-76df7bba8544
+  subjects:
+  - entities:
+    - role: player
+      name: Manny Machado
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: P-17
+  uuid: a38fd5b7-90e6-452e-8618-d1990452c68c
+  subjects:
+  - entities:
+    - role: player
+      name: Jesús Made
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: P-18
+  uuid: 1c6fb873-6122-4e10-9b18-9b863b760c37
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Harper
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: P-19
+  uuid: 5dc3d61c-de1d-44ef-b36d-76b31d6e18d7
+  subjects:
+  - entities:
+    - role: player
+      name: Roki Sasaki
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: P-20
+  uuid: c52874f6-9636-4be7-be1b-e13de12aaef1
+  subjects:
+  - entities:
+    - role: player
+      name: George Lombard Jr.
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: P-21
+  uuid: 96406b58-8c72-4e23-8361-f516ce42bb4e
+  subjects:
+  - entities:
+    - role: player
+      name: Charlie Condon
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: P-22
+  uuid: 863e130c-0c6f-4871-9ff0-4aaf2f736e65
+  subjects:
+  - entities:
+    - role: player
+      name: Tony Gwynn
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: P-23
+  uuid: c1262765-5479-411d-a35d-d8b381c6133b
+  subjects:
+  - entities:
+    - role: player
+      name: Jac Caglianone
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: P-24
+  uuid: f85cbe67-28ea-434d-af5b-7303a69310d5
+  subjects:
+  - entities:
+    - role: player
+      name: Fernando Tatis Jr.
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: P-25
+  uuid: 261ca33e-b4cd-440d-9b93-cc953ff23dc3
+  subjects:
+  - entities:
+    - role: player
+      name: Max Clark
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: P-26
+  uuid: 0c7ed2d2-2f47-4e80-8cb2-eaa973c57626
+  subjects:
+  - entities:
+    - role: player
+      name: Junior Caminero
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: P-27
+  uuid: 94454a67-9a1c-44ef-b942-b1a3e0157414
+  subjects:
+  - entities:
+    - role: player
+      name: José Ramírez
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: P-28
+  uuid: 3e69348f-0609-4532-8453-675e00608644
+  subjects:
+  - entities:
+    - role: player
+      name: Jim Thome
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: P-29
+  uuid: 2411b353-6606-46b5-80b2-4be398449df8
+  subjects:
+  - entities:
+    - role: player
+      name: JJ Wetherholt
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: P-30
+  uuid: d74f1a71-bace-4b44-863f-131f087263a9
+  subjects:
+  - entities:
+    - role: player
+      name: James Wood
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 

--- a/data/baseball/2026-bowman/checklists/patchwork.yaml
+++ b/data/baseball/2026-bowman/checklists/patchwork.yaml
@@ -133,7 +133,7 @@
   subjects:
   - entities:
     - role: player
-      name: Andrew Mccutchen
+      name: Andrew McCutchen
       ref: 
     - role: team
       name: Pittsburgh Pirates

--- a/data/baseball/2026-bowman/checklists/power-chords-autographs.yaml
+++ b/data/baseball/2026-bowman/checklists/power-chords-autographs.yaml
@@ -1,0 +1,150 @@
+- number: PCA-1
+  uuid: f772d2ac-2eae-4e53-9d5b-92a9fe71623f
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Trout
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: PCA-2
+  uuid: 5a4bfd22-c9a3-4d92-9c3f-24542c907ab1
+  subjects:
+  - entities:
+    - role: player
+      name: Ronald Acuña Jr.
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: PCA-3
+  uuid: 71374614-83f1-4e62-90bd-8b43a9e3916e
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: PCA-4
+  uuid: dd0da4f1-d307-4c34-917e-3a5a7ed20594
+  subjects:
+  - entities:
+    - role: player
+      name: Junior Caminero
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: PCA-5
+  uuid: 30d0fed5-e9a1-4bcc-a177-7c26af2fed08
+  subjects:
+  - entities:
+    - role: player
+      name: Kevin McGonigle
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: PCA-6
+  uuid: 9126572d-dda1-45e1-951e-a00aa2a2afea
+  subjects:
+  - entities:
+    - role: player
+      name: JJ Wetherholt
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: PCA-7
+  uuid: c8b998fe-231d-4a6a-954a-f8eb97e1f79f
+  subjects:
+  - entities:
+    - role: player
+      name: Cal Raleigh
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: PCA-8
+  uuid: a3724ca3-4b51-4595-ade4-c84e6faab848
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Eldridge
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: PCA-9
+  uuid: c353481b-cfdd-4eb2-af30-a053a1102a24
+  subjects:
+  - entities:
+    - role: player
+      name: Walker Jenkins
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: PCA-10
+  uuid: 91ce4b6c-636c-44ba-b1d1-b97c481f00a5
+  subjects:
+  - entities:
+    - role: player
+      name: Edward Florentino
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: PCA-11
+  uuid: b0d38b1b-9cd5-4ab4-ae1c-029762121826
+  subjects:
+  - entities:
+    - role: player
+      name: Christian Moore
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: PCA-12
+  uuid: 22ac6bc0-3ff2-436d-9785-a9ed1412752d
+  subjects:
+  - entities:
+    - role: player
+      name: Samuel Basallo
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: PCA-13
+  uuid: 78069677-d3f4-46b2-a681-fb1292c8f0a6
+  subjects:
+  - entities:
+    - role: player
+      name: Roman Anthony
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: PCA-14
+  uuid: f9e18324-dd64-4bbe-b5bf-399aed98bbec
+  subjects:
+  - entities:
+    - role: player
+      name: Jac Caglianone
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: PCA-15
+  uuid: 70c31a8e-b511-44c6-a62b-915dbceeaf48
+  subjects:
+  - entities:
+    - role: player
+      name: Ethan Holliday
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 

--- a/data/baseball/2026-bowman/checklists/power-chords.yaml
+++ b/data/baseball/2026-bowman/checklists/power-chords.yaml
@@ -1,0 +1,250 @@
+- number: PC-1
+  uuid: bfe68205-d3f1-41d3-97a9-5447d31b2bfd
+  subjects:
+  - entities:
+    - role: player
+      name: Aaron Judge
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: PC-2
+  uuid: 322b017c-4208-4bd0-95a2-0b71e2d58be2
+  subjects:
+  - entities:
+    - role: player
+      name: Charlie Condon
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: PC-3
+  uuid: e42e8b52-183e-40e4-ab2e-1a58ee83cd99
+  subjects:
+  - entities:
+    - role: player
+      name: Ronald Acuña Jr.
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: PC-4
+  uuid: 23a34c51-13be-4096-9873-66331c031eb9
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Chourio
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: PC-5
+  uuid: 90e14954-2e23-4e38-bb36-2ce756aaf1c8
+  subjects:
+  - entities:
+    - role: player
+      name: JJ Wetherholt
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: PC-6
+  uuid: fd44e5d6-40f7-4225-a78c-b3ea2f0cdc12
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Kurtz
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: PC-7
+  uuid: c07e5ad4-aa6f-42ff-99e7-c408239325ef
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Harper
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: PC-8
+  uuid: d0fccc92-f533-448f-a1a4-f7697e16c1d2
+  subjects:
+  - entities:
+    - role: player
+      name: Walker Jenkins
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: PC-9
+  uuid: 1c829912-ad83-4093-bd18-23b1bd62b842
+  subjects:
+  - entities:
+    - role: player
+      name: Vladimir Guerrero Jr.
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: PC-10
+  uuid: fcc40983-2c5e-488f-97be-10ff0bb51590
+  subjects:
+  - entities:
+    - role: player
+      name: Edward Florentino
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: PC-11
+  uuid: ceaf3ad2-9294-404e-8ff4-55a0c0218490
+  subjects:
+  - entities:
+    - role: player
+      name: Shohei Ohtani
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: PC-12
+  uuid: b147c10b-d304-4f62-a2ca-a6bd340d7068
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: PC-13
+  uuid: dad5ddcc-3667-4379-a22b-1d8b05ac80cb
+  subjects:
+  - entities:
+    - role: player
+      name: Bobby Witt Jr.
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: PC-14
+  uuid: b69724ef-7474-4098-8d76-8fdb5d558454
+  subjects:
+  - entities:
+    - role: player
+      name: Roman Anthony
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: PC-15
+  uuid: a76789c4-75eb-435e-86c4-e427d26c1c59
+  subjects:
+  - entities:
+    - role: player
+      name: Kevin McGonigle
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: PC-16
+  uuid: 5b727b98-8db7-4aa6-b466-6d8eba55fa58
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Eldridge
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: PC-17
+  uuid: 1f0adf0b-27c5-41f2-8848-2d04d56160a8
+  subjects:
+  - entities:
+    - role: player
+      name: Jac Caglianone
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: PC-18
+  uuid: ce048c2d-7f6e-41a7-b558-29a63a4cdbae
+  subjects:
+  - entities:
+    - role: player
+      name: Aiva Arquette
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: PC-19
+  uuid: 195e3fbc-8a94-4406-853b-4099987d6a39
+  subjects:
+  - entities:
+    - role: player
+      name: Christian Moore
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: PC-20
+  uuid: 90b6f10c-ea21-40fd-8a7b-34b2c9aac238
+  subjects:
+  - entities:
+    - role: player
+      name: Ethan Holliday
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: PC-21
+  uuid: db7b7cd8-42e1-4410-af2f-4de0eca4a1da
+  subjects:
+  - entities:
+    - role: player
+      name: Cal Raleigh
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: PC-22
+  uuid: a673bbc3-3a52-4134-8e15-b03b70745fad
+  subjects:
+  - entities:
+    - role: player
+      name: Fernando Tatis Jr.
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: PC-23
+  uuid: bd7746c2-96f8-4b6c-90c7-3ae38ed07807
+  subjects:
+  - entities:
+    - role: player
+      name: Junior Caminero
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: PC-24
+  uuid: 48b1343f-7c59-460a-8c4b-62bfbe24fb8f
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Trout
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: PC-25
+  uuid: 4fbf2a4e-46ff-4e8c-aa8a-d87d750421aa
+  subjects:
+  - entities:
+    - role: player
+      name: Samuel Basallo
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 

--- a/data/baseball/2026-bowman/checklists/ultimate-autograph-booklet.yaml
+++ b/data/baseball/2026-bowman/checklists/ultimate-autograph-booklet.yaml
@@ -1,0 +1,171 @@
+- number: UAC-1
+  uuid: f3a451a7-e30d-4afc-91b7-b0c86e732326
+  subjects:
+  - entities:
+    - role: player
+      name: Josuar Gonzalez
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+  - entities:
+    - role: player
+      name: Edward Florentino
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+  - entities:
+    - role: player
+      name: Luis Peña
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+  - entities:
+    - role: player
+      name: Zyhir Hope
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+  - entities:
+    - role: player
+      name: Carson Benge
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+  - entities:
+    - role: player
+      name: JoJo Parker
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+  - entities:
+    - role: player
+      name: Steele Hall
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+  - entities:
+    - role: player
+      name: Seth Hernandez
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+  - entities:
+    - role: player
+      name: Liam Doyle
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+  - entities:
+    - role: player
+      name: Kade Anderson
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+  - entities:
+    - role: player
+      name: Billy Carlson
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+  - entities:
+    - role: player
+      name: George Lombard Jr.
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+  - entities:
+    - role: player
+      name: Charlie Condon
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+  - entities:
+    - role: player
+      name: JJ Wetherholt
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+  - entities:
+    - role: player
+      name: Jesús Made
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+  - entities:
+    - role: player
+      name: Leo De Vries
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+  - entities:
+    - role: player
+      name: Kevin McGonigle
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+  - entities:
+    - role: player
+      name: Walker Jenkins
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+  - entities:
+    - role: player
+      name: Travis Bazzana
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+  - entities:
+    - role: player
+      name: Bryce Rainer
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+  - entities:
+    - role: player
+      name: Ethan Holliday
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+  - entities:
+    - role: player
+      name: Eli Willits
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+  - entities:
+    - role: player
+      name: Colt Emerson
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+  - entities:
+    - role: player
+      name: Konnor Griffin
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 

--- a/data/baseball/2026-bowman/checklists/under-the-radar-autographs.yaml
+++ b/data/baseball/2026-bowman/checklists/under-the-radar-autographs.yaml
@@ -1,0 +1,130 @@
+- number: UTRA-1
+  uuid: 1b8a0de9-074f-4cf6-ab33-b6d1a4188291
+  subjects:
+  - entities:
+    - role: player
+      name: Connelly Early
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: UTRA-2
+  uuid: 15efab3e-5516-453f-9e93-f75feb1e837a
+  subjects:
+  - entities:
+    - role: player
+      name: Samuel Basallo
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: UTRA-3
+  uuid: 8f783b3f-5de3-4c76-85a1-e5a5567949ab
+  subjects:
+  - entities:
+    - role: player
+      name: Cam Schlittler
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: UTRA-4
+  uuid: bcfbeb1c-9810-40bd-8a08-63d9739a36f9
+  subjects:
+  - entities:
+    - role: player
+      name: Trey Yesavage
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: UTRA-5
+  uuid: 3de82923-5801-4932-bec4-cc7776da0c53
+  subjects:
+  - entities:
+    - role: player
+      name: Carson Benge
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: UTRA-6
+  uuid: c8cec429-7089-4d7f-b159-9cc5cc78d2f7
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Teel
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: UTRA-7
+  uuid: e031a324-1b58-4739-90fa-1efd46817d79
+  subjects:
+  - entities:
+    - role: player
+      name: Sal Stewart
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: UTRA-8
+  uuid: 648dcf79-48e9-4176-8817-ac58fd2751c4
+  subjects:
+  - entities:
+    - role: player
+      name: Franklin Arias
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: UTRA-9
+  uuid: 76b8175f-b882-408a-99a6-fa092e9b7621
+  subjects:
+  - entities:
+    - role: player
+      name: Josue De Paula
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: UTRA-10
+  uuid: faf7c975-05f0-4c16-8251-fa3c05eda9e4
+  subjects:
+  - entities:
+    - role: player
+      name: Kaelen Culpepper
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: UTRA-11
+  uuid: 0bffdee1-4b0e-4b62-b4be-c77606b9f11a
+  subjects:
+  - entities:
+    - role: player
+      name: Edward Florentino
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: UTRA-12
+  uuid: e6351db5-3e06-45a7-bda0-b2d3470d1760
+  subjects:
+  - entities:
+    - role: player
+      name: Colt Emerson
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: UTRA-13
+  uuid: 8b3014b1-6356-4edb-9ef9-fe839ce4f317
+  subjects:
+  - entities:
+    - role: player
+      name: Kevin McGonigle
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 

--- a/data/baseball/2026-bowman/checklists/under-the-radar.yaml
+++ b/data/baseball/2026-bowman/checklists/under-the-radar.yaml
@@ -1,0 +1,200 @@
+- number: UR-1
+  uuid: 624b6c63-703b-4207-b4bf-974dcd49e347
+  subjects:
+  - entities:
+    - role: player
+      name: Kevin McGonigle
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: UR-2
+  uuid: ede39e7e-b71a-42af-9750-43f1ed895864
+  subjects:
+  - entities:
+    - role: player
+      name: Cam Schlittler
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: UR-3
+  uuid: 90105701-1698-4a0e-b2fd-856d8eeabbf7
+  subjects:
+  - entities:
+    - role: player
+      name: Jhonny Level
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: UR-4
+  uuid: 501f779c-68dd-49ed-8cbc-2501ff781147
+  subjects:
+  - entities:
+    - role: player
+      name: Colt Emerson
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: UR-5
+  uuid: f7aacfa7-9be8-4c63-8593-d73f630b944d
+  subjects:
+  - entities:
+    - role: player
+      name: Franklin Arias
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: UR-6
+  uuid: 3382b548-8e5c-4358-855c-76c5731f975a
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Teel
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: UR-7
+  uuid: 50bd550e-7b10-4313-888d-353d7168e0f3
+  subjects:
+  - entities:
+    - role: player
+      name: Rainiel Rodriguez
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: UR-8
+  uuid: 0b56e004-2852-4945-9661-8ddf4e07ad11
+  subjects:
+  - entities:
+    - role: player
+      name: Thomas White
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: UR-9
+  uuid: '095d2857-c882-4843-a0e3-51e9e9dc37e8'
+  subjects:
+  - entities:
+    - role: player
+      name: Edward Florentino
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: UR-10
+  uuid: c9aab8a5-4d70-4ac2-9203-81798e6cbbd0
+  subjects:
+  - entities:
+    - role: player
+      name: Ryan Waldschmidt
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: UR-11
+  uuid: 6019b10a-4a50-443c-9ccd-99a9d979327f
+  subjects:
+  - entities:
+    - role: player
+      name: Sal Stewart
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: UR-12
+  uuid: 8dc75258-5a5a-4d3f-8afd-431e608da100
+  subjects:
+  - entities:
+    - role: player
+      name: Carson Benge
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: UR-13
+  uuid: 14f3d41d-4c29-46a8-bcee-72dd15df55e8
+  subjects:
+  - entities:
+    - role: player
+      name: Daniel Pierce
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: UR-14
+  uuid: bf7c098d-b317-41ee-9a3d-28250955bc7e
+  subjects:
+  - entities:
+    - role: player
+      name: Josue De Paula
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: UR-15
+  uuid: c7c5498d-c06c-40e5-a16c-a6b102fc2ab3
+  subjects:
+  - entities:
+    - role: player
+      name: Trey Yesavage
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: UR-16
+  uuid: 82862942-d5b2-4ae4-8482-45c93a835dbe
+  subjects:
+  - entities:
+    - role: player
+      name: Samuel Basallo
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: UR-17
+  uuid: 87cb05a9-154d-47fd-a13f-2c89f8c7aa2f
+  subjects:
+  - entities:
+    - role: player
+      name: Wehiwa Aloy
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: UR-18
+  uuid: 0bb310d5-6ba4-4bbf-93fa-12951160603d
+  subjects:
+  - entities:
+    - role: player
+      name: Caleb Bonemer
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: UR-19
+  uuid: 9f2d644d-7388-45e2-bc76-4c852bc6a227
+  subjects:
+  - entities:
+    - role: player
+      name: Connelly Early
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: UR-20
+  uuid: 982b0249-9623-4002-81da-e44a539e6a0d
+  subjects:
+  - entities:
+    - role: player
+      name: Kaelen Culpepper
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 

--- a/data/baseball/2026-bowman/manifest.yaml
+++ b/data/baseball/2026-bowman/manifest.yaml
@@ -1,0 +1,660 @@
+set_id: 2026-bowman
+base_sets:
+- id: base-set
+  name: Base Set
+  uuid: 168d4ff6-9273-4035-b6ba-73c4387f8fba
+  declared_card_count: 100
+  parallels:
+  - name: Green Pattern
+    print_run: 99
+    serial_numbered: true
+  - name: Purple Pattern
+    print_run: 250
+    serial_numbered: true
+  - name: Bowman Logo
+  - name: Gold Pattern
+    print_run: 50
+    serial_numbered: true
+  - name: Purple
+    print_run: 250
+    serial_numbered: true
+  - name: Yellow
+    print_run: 75
+    serial_numbered: true
+  - name: Pink
+    print_run: 175
+    serial_numbered: true
+  - name: Blue
+    print_run: 150
+    serial_numbered: true
+  - name: Orange
+    print_run: 25
+    serial_numbered: true
+  - name: Blue Pattern
+    print_run: 150
+    serial_numbered: true
+  - name: Yellow Pattern
+    print_run: 75
+    serial_numbered: true
+  - name: Fuchsia
+    print_run: 299
+    serial_numbered: true
+  - name: Green
+    print_run: 99
+    serial_numbered: true
+  - name: Sky Blue
+    print_run: 499
+    serial_numbered: true
+  - name: Printing Plates
+    print_run: 4
+    serial_numbered: true
+  - name: Neon Green
+    print_run: 399
+    serial_numbered: true
+  - name: Black Pattern
+    print_run: 10
+    serial_numbered: true
+  - name: Black
+    print_run: 10
+    serial_numbered: true
+  - name: Red
+    print_run: 5
+    serial_numbered: true
+  - name: Platinum
+    print_run: 1
+    serial_numbered: true
+  - name: Orange Pattern
+    print_run: 25
+    serial_numbered: true
+  - name: Gold
+    print_run: 50
+    serial_numbered: true
+  subsets:
+  - id: anime
+    name: Anime
+    uuid: 9e59ac20-79fc-4f23-b8fb-f7a72778bf2c
+    type: insert
+    declared_card_count: 29
+    subsets:
+    - id: anime-kanji-variations
+      name: Anime - Kanji Variations
+      uuid: 2c02fa89-b805-4344-8a9b-77a92549693f
+      type: variation
+      declared_card_count: 7
+  - id: base-etched-in-glass-variations
+    name: Base - Etched In Glass Variations
+    uuid: d4434c54-bdd9-41f2-86fb-d9b717e5aa28
+    type: variation
+    declared_card_count: 12
+  - id: base-red-rc-variations
+    name: Base - Red RC Variations
+    uuid: dff7e2d9-07b2-4738-ad5f-6706e288e9f9
+    type: variation
+    declared_card_count: 40
+  - id: base-rookie-and-veteran-retail-autographs
+    name: Base Rookie and Veteran Retail Autographs
+    uuid: 6bed788b-2bec-40e3-a12f-65f2499bee7e
+    type: autograph
+    declared_card_count: 35
+  - id: bowman-scouts-top-100
+    name: Bowman Scouts Top 100
+    uuid: e571ff1d-33c3-437f-9465-ed6b4e4cf944
+    type: insert
+    declared_card_count: 100
+  - id: bowman-spotlights
+    name: Bowman Spotlights
+    uuid: c6f0e0b7-3be3-42c3-b76e-0e80cd2b57b8
+    type: insert
+    declared_card_count: 15
+  - id: bowman-sterling
+    name: Bowman Sterling
+    uuid: 338ec5f8-677f-4734-a223-69d1cc03ffe8
+    type: insert
+    declared_card_count: 15
+    parallels:
+    - name: Mega Chrome Rose Gold Refractor
+      print_run: 1
+      serial_numbered: true
+    - name: Mega Chrome Red Refractor
+      print_run: 5
+      serial_numbered: true
+    - name: Mega Chrome Blue Refractor
+      print_run: 150
+      serial_numbered: true
+    - name: Mega Chrome Pink Refractor
+      print_run: 199
+      serial_numbered: true
+    - name: SuperFractor
+      print_run: 1
+      serial_numbered: true
+    - name: Mega Chrome Black Refractor
+      print_run: 10
+      serial_numbered: true
+    - name: Green Refractor
+      print_run: 99
+      serial_numbered: true
+    - name: Autograph Gold Refractor
+      print_run: 50
+      serial_numbered: true
+    - name: Autograph Orange Refractor
+      print_run: 25
+      serial_numbered: true
+    - name: Mega Chrome
+    - name: Orange Refractor
+      print_run: 25
+      serial_numbered: true
+    - name: Mega Chrome Purple Refractor
+      print_run: 250
+      serial_numbered: true
+    - name: Red Refractor
+      print_run: 5
+      serial_numbered: true
+    - name: Mega Chrome Orange Refractor
+      print_run: 25
+      serial_numbered: true
+    - name: Mega Chrome Gold Refractor
+      print_run: 50
+      serial_numbered: true
+    - name: Mega Chrome Green Refractor
+      print_run: 99
+      serial_numbered: true
+    - name: Mini-Diamond Refractor
+      print_run: 150
+      serial_numbered: true
+    - name: Autograph Red Refractor
+      print_run: 5
+      serial_numbered: true
+    - name: Aqua Refractor
+      print_run: 125
+      serial_numbered: true
+    - name: Gold Refractor
+      print_run: 50
+      serial_numbered: true
+    subsets:
+    - id: bowman-sterling-autographs
+      name: Bowman Sterling Autographs
+      uuid: a305d487-4bf2-4c1a-ac92-3260514dd44e
+      type: autograph
+      declared_card_count: 10
+      parallels:
+      - name: SuperFractor
+        print_run: 1
+        serial_numbered: true
+  - id: crystallized
+    name: Crystallized
+    uuid: 32be62c5-f1c2-4a9c-a5e4-f1c0f9d72c11
+    type: insert
+    declared_card_count: 20
+  - id: draft-pick-pairings
+    name: Draft Pick Pairings
+    uuid: 95a7c168-1959-4844-a7b3-05f702728353
+    type: insert
+    declared_card_count: 16
+  - id: electric-sluggers
+    name: Electric Sluggers
+    uuid: 6659aa51-202e-4377-8f06-6c149d2ca62a
+    type: insert
+    declared_card_count: 25
+    parallels:
+    - name: Autograph Orange Refractor
+      print_run: 25
+      serial_numbered: true
+    - name: Gold Refractor
+      print_run: 50
+      serial_numbered: true
+    - name: SuperFractor
+      print_run: 1
+      serial_numbered: true
+    - name: Mega Chrome Gold Refractor
+      print_run: 50
+      serial_numbered: true
+    - name: Mega Chrome Pink Refractor
+      print_run: 199
+      serial_numbered: true
+    - name: Mega Chrome Red Refractor
+      print_run: 5
+      serial_numbered: true
+    - name: Mega Chrome
+    - name: Autograph Red Refractor
+      print_run: 5
+      serial_numbered: true
+    - name: Mini-Diamond Refractor
+      print_run: 150
+      serial_numbered: true
+    - name: Mega Chrome Black Refractor
+      print_run: 10
+      serial_numbered: true
+    - name: Mega Chrome Purple Refractor
+      print_run: 250
+      serial_numbered: true
+    - name: Mega Chrome Rose Gold Refractor
+      print_run: 1
+      serial_numbered: true
+    - name: Orange Refractor
+      print_run: 25
+      serial_numbered: true
+    - name: Mega Chrome Burgundy Refractor
+      print_run: 299
+      serial_numbered: true
+    - name: Mega Chrome Blue Refractor
+      print_run: 150
+      serial_numbered: true
+    - name: Mega Chrome Orange Refractor
+      print_run: 25
+      serial_numbered: true
+    - name: Autograph Gold Refractor
+      print_run: 50
+      serial_numbered: true
+    - name: Red Refractor
+      print_run: 5
+      serial_numbered: true
+    - name: Green Refractor
+      print_run: 99
+      serial_numbered: true
+    - name: Mega Chrome Green Refractor
+      print_run: 99
+      serial_numbered: true
+    - name: Aqua Refractor
+      print_run: 125
+      serial_numbered: true
+    subsets:
+    - id: electric-sluggers-autographs
+      name: Electric Sluggers Autographs
+      uuid: 37ba0ff1-5e16-4f32-b8fd-85250ef8fb06
+      type: autograph
+      declared_card_count: 14
+      parallels:
+      - name: SuperFractor
+        print_run: 1
+        serial_numbered: true
+  - id: final-draft
+    name: Final Draft
+    uuid: c049abb0-b631-4237-a6dd-8c54258ed067
+    type: insert
+    declared_card_count: 20
+  - id: patchwork
+    name: Patchwork
+    uuid: ef897d31-5856-4801-a942-d5d7e44594d2
+    type: relic
+    declared_card_count: 30
+  - id: power-chords
+    name: Power Chords
+    uuid: 5deb89a1-d269-4dc3-a773-0abc824da32b
+    type: insert
+    declared_card_count: 25
+    parallels:
+    - name: Green Refractor
+      print_run: 99
+      serial_numbered: true
+    - name: Aqua Refractor
+      print_run: 125
+      serial_numbered: true
+    - name: Orange Refractor
+      print_run: 25
+      serial_numbered: true
+    - name: Gold Refractor
+      print_run: 50
+      serial_numbered: true
+    - name: Autograph Red Refractor
+      print_run: 5
+      serial_numbered: true
+    - name: Red Refractor
+      print_run: 5
+      serial_numbered: true
+    - name: Autograph Gold Refractor
+      print_run: 50
+      serial_numbered: true
+    - name: Autograph Orange Refractor
+      print_run: 25
+      serial_numbered: true
+    - name: Mini-Diamond Refractor
+      print_run: 150
+      serial_numbered: true
+    - name: SuperFractor
+      print_run: 1
+      serial_numbered: true
+    subsets:
+    - id: power-chords-autographs
+      name: Power Chords Autographs
+      uuid: 57372ac6-8bfc-4679-bf2f-597bdddf6159
+      type: autograph
+      declared_card_count: 15
+      parallels:
+      - name: SuperFractor
+        print_run: 1
+        serial_numbered: true
+  - id: ultimate-autograph-booklet
+    name: Ultimate Autograph Booklet
+    uuid: ceea2c53-da1c-41f4-aa91-5d3648440ac0
+    type: autograph
+    declared_card_count: 1
+  - id: under-the-radar
+    name: Under The Radar
+    uuid: 76baedab-d921-467c-afb1-96bf1f9c1bdd
+    type: insert
+    declared_card_count: 20
+    parallels:
+    - name: Red Refractor
+      print_run: 5
+      serial_numbered: true
+    - name: Autograph Red Refractor
+      print_run: 5
+      serial_numbered: true
+    - name: Autograph Gold Refractor
+      print_run: 50
+      serial_numbered: true
+    - name: SuperFractor
+      print_run: 1
+      serial_numbered: true
+    - name: Mini-Diamond Refractor
+      print_run: 150
+      serial_numbered: true
+    - name: Green Refractor
+      print_run: 99
+      serial_numbered: true
+    - name: Gold Refractor
+      print_run: 50
+      serial_numbered: true
+    - name: Orange Refractor
+      print_run: 25
+      serial_numbered: true
+    - name: Autograph Orange Refractor
+      print_run: 25
+      serial_numbered: true
+    - name: Aqua Refractor
+      print_run: 125
+      serial_numbered: true
+    subsets:
+    - id: under-the-radar-autographs
+      name: Under The Radar Autographs
+      uuid: 31438de5-9725-4141-84fe-1cefa6e6fdf4
+      type: autograph
+      declared_card_count: 13
+      parallels:
+      - name: SuperFractor
+        print_run: 1
+        serial_numbered: true
+- id: base-prospects
+  name: Base Prospects
+  uuid: 9f84812d-a258-441e-860c-0ae8052eae8c
+  declared_card_count: 150
+  parallels:
+  - name: Neon Green
+    print_run: 299
+    serial_numbered: true
+  - name: Green Pattern
+    print_run: 75
+    serial_numbered: true
+  - name: Fuchsia
+    print_run: 250
+    serial_numbered: true
+  - name: Yellow
+    print_run: 75
+    serial_numbered: true
+  - name: Gold Pattern
+    print_run: 50
+    serial_numbered: true
+  - name: Yellow Pattern
+    print_run: 75
+    serial_numbered: true
+  - name: Platinum
+    print_run: 1
+    serial_numbered: true
+  - name: Black
+    print_run: 10
+    serial_numbered: true
+  - name: Black Pattern
+    print_run: 10
+    serial_numbered: true
+  - name: Orange
+    print_run: 25
+    serial_numbered: true
+  - name: Pink
+    print_run: 150
+    serial_numbered: true
+  - name: Blue
+    print_run: 150
+    serial_numbered: true
+  - name: Purple Pattern
+    print_run: 175
+    serial_numbered: true
+  - name: Printing Plates
+    print_run: 4
+    serial_numbered: true
+  - name: Blue Pattern
+    print_run: 99
+    serial_numbered: true
+  - name: Bowman Logo
+  - name: Sky Blue
+    print_run: 399
+    serial_numbered: true
+  - name: Green
+    print_run: 99
+    serial_numbered: true
+  - name: Orange Pattern
+    print_run: 25
+    serial_numbered: true
+  - name: Red
+    print_run: 5
+    serial_numbered: true
+  - name: Gold
+    print_run: 50
+    serial_numbered: true
+  - name: Purple
+    print_run: 250
+    serial_numbered: true
+  subsets:
+  - id: base-prospect-retail-autographs
+    name: Base Prospect Retail Autographs
+    uuid: fc4fa5fa-cf08-49c7-bad6-96348c4bd3de
+    type: autograph
+    declared_card_count: 31
+- id: chrome-prospects
+  name: Chrome Prospects
+  uuid: 8b1c2b09-2551-4496-9c2c-1d38ff731557
+  declared_card_count: 150
+  parallels:
+  - name: Speckle Refractor
+    print_run: 299
+    serial_numbered: true
+  - name: Reptilian Refractor
+  - name: FireFractor
+    print_run: 3
+    serial_numbered: true
+  - name: Peanuts Refractor
+  - name: Rose Gold X-Fractor
+    print_run: 15
+    serial_numbered: true
+  - name: Gold Shimmer Refractor
+    print_run: 50
+    serial_numbered: true
+  - name: Yellow Refractor
+    print_run: 75
+    serial_numbered: true
+  - name: Reptilian Orange Refractor
+    print_run: 25
+    serial_numbered: true
+  - name: Green Shimmer Refractor
+    print_run: 99
+    serial_numbered: true
+  - name: Orange Geometric Refractor
+    print_run: 25
+    serial_numbered: true
+  - name: Refractor
+    print_run: 499
+    serial_numbered: true
+  - name: Green Refractor
+    print_run: 99
+    serial_numbered: true
+  - name: Purple Geometric Refractor
+    print_run: 250
+    serial_numbered: true
+  - name: Gold Geometric Refractor
+    print_run: 50
+    serial_numbered: true
+  - name: Red Geometric Refractor
+    print_run: 5
+    serial_numbered: true
+  - name: Orange Shimmer Refractor
+    print_run: 25
+    serial_numbered: true
+  - name: Sunflower Seeds Refractor
+  - name: Blue Geometric Refractor
+    print_run: 150
+    serial_numbered: true
+  - name: X-Fractor
+  - name: Reptilian Fuschia Refractor
+    print_run: 199
+    serial_numbered: true
+  - name: Orange Refractor
+    print_run: 25
+    serial_numbered: true
+  - name: Mini-Diamond Refractor
+  - name: PackFractor
+    print_run: 89
+    serial_numbered: true
+  - name: Yellow Wave Refractor
+    print_run: 75
+    serial_numbered: true
+  - name: Laser Refractor
+  - name: Aqua Geometric Refractor
+    print_run: 125
+    serial_numbered: true
+  - name: Red Lava Refractor
+    print_run: 5
+    serial_numbered: true
+  - name: Green Geometric Refractor
+    print_run: 99
+    serial_numbered: true
+  - name: Bowman LogoFractor
+    print_run: 35
+    serial_numbered: true
+  - name: Black Geometric Refractor
+    print_run: 10
+    serial_numbered: true
+  - name: Reptilian Green Refractor
+    print_run: 99
+    serial_numbered: true
+  - name: Blue Refractor
+    print_run: 150
+    serial_numbered: true
+  - name: Fuschia Wave Refractor
+    print_run: 199
+    serial_numbered: true
+  - name: Yellow X-Fractor
+    print_run: 75
+    serial_numbered: true
+  - name: Gum Ball Refractor
+  - name: Fuschia Refractor
+    print_run: 199
+    serial_numbered: true
+  - name: Blue RayWave Refractor
+    print_run: 150
+    serial_numbered: true
+  - name: Black Refractor
+    print_run: 10
+    serial_numbered: true
+  - name: SuperFractor
+    print_run: 1
+    serial_numbered: true
+  - name: Pop Corn Refractor
+  - name: Purple Refractor
+    print_run: 250
+    serial_numbered: true
+  - name: Reptilian Gold Refractor
+    print_run: 50
+    serial_numbered: true
+  - name: Printing Plates
+    print_run: 4
+    serial_numbered: true
+  - name: Red Refractor
+    print_run: 5
+    serial_numbered: true
+  - name: Black X-Fractor
+    print_run: 10
+    serial_numbered: true
+  - name: Aqua X-Fractor
+    print_run: 125
+    serial_numbered: true
+  - name: Wave Refractor
+    print_run: 350
+    serial_numbered: true
+  - name: LogoFractor
+  - name: Reptilian Red Refractor
+    print_run: 5
+    serial_numbered: true
+  - name: Gold Refractor
+    print_run: 50
+    serial_numbered: true
+  - name: Blue Shimmer Refractor
+    print_run: 150
+    serial_numbered: true
+  - name: Lava Refractor
+    print_run: 399
+    serial_numbered: true
+  - name: Rose Gold Refractor
+    print_run: 15
+    serial_numbered: true
+  - name: Aqua Shimmer Refractor
+    print_run: 125
+    serial_numbered: true
+  - name: Reptilian Blue Refractor
+    print_run: 150
+    serial_numbered: true
+  - name: Purple RayWave Refractor
+    print_run: 250
+    serial_numbered: true
+  - name: Steel Metal Refractor
+    print_run: 100
+    serial_numbered: true
+  - name: Green Grass Refractor
+    print_run: 99
+    serial_numbered: true
+  subsets:
+  - id: chrome-prospect-autographs
+    name: Chrome Prospect Autographs
+    uuid: a1d9ce29-180b-49eb-aa29-364ba287fa16
+    type: autograph
+    declared_card_count: 87
+    parallels:
+    - name: Speckle Refractor
+      print_run: 299
+      serial_numbered: true
+    - name: Sunflower Seeds Refractor
+      print_run: 5
+      serial_numbered: true
+    - name: Gold Ink
+      print_run: 15
+      serial_numbered: true
+    - name: SuperFractor
+      print_run: 1
+      serial_numbered: true
+  - id: chrome-prospect-gold-ink-autographs
+    name: Chrome Prospect Gold Ink Autographs
+    uuid: e3562052-c34d-4e18-a224-343c5df62cbc
+    type: autograph
+    declared_card_count: 47
+  - id: chrome-prospect-packfractor-autographs
+    name: Chrome Prospect Packfractor Autographs
+    uuid: 989d3c5d-6e11-4181-a8bc-9d47b80afb05
+    type: autograph
+    declared_card_count: 39
+  - id: chrome-prospects-etched-in-glass-variations
+    name: Chrome Prospects - Etched In Glass Variations
+    uuid: 7d6ece78-81f3-4873-b309-e85fc9a4c353
+    type: variation
+    declared_card_count: 11
+  - id: chrome-prospects-packfractor-variation
+    name: Chrome Prospects Packfractor Variation
+    uuid: 4b6cb4ee-8333-45bd-b590-e6f4c86dc021
+    type: variation
+    declared_card_count: 150
+  - id: chrome-rookie-autographs
+    name: Chrome Rookie Autographs
+    uuid: e4ba7ada-b8b8-447c-aea6-8721b8315b65
+    type: autograph
+    declared_card_count: 13
+    parallels:
+    - name: SuperFractor
+      print_run: 1
+      serial_numbered: true

--- a/data/baseball/2026-bowman/manifest.yaml
+++ b/data/baseball/2026-bowman/manifest.yaml
@@ -73,17 +73,20 @@ base_sets:
   - id: base-etched-in-glass-variations
     name: Base - Etched In Glass Variations
     uuid: b2fddb62-4145-5652-9273-1d352949b0b6
-    type: variation
+    type:
+    - variation
     declared_card_count: 12
   - id: base-red-rc-variations
     name: Base - Red RC Variations
     uuid: e780c379-6579-55a9-94c0-dc4e3bf10a4c
-    type: variation
+    type:
+    - variation
     declared_card_count: 40
   - id: base-rookie-and-veteran-retail-autographs
     name: Base Rookie and Veteran Retail Autographs
     uuid: 6a5477d8-69cd-5235-8cbe-27ac37b49d88
-    type: autograph
+    type:
+    - autograph
     declared_card_count: 35
 - id: base-prospects
   name: Base Prospects
@@ -158,7 +161,8 @@ base_sets:
   - id: base-prospect-retail-autographs
     name: Base Prospect Retail Autographs
     uuid: b1a94b14-4a0b-5d93-8b4e-f04e3effbcf8
-    type: autograph
+    type:
+    - autograph
     declared_card_count: 31
 - id: chrome-prospects
   name: Chrome Prospects
@@ -325,7 +329,8 @@ base_sets:
   - id: chrome-prospect-autographs
     name: Chrome Prospect Autographs
     uuid: 95d91fa8-4add-51a9-b5d3-3b8b820ea58c
-    type: autograph
+    type:
+    - autograph
     declared_card_count: 87
     parallels:
     - name: Gold Ink
@@ -343,27 +348,32 @@ base_sets:
   - id: chrome-prospect-gold-ink-autographs
     name: Chrome Prospect Gold Ink Autographs
     uuid: 5200e101-3a7c-587a-92ba-f2288073057d
-    type: autograph
+    type:
+    - autograph
     declared_card_count: 47
   - id: chrome-prospect-packfractor-autographs
     name: Chrome Prospect Packfractor Autographs
     uuid: '08a54c52-3d8a-5851-acea-0f7ef8283284'
-    type: autograph
+    type:
+    - autograph
     declared_card_count: 39
   - id: chrome-prospects-etched-in-glass-variations
     name: Chrome Prospects - Etched In Glass Variations
     uuid: 3fe34161-99d4-53a9-94e8-9c6745f5d9a6
-    type: variation
+    type:
+    - variation
     declared_card_count: 11
   - id: chrome-prospects-packfractor-variation
     name: Chrome Prospects Packfractor Variation
     uuid: 27caf6b1-932c-56d8-8a8b-509bfcbffd21
-    type: variation
+    type:
+    - variation
     declared_card_count: 150
   - id: chrome-rookie-autographs
     name: Chrome Rookie Autographs
     uuid: c7cd4971-70b2-5f34-8a73-849f11d7c234
-    type: autograph
+    type:
+    - autograph
     declared_card_count: 13
     parallels:
     - name: SuperFractor
@@ -373,18 +383,21 @@ subsets:
 - id: anime
   name: Anime
   uuid: c0b4f077-6cd2-5176-a51b-b17ca03ab49b
-  type: insert
+  type:
+  - insert
   declared_card_count: 29
   subsets:
   - id: anime-kanji-variations
     name: Anime - Kanji Variations
     uuid: 1a87fa38-33b6-5a29-a0c4-e5d8a2bc8f58
-    type: variation
+    type:
+    - variation
     declared_card_count: 7
 - id: bowman-scouts-top-100
   name: Bowman Scouts Top 100
   uuid: 311bec3c-6ff6-5a1b-9186-e30ac13fce15
-  type: insert
+  type:
+  - insert
   declared_card_count: 100
   parallels:
   - name: Aqua Refractor
@@ -411,12 +424,14 @@ subsets:
 - id: bowman-spotlights
   name: Bowman Spotlights
   uuid: 673f14fe-3301-563a-a1fa-9c2443a1fca8
-  type: insert
+  type:
+  - insert
   declared_card_count: 15
 - id: bowman-sterling
   name: Bowman Sterling
   uuid: ca741378-80ba-5346-b45b-2d5878d9dd67
-  type: insert
+  type:
+  - insert
   declared_card_count: 15
   parallels:
   - name: Aqua Refractor
@@ -481,7 +496,8 @@ subsets:
   - id: bowman-sterling-autographs
     name: Bowman Sterling Autographs
     uuid: cda9cf02-7b42-5289-92c4-21641713075c
-    type: autograph
+    type:
+    - autograph
     declared_card_count: 10
     parallels:
     - name: SuperFractor
@@ -490,17 +506,20 @@ subsets:
 - id: crystallized
   name: Crystallized
   uuid: 902e8c70-d8cc-5475-8182-f3f687bc2d37
-  type: insert
+  type:
+  - insert
   declared_card_count: 20
 - id: draft-pick-pairings
   name: Draft Pick Pairings
   uuid: ec46ca4e-2b68-5092-b52c-5f58c6ddfb69
-  type: insert
+  type:
+  - insert
   declared_card_count: 16
 - id: electric-sluggers
   name: Electric Sluggers
   uuid: c2753dd5-6fd9-5082-a15d-4de78dadbb9c
-  type: insert
+  type:
+  - insert
   declared_card_count: 25
   parallels:
   - name: Aqua Refractor
@@ -568,7 +587,8 @@ subsets:
   - id: electric-sluggers-autographs
     name: Electric Sluggers Autographs
     uuid: e6914bd3-9ae8-5656-9f6e-fbae45363c7f
-    type: autograph
+    type:
+    - autograph
     declared_card_count: 14
     parallels:
     - name: SuperFractor
@@ -577,17 +597,20 @@ subsets:
 - id: final-draft
   name: Final Draft
   uuid: 39342dd2-9dc7-5c2f-b47d-9cc841ba95e6
-  type: insert
+  type:
+  - insert
   declared_card_count: 20
 - id: patchwork
   name: Patchwork
   uuid: 78e7d64e-f65a-557d-a20a-3323a1a90634
-  type: relic
+  type:
+  - relic
   declared_card_count: 30
 - id: power-chords
   name: Power Chords
   uuid: beb3edd0-2459-5d8e-86ad-d4a483ae34ab
-  type: insert
+  type:
+  - insert
   declared_card_count: 25
   parallels:
   - name: Aqua Refractor
@@ -624,7 +647,8 @@ subsets:
   - id: power-chords-autographs
     name: Power Chords Autographs
     uuid: edc9165f-ab52-522e-8453-b6b2f378b9b9
-    type: autograph
+    type:
+    - autograph
     declared_card_count: 15
     parallels:
     - name: SuperFractor
@@ -633,12 +657,14 @@ subsets:
 - id: ultimate-autograph-booklet
   name: Ultimate Autograph Booklet
   uuid: b0cb348f-7aab-5553-acbf-f632e8ce86ce
-  type: autograph
+  type:
+  - autograph
   declared_card_count: 1
 - id: under-the-radar
   name: Under The Radar
   uuid: 15079f18-4d56-5b89-a419-cfbb3ee194d6
-  type: insert
+  type:
+  - insert
   declared_card_count: 20
   parallels:
   - name: Aqua Refractor
@@ -675,7 +701,8 @@ subsets:
   - id: under-the-radar-autographs
     name: Under The Radar Autographs
     uuid: a042e049-b38e-5c15-a005-5becb3288d27
-    type: autograph
+    type:
+    - autograph
     declared_card_count: 13
     parallels:
     - name: SuperFractor

--- a/data/baseball/2026-bowman/manifest.yaml
+++ b/data/baseball/2026-bowman/manifest.yaml
@@ -2,7 +2,7 @@ set_id: 2026-bowman
 base_sets:
 - id: base-set
   name: Base Set
-  uuid: f5a286b5-d063-4ab7-a8a2-4548e01da134
+  uuid: 1cf30f3d-a7b0-5a34-919f-d859ddbdbc99
   declared_card_count: 100
   parallels:
   - name: Black
@@ -70,335 +70,24 @@ base_sets:
     print_run: 75
     serial_numbered: true
   subsets:
-  - id: anime
-    name: Anime
-    uuid: eab6f0ed-d765-4f6a-93e9-aad8b92f6036
-    type: insert
-    declared_card_count: 29
-    subsets:
-    - id: anime-kanji-variations
-      name: Anime - Kanji Variations
-      uuid: 70dfe11a-2035-4857-815c-010c7ccf77bf
-      type: variation
-      declared_card_count: 7
   - id: base-etched-in-glass-variations
     name: Base - Etched In Glass Variations
-    uuid: 19c1ee6c-ac8b-4e1b-ae5b-c0d614a5da9f
+    uuid: b2fddb62-4145-5652-9273-1d352949b0b6
     type: variation
     declared_card_count: 12
   - id: base-red-rc-variations
     name: Base - Red RC Variations
-    uuid: 2a1639c7-6892-4ec4-b7a5-a2f0005fd638
+    uuid: e780c379-6579-55a9-94c0-dc4e3bf10a4c
     type: variation
     declared_card_count: 40
   - id: base-rookie-and-veteran-retail-autographs
     name: Base Rookie and Veteran Retail Autographs
-    uuid: 7b8b8faf-a578-478f-9d06-4d8b2d7ce943
+    uuid: 6a5477d8-69cd-5235-8cbe-27ac37b49d88
     type: autograph
     declared_card_count: 35
-  - id: bowman-scouts-top-100
-    name: Bowman Scouts Top 100
-    uuid: 2deb3a4f-afa9-433b-b121-f2970f184bb9
-    type: insert
-    declared_card_count: 100
-    parallels:
-    - name: Aqua Refractor
-      print_run: 125
-      serial_numbered: true
-    - name: Gold Refractor
-      print_run: 50
-      serial_numbered: true
-    - name: Green Refractor
-      print_run: 99
-      serial_numbered: true
-    - name: Mini-Diamond Refractor
-      print_run: 150
-      serial_numbered: true
-    - name: Orange Refractor
-      print_run: 25
-      serial_numbered: true
-    - name: Red Refractor
-      print_run: 5
-      serial_numbered: true
-    - name: SuperFractor
-      print_run: 1
-      serial_numbered: true
-  - id: bowman-spotlights
-    name: Bowman Spotlights
-    uuid: 5b768b03-46f2-4416-8d64-1814e6b16e80
-    type: insert
-    declared_card_count: 15
-  - id: bowman-sterling
-    name: Bowman Sterling
-    uuid: ae3404d6-24f9-4838-9ba5-0382792324ae
-    type: insert
-    declared_card_count: 15
-    parallels:
-    - name: Aqua Refractor
-      print_run: 125
-      serial_numbered: true
-    - name: Autograph Gold Refractor
-      print_run: 50
-      serial_numbered: true
-    - name: Autograph Orange Refractor
-      print_run: 25
-      serial_numbered: true
-    - name: Autograph Red Refractor
-      print_run: 5
-      serial_numbered: true
-    - name: Gold Refractor
-      print_run: 50
-      serial_numbered: true
-    - name: Green Refractor
-      print_run: 99
-      serial_numbered: true
-    - name: Mega Chrome
-    - name: Mega Chrome Black Refractor
-      print_run: 10
-      serial_numbered: true
-    - name: Mega Chrome Blue Refractor
-      print_run: 150
-      serial_numbered: true
-    - name: Mega Chrome Gold Refractor
-      print_run: 50
-      serial_numbered: true
-    - name: Mega Chrome Green Refractor
-      print_run: 99
-      serial_numbered: true
-    - name: Mega Chrome Orange Refractor
-      print_run: 25
-      serial_numbered: true
-    - name: Mega Chrome Pink Refractor
-      print_run: 199
-      serial_numbered: true
-    - name: Mega Chrome Purple Refractor
-      print_run: 250
-      serial_numbered: true
-    - name: Mega Chrome Red Refractor
-      print_run: 5
-      serial_numbered: true
-    - name: Mega Chrome Rose Gold Refractor
-      print_run: 1
-      serial_numbered: true
-    - name: Mini-Diamond Refractor
-      print_run: 150
-      serial_numbered: true
-    - name: Orange Refractor
-      print_run: 25
-      serial_numbered: true
-    - name: Red Refractor
-      print_run: 5
-      serial_numbered: true
-    - name: SuperFractor
-      print_run: 1
-      serial_numbered: true
-    subsets:
-    - id: bowman-sterling-autographs
-      name: Bowman Sterling Autographs
-      uuid: 268eddee-1e2a-483b-9e13-df8a775db8dc
-      type: autograph
-      declared_card_count: 10
-      parallels:
-      - name: SuperFractor
-        print_run: 1
-        serial_numbered: true
-  - id: crystallized
-    name: Crystallized
-    uuid: 2f3a8e7f-9e15-4f66-bfdc-91101767bb33
-    type: insert
-    declared_card_count: 20
-  - id: draft-pick-pairings
-    name: Draft Pick Pairings
-    uuid: c472e3d9-f579-4f1b-bd99-ce7d925c5368
-    type: insert
-    declared_card_count: 16
-  - id: electric-sluggers
-    name: Electric Sluggers
-    uuid: c7813708-51de-4cb2-960e-3a83c7216b6d
-    type: insert
-    declared_card_count: 25
-    parallels:
-    - name: Aqua Refractor
-      print_run: 125
-      serial_numbered: true
-    - name: Autograph Gold Refractor
-      print_run: 50
-      serial_numbered: true
-    - name: Autograph Orange Refractor
-      print_run: 25
-      serial_numbered: true
-    - name: Autograph Red Refractor
-      print_run: 5
-      serial_numbered: true
-    - name: Gold Refractor
-      print_run: 50
-      serial_numbered: true
-    - name: Green Refractor
-      print_run: 99
-      serial_numbered: true
-    - name: Mega Chrome
-    - name: Mega Chrome Black Refractor
-      print_run: 10
-      serial_numbered: true
-    - name: Mega Chrome Blue Refractor
-      print_run: 150
-      serial_numbered: true
-    - name: Mega Chrome Burgundy Refractor
-      print_run: 299
-      serial_numbered: true
-    - name: Mega Chrome Gold Refractor
-      print_run: 50
-      serial_numbered: true
-    - name: Mega Chrome Green Refractor
-      print_run: 99
-      serial_numbered: true
-    - name: Mega Chrome Orange Refractor
-      print_run: 25
-      serial_numbered: true
-    - name: Mega Chrome Pink Refractor
-      print_run: 199
-      serial_numbered: true
-    - name: Mega Chrome Purple Refractor
-      print_run: 250
-      serial_numbered: true
-    - name: Mega Chrome Red Refractor
-      print_run: 5
-      serial_numbered: true
-    - name: Mega Chrome Rose Gold Refractor
-      print_run: 1
-      serial_numbered: true
-    - name: Mini-Diamond Refractor
-      print_run: 150
-      serial_numbered: true
-    - name: Orange Refractor
-      print_run: 25
-      serial_numbered: true
-    - name: Red Refractor
-      print_run: 5
-      serial_numbered: true
-    - name: SuperFractor
-      print_run: 1
-      serial_numbered: true
-    subsets:
-    - id: electric-sluggers-autographs
-      name: Electric Sluggers Autographs
-      uuid: b9b00579-dc2e-462e-bf68-d62d06f53b79
-      type: autograph
-      declared_card_count: 14
-      parallels:
-      - name: SuperFractor
-        print_run: 1
-        serial_numbered: true
-  - id: final-draft
-    name: Final Draft
-    uuid: 5fa9dda9-7eff-4bd1-a846-21f4865f23d1
-    type: insert
-    declared_card_count: 20
-  - id: patchwork
-    name: Patchwork
-    uuid: 6c80b645-b235-4691-9eba-e4ec08f56649
-    type: relic
-    declared_card_count: 30
-  - id: power-chords
-    name: Power Chords
-    uuid: cb4d56b1-932b-4bf7-ae83-05e2ee57eb00
-    type: insert
-    declared_card_count: 25
-    parallels:
-    - name: Aqua Refractor
-      print_run: 125
-      serial_numbered: true
-    - name: Autograph Gold Refractor
-      print_run: 50
-      serial_numbered: true
-    - name: Autograph Orange Refractor
-      print_run: 25
-      serial_numbered: true
-    - name: Autograph Red Refractor
-      print_run: 5
-      serial_numbered: true
-    - name: Gold Refractor
-      print_run: 50
-      serial_numbered: true
-    - name: Green Refractor
-      print_run: 99
-      serial_numbered: true
-    - name: Mini-Diamond Refractor
-      print_run: 150
-      serial_numbered: true
-    - name: Orange Refractor
-      print_run: 25
-      serial_numbered: true
-    - name: Red Refractor
-      print_run: 5
-      serial_numbered: true
-    - name: SuperFractor
-      print_run: 1
-      serial_numbered: true
-    subsets:
-    - id: power-chords-autographs
-      name: Power Chords Autographs
-      uuid: e9f80553-ef5f-4199-8091-24166a15f174
-      type: autograph
-      declared_card_count: 15
-      parallels:
-      - name: SuperFractor
-        print_run: 1
-        serial_numbered: true
-  - id: ultimate-autograph-booklet
-    name: Ultimate Autograph Booklet
-    uuid: 0fb32f94-c923-4bec-b085-295d650442ec
-    type: autograph
-    declared_card_count: 1
-  - id: under-the-radar
-    name: Under The Radar
-    uuid: d107b9c1-8ab1-44e9-89f1-dc8e9c518e22
-    type: insert
-    declared_card_count: 20
-    parallels:
-    - name: Aqua Refractor
-      print_run: 125
-      serial_numbered: true
-    - name: Autograph Gold Refractor
-      print_run: 50
-      serial_numbered: true
-    - name: Autograph Orange Refractor
-      print_run: 25
-      serial_numbered: true
-    - name: Autograph Red Refractor
-      print_run: 5
-      serial_numbered: true
-    - name: Gold Refractor
-      print_run: 50
-      serial_numbered: true
-    - name: Green Refractor
-      print_run: 99
-      serial_numbered: true
-    - name: Mini-Diamond Refractor
-      print_run: 150
-      serial_numbered: true
-    - name: Orange Refractor
-      print_run: 25
-      serial_numbered: true
-    - name: Red Refractor
-      print_run: 5
-      serial_numbered: true
-    - name: SuperFractor
-      print_run: 1
-      serial_numbered: true
-    subsets:
-    - id: under-the-radar-autographs
-      name: Under The Radar Autographs
-      uuid: e6297d4f-0fe9-4b12-8ec6-b4a6ee954474
-      type: autograph
-      declared_card_count: 13
-      parallels:
-      - name: SuperFractor
-        print_run: 1
-        serial_numbered: true
 - id: base-prospects
   name: Base Prospects
-  uuid: '0438c27f-56e6-4bd0-928a-d47a774e14fd'
+  uuid: 035da0ee-6134-552e-8296-e4aa9d48e919
   declared_card_count: 150
   parallels:
   - name: Black
@@ -468,12 +157,12 @@ base_sets:
   subsets:
   - id: base-prospect-retail-autographs
     name: Base Prospect Retail Autographs
-    uuid: 304d6ae4-9f94-40e8-b0ef-f545ff0bb90d
+    uuid: b1a94b14-4a0b-5d93-8b4e-f04e3effbcf8
     type: autograph
     declared_card_count: 31
 - id: chrome-prospects
   name: Chrome Prospects
-  uuid: 487aa2ee-8e5d-4a65-8aff-db1e78e14bf5
+  uuid: d85e4f96-760b-5102-80f0-09765c8cc2c5
   declared_card_count: 150
   parallels:
   - name: Aqua Geometric Refractor
@@ -635,7 +324,7 @@ base_sets:
   subsets:
   - id: chrome-prospect-autographs
     name: Chrome Prospect Autographs
-    uuid: e3a5ee3a-af47-46a0-bd21-ca2e8a4d28ee
+    uuid: 95d91fa8-4add-51a9-b5d3-3b8b820ea58c
     type: autograph
     declared_card_count: 87
     parallels:
@@ -653,27 +342,339 @@ base_sets:
       serial_numbered: true
   - id: chrome-prospect-gold-ink-autographs
     name: Chrome Prospect Gold Ink Autographs
-    uuid: c36f91c9-3bfa-48d7-baa1-2882f76e2ecd
+    uuid: 5200e101-3a7c-587a-92ba-f2288073057d
     type: autograph
     declared_card_count: 47
   - id: chrome-prospect-packfractor-autographs
     name: Chrome Prospect Packfractor Autographs
-    uuid: 8cc95f80-0b54-4925-9a7e-c7f6144ca975
+    uuid: '08a54c52-3d8a-5851-acea-0f7ef8283284'
     type: autograph
     declared_card_count: 39
   - id: chrome-prospects-etched-in-glass-variations
     name: Chrome Prospects - Etched In Glass Variations
-    uuid: e5cae530-4a02-4f14-af3e-c6fbaf0e2daf
+    uuid: 3fe34161-99d4-53a9-94e8-9c6745f5d9a6
     type: variation
     declared_card_count: 11
   - id: chrome-prospects-packfractor-variation
     name: Chrome Prospects Packfractor Variation
-    uuid: 24041b79-fee3-44e3-ac25-498295e5557d
+    uuid: 27caf6b1-932c-56d8-8a8b-509bfcbffd21
     type: variation
     declared_card_count: 150
   - id: chrome-rookie-autographs
     name: Chrome Rookie Autographs
-    uuid: 4a8884cc-e7db-44ce-a381-2fd022817948
+    uuid: c7cd4971-70b2-5f34-8a73-849f11d7c234
+    type: autograph
+    declared_card_count: 13
+    parallels:
+    - name: SuperFractor
+      print_run: 1
+      serial_numbered: true
+subsets:
+- id: anime
+  name: Anime
+  uuid: c0b4f077-6cd2-5176-a51b-b17ca03ab49b
+  type: insert
+  declared_card_count: 29
+  subsets:
+  - id: anime-kanji-variations
+    name: Anime - Kanji Variations
+    uuid: 1a87fa38-33b6-5a29-a0c4-e5d8a2bc8f58
+    type: variation
+    declared_card_count: 7
+- id: bowman-scouts-top-100
+  name: Bowman Scouts Top 100
+  uuid: 311bec3c-6ff6-5a1b-9186-e30ac13fce15
+  type: insert
+  declared_card_count: 100
+  parallels:
+  - name: Aqua Refractor
+    print_run: 125
+    serial_numbered: true
+  - name: Gold Refractor
+    print_run: 50
+    serial_numbered: true
+  - name: Green Refractor
+    print_run: 99
+    serial_numbered: true
+  - name: Mini-Diamond Refractor
+    print_run: 150
+    serial_numbered: true
+  - name: Orange Refractor
+    print_run: 25
+    serial_numbered: true
+  - name: Red Refractor
+    print_run: 5
+    serial_numbered: true
+  - name: SuperFractor
+    print_run: 1
+    serial_numbered: true
+- id: bowman-spotlights
+  name: Bowman Spotlights
+  uuid: 673f14fe-3301-563a-a1fa-9c2443a1fca8
+  type: insert
+  declared_card_count: 15
+- id: bowman-sterling
+  name: Bowman Sterling
+  uuid: ca741378-80ba-5346-b45b-2d5878d9dd67
+  type: insert
+  declared_card_count: 15
+  parallels:
+  - name: Aqua Refractor
+    print_run: 125
+    serial_numbered: true
+  - name: Autograph Gold Refractor
+    print_run: 50
+    serial_numbered: true
+  - name: Autograph Orange Refractor
+    print_run: 25
+    serial_numbered: true
+  - name: Autograph Red Refractor
+    print_run: 5
+    serial_numbered: true
+  - name: Gold Refractor
+    print_run: 50
+    serial_numbered: true
+  - name: Green Refractor
+    print_run: 99
+    serial_numbered: true
+  - name: Mega Chrome
+  - name: Mega Chrome Black Refractor
+    print_run: 10
+    serial_numbered: true
+  - name: Mega Chrome Blue Refractor
+    print_run: 150
+    serial_numbered: true
+  - name: Mega Chrome Gold Refractor
+    print_run: 50
+    serial_numbered: true
+  - name: Mega Chrome Green Refractor
+    print_run: 99
+    serial_numbered: true
+  - name: Mega Chrome Orange Refractor
+    print_run: 25
+    serial_numbered: true
+  - name: Mega Chrome Pink Refractor
+    print_run: 199
+    serial_numbered: true
+  - name: Mega Chrome Purple Refractor
+    print_run: 250
+    serial_numbered: true
+  - name: Mega Chrome Red Refractor
+    print_run: 5
+    serial_numbered: true
+  - name: Mega Chrome Rose Gold Refractor
+    print_run: 1
+    serial_numbered: true
+  - name: Mini-Diamond Refractor
+    print_run: 150
+    serial_numbered: true
+  - name: Orange Refractor
+    print_run: 25
+    serial_numbered: true
+  - name: Red Refractor
+    print_run: 5
+    serial_numbered: true
+  - name: SuperFractor
+    print_run: 1
+    serial_numbered: true
+  subsets:
+  - id: bowman-sterling-autographs
+    name: Bowman Sterling Autographs
+    uuid: cda9cf02-7b42-5289-92c4-21641713075c
+    type: autograph
+    declared_card_count: 10
+    parallels:
+    - name: SuperFractor
+      print_run: 1
+      serial_numbered: true
+- id: crystallized
+  name: Crystallized
+  uuid: 902e8c70-d8cc-5475-8182-f3f687bc2d37
+  type: insert
+  declared_card_count: 20
+- id: draft-pick-pairings
+  name: Draft Pick Pairings
+  uuid: ec46ca4e-2b68-5092-b52c-5f58c6ddfb69
+  type: insert
+  declared_card_count: 16
+- id: electric-sluggers
+  name: Electric Sluggers
+  uuid: c2753dd5-6fd9-5082-a15d-4de78dadbb9c
+  type: insert
+  declared_card_count: 25
+  parallels:
+  - name: Aqua Refractor
+    print_run: 125
+    serial_numbered: true
+  - name: Autograph Gold Refractor
+    print_run: 50
+    serial_numbered: true
+  - name: Autograph Orange Refractor
+    print_run: 25
+    serial_numbered: true
+  - name: Autograph Red Refractor
+    print_run: 5
+    serial_numbered: true
+  - name: Gold Refractor
+    print_run: 50
+    serial_numbered: true
+  - name: Green Refractor
+    print_run: 99
+    serial_numbered: true
+  - name: Mega Chrome
+  - name: Mega Chrome Black Refractor
+    print_run: 10
+    serial_numbered: true
+  - name: Mega Chrome Blue Refractor
+    print_run: 150
+    serial_numbered: true
+  - name: Mega Chrome Burgundy Refractor
+    print_run: 299
+    serial_numbered: true
+  - name: Mega Chrome Gold Refractor
+    print_run: 50
+    serial_numbered: true
+  - name: Mega Chrome Green Refractor
+    print_run: 99
+    serial_numbered: true
+  - name: Mega Chrome Orange Refractor
+    print_run: 25
+    serial_numbered: true
+  - name: Mega Chrome Pink Refractor
+    print_run: 199
+    serial_numbered: true
+  - name: Mega Chrome Purple Refractor
+    print_run: 250
+    serial_numbered: true
+  - name: Mega Chrome Red Refractor
+    print_run: 5
+    serial_numbered: true
+  - name: Mega Chrome Rose Gold Refractor
+    print_run: 1
+    serial_numbered: true
+  - name: Mini-Diamond Refractor
+    print_run: 150
+    serial_numbered: true
+  - name: Orange Refractor
+    print_run: 25
+    serial_numbered: true
+  - name: Red Refractor
+    print_run: 5
+    serial_numbered: true
+  - name: SuperFractor
+    print_run: 1
+    serial_numbered: true
+  subsets:
+  - id: electric-sluggers-autographs
+    name: Electric Sluggers Autographs
+    uuid: e6914bd3-9ae8-5656-9f6e-fbae45363c7f
+    type: autograph
+    declared_card_count: 14
+    parallels:
+    - name: SuperFractor
+      print_run: 1
+      serial_numbered: true
+- id: final-draft
+  name: Final Draft
+  uuid: 39342dd2-9dc7-5c2f-b47d-9cc841ba95e6
+  type: insert
+  declared_card_count: 20
+- id: patchwork
+  name: Patchwork
+  uuid: 78e7d64e-f65a-557d-a20a-3323a1a90634
+  type: relic
+  declared_card_count: 30
+- id: power-chords
+  name: Power Chords
+  uuid: beb3edd0-2459-5d8e-86ad-d4a483ae34ab
+  type: insert
+  declared_card_count: 25
+  parallels:
+  - name: Aqua Refractor
+    print_run: 125
+    serial_numbered: true
+  - name: Autograph Gold Refractor
+    print_run: 50
+    serial_numbered: true
+  - name: Autograph Orange Refractor
+    print_run: 25
+    serial_numbered: true
+  - name: Autograph Red Refractor
+    print_run: 5
+    serial_numbered: true
+  - name: Gold Refractor
+    print_run: 50
+    serial_numbered: true
+  - name: Green Refractor
+    print_run: 99
+    serial_numbered: true
+  - name: Mini-Diamond Refractor
+    print_run: 150
+    serial_numbered: true
+  - name: Orange Refractor
+    print_run: 25
+    serial_numbered: true
+  - name: Red Refractor
+    print_run: 5
+    serial_numbered: true
+  - name: SuperFractor
+    print_run: 1
+    serial_numbered: true
+  subsets:
+  - id: power-chords-autographs
+    name: Power Chords Autographs
+    uuid: edc9165f-ab52-522e-8453-b6b2f378b9b9
+    type: autograph
+    declared_card_count: 15
+    parallels:
+    - name: SuperFractor
+      print_run: 1
+      serial_numbered: true
+- id: ultimate-autograph-booklet
+  name: Ultimate Autograph Booklet
+  uuid: b0cb348f-7aab-5553-acbf-f632e8ce86ce
+  type: autograph
+  declared_card_count: 1
+- id: under-the-radar
+  name: Under The Radar
+  uuid: 15079f18-4d56-5b89-a419-cfbb3ee194d6
+  type: insert
+  declared_card_count: 20
+  parallels:
+  - name: Aqua Refractor
+    print_run: 125
+    serial_numbered: true
+  - name: Autograph Gold Refractor
+    print_run: 50
+    serial_numbered: true
+  - name: Autograph Orange Refractor
+    print_run: 25
+    serial_numbered: true
+  - name: Autograph Red Refractor
+    print_run: 5
+    serial_numbered: true
+  - name: Gold Refractor
+    print_run: 50
+    serial_numbered: true
+  - name: Green Refractor
+    print_run: 99
+    serial_numbered: true
+  - name: Mini-Diamond Refractor
+    print_run: 150
+    serial_numbered: true
+  - name: Orange Refractor
+    print_run: 25
+    serial_numbered: true
+  - name: Red Refractor
+    print_run: 5
+    serial_numbered: true
+  - name: SuperFractor
+    print_run: 1
+    serial_numbered: true
+  subsets:
+  - id: under-the-radar-autographs
+    name: Under The Radar Autographs
+    uuid: a042e049-b38e-5c15-a005-5becb3288d27
     type: autograph
     declared_card_count: 13
     parallels:

--- a/data/baseball/2026-bowman/manifest.yaml
+++ b/data/baseball/2026-bowman/manifest.yaml
@@ -205,10 +205,10 @@ base_sets:
   - name: FireFractor
     print_run: 3
     serial_numbered: true
-  - name: Fuschia Refractor
+  - name: Fuchsia Refractor
     print_run: 199
     serial_numbered: true
-  - name: Fuschia Wave Refractor
+  - name: Fuchsia Wave Refractor
     print_run: 199
     serial_numbered: true
   - name: Gold Geometric Refractor
@@ -280,7 +280,7 @@ base_sets:
   - name: Reptilian Blue Refractor
     print_run: 150
     serial_numbered: true
-  - name: Reptilian Fuschia Refractor
+  - name: Reptilian Fuchsia Refractor
     print_run: 199
     serial_numbered: true
   - name: Reptilian Gold Refractor
@@ -352,7 +352,7 @@ base_sets:
     - autograph
     declared_card_count: 47
   - id: chrome-prospect-packfractor-autographs
-    name: Chrome Prospect Packfractor Autographs
+    name: Chrome Prospect PackFractor Autographs
     uuid: '08a54c52-3d8a-5851-acea-0f7ef8283284'
     type:
     - autograph
@@ -364,7 +364,7 @@ base_sets:
     - variation
     declared_card_count: 11
   - id: chrome-prospects-packfractor-variation
-    name: Chrome Prospects Packfractor Variation
+    name: Chrome Prospects PackFractor Variation
     uuid: 27caf6b1-932c-56d8-8a8b-509bfcbffd21
     type:
     - variation

--- a/data/baseball/2026-bowman/manifest.yaml
+++ b/data/baseball/2026-bowman/manifest.yaml
@@ -2,136 +2,140 @@ set_id: 2026-bowman
 base_sets:
 - id: base-set
   name: Base Set
-  uuid: 168d4ff6-9273-4035-b6ba-73c4387f8fba
+  uuid: f5a286b5-d063-4ab7-a8a2-4548e01da134
   declared_card_count: 100
   parallels:
-  - name: Green Pattern
-    print_run: 99
-    serial_numbered: true
-  - name: Purple Pattern
-    print_run: 250
-    serial_numbered: true
-  - name: Bowman Logo
-  - name: Gold Pattern
-    print_run: 50
-    serial_numbered: true
-  - name: Purple
-    print_run: 250
-    serial_numbered: true
-  - name: Yellow
-    print_run: 75
-    serial_numbered: true
-  - name: Pink
-    print_run: 175
-    serial_numbered: true
-  - name: Blue
-    print_run: 150
-    serial_numbered: true
-  - name: Orange
-    print_run: 25
-    serial_numbered: true
-  - name: Blue Pattern
-    print_run: 150
-    serial_numbered: true
-  - name: Yellow Pattern
-    print_run: 75
-    serial_numbered: true
-  - name: Fuchsia
-    print_run: 299
-    serial_numbered: true
-  - name: Green
-    print_run: 99
-    serial_numbered: true
-  - name: Sky Blue
-    print_run: 499
-    serial_numbered: true
-  - name: Printing Plates
-    print_run: 4
-    serial_numbered: true
-  - name: Neon Green
-    print_run: 399
+  - name: Black
+    print_run: 10
     serial_numbered: true
   - name: Black Pattern
     print_run: 10
     serial_numbered: true
-  - name: Black
-    print_run: 10
+  - name: Blue
+    print_run: 150
     serial_numbered: true
-  - name: Red
-    print_run: 5
+  - name: Blue Pattern
+    print_run: 150
     serial_numbered: true
-  - name: Platinum
-    print_run: 1
-    serial_numbered: true
-  - name: Orange Pattern
-    print_run: 25
+  - name: Bowman Logo
+  - name: Fuchsia
+    print_run: 299
     serial_numbered: true
   - name: Gold
     print_run: 50
     serial_numbered: true
+  - name: Gold Pattern
+    print_run: 50
+    serial_numbered: true
+  - name: Green
+    print_run: 99
+    serial_numbered: true
+  - name: Green Pattern
+    print_run: 99
+    serial_numbered: true
+  - name: Neon Green
+    print_run: 399
+    serial_numbered: true
+  - name: Orange
+    print_run: 25
+    serial_numbered: true
+  - name: Orange Pattern
+    print_run: 25
+    serial_numbered: true
+  - name: Pink
+    print_run: 175
+    serial_numbered: true
+  - name: Platinum
+    print_run: 1
+    serial_numbered: true
+  - name: Printing Plates
+    print_run: 4
+    serial_numbered: true
+  - name: Purple
+    print_run: 250
+    serial_numbered: true
+  - name: Purple Pattern
+    print_run: 250
+    serial_numbered: true
+  - name: Red
+    print_run: 5
+    serial_numbered: true
+  - name: Sky Blue
+    print_run: 499
+    serial_numbered: true
+  - name: Yellow
+    print_run: 75
+    serial_numbered: true
+  - name: Yellow Pattern
+    print_run: 75
+    serial_numbered: true
   subsets:
   - id: anime
     name: Anime
-    uuid: 9e59ac20-79fc-4f23-b8fb-f7a72778bf2c
+    uuid: eab6f0ed-d765-4f6a-93e9-aad8b92f6036
     type: insert
     declared_card_count: 29
     subsets:
     - id: anime-kanji-variations
       name: Anime - Kanji Variations
-      uuid: 2c02fa89-b805-4344-8a9b-77a92549693f
+      uuid: 70dfe11a-2035-4857-815c-010c7ccf77bf
       type: variation
       declared_card_count: 7
   - id: base-etched-in-glass-variations
     name: Base - Etched In Glass Variations
-    uuid: d4434c54-bdd9-41f2-86fb-d9b717e5aa28
+    uuid: 19c1ee6c-ac8b-4e1b-ae5b-c0d614a5da9f
     type: variation
     declared_card_count: 12
   - id: base-red-rc-variations
     name: Base - Red RC Variations
-    uuid: dff7e2d9-07b2-4738-ad5f-6706e288e9f9
+    uuid: 2a1639c7-6892-4ec4-b7a5-a2f0005fd638
     type: variation
     declared_card_count: 40
   - id: base-rookie-and-veteran-retail-autographs
     name: Base Rookie and Veteran Retail Autographs
-    uuid: 6bed788b-2bec-40e3-a12f-65f2499bee7e
+    uuid: 7b8b8faf-a578-478f-9d06-4d8b2d7ce943
     type: autograph
     declared_card_count: 35
   - id: bowman-scouts-top-100
     name: Bowman Scouts Top 100
-    uuid: e571ff1d-33c3-437f-9465-ed6b4e4cf944
+    uuid: 2deb3a4f-afa9-433b-b121-f2970f184bb9
     type: insert
     declared_card_count: 100
-  - id: bowman-spotlights
-    name: Bowman Spotlights
-    uuid: c6f0e0b7-3be3-42c3-b76e-0e80cd2b57b8
-    type: insert
-    declared_card_count: 15
-  - id: bowman-sterling
-    name: Bowman Sterling
-    uuid: 338ec5f8-677f-4734-a223-69d1cc03ffe8
-    type: insert
-    declared_card_count: 15
     parallels:
-    - name: Mega Chrome Rose Gold Refractor
-      print_run: 1
+    - name: Aqua Refractor
+      print_run: 125
       serial_numbered: true
-    - name: Mega Chrome Red Refractor
-      print_run: 5
+    - name: Gold Refractor
+      print_run: 50
       serial_numbered: true
-    - name: Mega Chrome Blue Refractor
+    - name: Green Refractor
+      print_run: 99
+      serial_numbered: true
+    - name: Mini-Diamond Refractor
       print_run: 150
       serial_numbered: true
-    - name: Mega Chrome Pink Refractor
-      print_run: 199
+    - name: Orange Refractor
+      print_run: 25
+      serial_numbered: true
+    - name: Red Refractor
+      print_run: 5
       serial_numbered: true
     - name: SuperFractor
       print_run: 1
       serial_numbered: true
-    - name: Mega Chrome Black Refractor
-      print_run: 10
-      serial_numbered: true
-    - name: Green Refractor
-      print_run: 99
+  - id: bowman-spotlights
+    name: Bowman Spotlights
+    uuid: 5b768b03-46f2-4416-8d64-1814e6b16e80
+    type: insert
+    declared_card_count: 15
+  - id: bowman-sterling
+    name: Bowman Sterling
+    uuid: ae3404d6-24f9-4838-9ba5-0382792324ae
+    type: insert
+    declared_card_count: 15
+    parallels:
+    - name: Aqua Refractor
+      print_run: 125
       serial_numbered: true
     - name: Autograph Gold Refractor
       print_run: 50
@@ -139,18 +143,21 @@ base_sets:
     - name: Autograph Orange Refractor
       print_run: 25
       serial_numbered: true
-    - name: Mega Chrome
-    - name: Orange Refractor
-      print_run: 25
-      serial_numbered: true
-    - name: Mega Chrome Purple Refractor
-      print_run: 250
-      serial_numbered: true
-    - name: Red Refractor
+    - name: Autograph Red Refractor
       print_run: 5
       serial_numbered: true
-    - name: Mega Chrome Orange Refractor
-      print_run: 25
+    - name: Gold Refractor
+      print_run: 50
+      serial_numbered: true
+    - name: Green Refractor
+      print_run: 99
+      serial_numbered: true
+    - name: Mega Chrome
+    - name: Mega Chrome Black Refractor
+      print_run: 10
+      serial_numbered: true
+    - name: Mega Chrome Blue Refractor
+      print_run: 150
       serial_numbered: true
     - name: Mega Chrome Gold Refractor
       print_run: 50
@@ -158,22 +165,37 @@ base_sets:
     - name: Mega Chrome Green Refractor
       print_run: 99
       serial_numbered: true
+    - name: Mega Chrome Orange Refractor
+      print_run: 25
+      serial_numbered: true
+    - name: Mega Chrome Pink Refractor
+      print_run: 199
+      serial_numbered: true
+    - name: Mega Chrome Purple Refractor
+      print_run: 250
+      serial_numbered: true
+    - name: Mega Chrome Red Refractor
+      print_run: 5
+      serial_numbered: true
+    - name: Mega Chrome Rose Gold Refractor
+      print_run: 1
+      serial_numbered: true
     - name: Mini-Diamond Refractor
       print_run: 150
       serial_numbered: true
-    - name: Autograph Red Refractor
+    - name: Orange Refractor
+      print_run: 25
+      serial_numbered: true
+    - name: Red Refractor
       print_run: 5
       serial_numbered: true
-    - name: Aqua Refractor
-      print_run: 125
-      serial_numbered: true
-    - name: Gold Refractor
-      print_run: 50
+    - name: SuperFractor
+      print_run: 1
       serial_numbered: true
     subsets:
     - id: bowman-sterling-autographs
       name: Bowman Sterling Autographs
-      uuid: a305d487-4bf2-4c1a-ac92-3260514dd44e
+      uuid: 268eddee-1e2a-483b-9e13-df8a775db8dc
       type: autograph
       declared_card_count: 10
       parallels:
@@ -182,85 +204,85 @@ base_sets:
         serial_numbered: true
   - id: crystallized
     name: Crystallized
-    uuid: 32be62c5-f1c2-4a9c-a5e4-f1c0f9d72c11
+    uuid: 2f3a8e7f-9e15-4f66-bfdc-91101767bb33
     type: insert
     declared_card_count: 20
   - id: draft-pick-pairings
     name: Draft Pick Pairings
-    uuid: 95a7c168-1959-4844-a7b3-05f702728353
+    uuid: c472e3d9-f579-4f1b-bd99-ce7d925c5368
     type: insert
     declared_card_count: 16
   - id: electric-sluggers
     name: Electric Sluggers
-    uuid: 6659aa51-202e-4377-8f06-6c149d2ca62a
+    uuid: c7813708-51de-4cb2-960e-3a83c7216b6d
     type: insert
     declared_card_count: 25
     parallels:
-    - name: Autograph Orange Refractor
-      print_run: 25
-      serial_numbered: true
-    - name: Gold Refractor
-      print_run: 50
-      serial_numbered: true
-    - name: SuperFractor
-      print_run: 1
-      serial_numbered: true
-    - name: Mega Chrome Gold Refractor
-      print_run: 50
-      serial_numbered: true
-    - name: Mega Chrome Pink Refractor
-      print_run: 199
-      serial_numbered: true
-    - name: Mega Chrome Red Refractor
-      print_run: 5
-      serial_numbered: true
-    - name: Mega Chrome
-    - name: Autograph Red Refractor
-      print_run: 5
-      serial_numbered: true
-    - name: Mini-Diamond Refractor
-      print_run: 150
-      serial_numbered: true
-    - name: Mega Chrome Black Refractor
-      print_run: 10
-      serial_numbered: true
-    - name: Mega Chrome Purple Refractor
-      print_run: 250
-      serial_numbered: true
-    - name: Mega Chrome Rose Gold Refractor
-      print_run: 1
-      serial_numbered: true
-    - name: Orange Refractor
-      print_run: 25
-      serial_numbered: true
-    - name: Mega Chrome Burgundy Refractor
-      print_run: 299
-      serial_numbered: true
-    - name: Mega Chrome Blue Refractor
-      print_run: 150
-      serial_numbered: true
-    - name: Mega Chrome Orange Refractor
-      print_run: 25
+    - name: Aqua Refractor
+      print_run: 125
       serial_numbered: true
     - name: Autograph Gold Refractor
       print_run: 50
       serial_numbered: true
-    - name: Red Refractor
+    - name: Autograph Orange Refractor
+      print_run: 25
+      serial_numbered: true
+    - name: Autograph Red Refractor
       print_run: 5
+      serial_numbered: true
+    - name: Gold Refractor
+      print_run: 50
       serial_numbered: true
     - name: Green Refractor
       print_run: 99
       serial_numbered: true
+    - name: Mega Chrome
+    - name: Mega Chrome Black Refractor
+      print_run: 10
+      serial_numbered: true
+    - name: Mega Chrome Blue Refractor
+      print_run: 150
+      serial_numbered: true
+    - name: Mega Chrome Burgundy Refractor
+      print_run: 299
+      serial_numbered: true
+    - name: Mega Chrome Gold Refractor
+      print_run: 50
+      serial_numbered: true
     - name: Mega Chrome Green Refractor
       print_run: 99
       serial_numbered: true
-    - name: Aqua Refractor
-      print_run: 125
+    - name: Mega Chrome Orange Refractor
+      print_run: 25
+      serial_numbered: true
+    - name: Mega Chrome Pink Refractor
+      print_run: 199
+      serial_numbered: true
+    - name: Mega Chrome Purple Refractor
+      print_run: 250
+      serial_numbered: true
+    - name: Mega Chrome Red Refractor
+      print_run: 5
+      serial_numbered: true
+    - name: Mega Chrome Rose Gold Refractor
+      print_run: 1
+      serial_numbered: true
+    - name: Mini-Diamond Refractor
+      print_run: 150
+      serial_numbered: true
+    - name: Orange Refractor
+      print_run: 25
+      serial_numbered: true
+    - name: Red Refractor
+      print_run: 5
+      serial_numbered: true
+    - name: SuperFractor
+      print_run: 1
       serial_numbered: true
     subsets:
     - id: electric-sluggers-autographs
       name: Electric Sluggers Autographs
-      uuid: 37ba0ff1-5e16-4f32-b8fd-85250ef8fb06
+      uuid: b9b00579-dc2e-462e-bf68-d62d06f53b79
       type: autograph
       declared_card_count: 14
       parallels:
@@ -269,37 +291,22 @@ base_sets:
         serial_numbered: true
   - id: final-draft
     name: Final Draft
-    uuid: c049abb0-b631-4237-a6dd-8c54258ed067
+    uuid: 5fa9dda9-7eff-4bd1-a846-21f4865f23d1
     type: insert
     declared_card_count: 20
   - id: patchwork
     name: Patchwork
-    uuid: ef897d31-5856-4801-a942-d5d7e44594d2
+    uuid: 6c80b645-b235-4691-9eba-e4ec08f56649
     type: relic
     declared_card_count: 30
   - id: power-chords
     name: Power Chords
-    uuid: 5deb89a1-d269-4dc3-a773-0abc824da32b
+    uuid: cb4d56b1-932b-4bf7-ae83-05e2ee57eb00
     type: insert
     declared_card_count: 25
     parallels:
-    - name: Green Refractor
-      print_run: 99
-      serial_numbered: true
     - name: Aqua Refractor
       print_run: 125
-      serial_numbered: true
-    - name: Orange Refractor
-      print_run: 25
-      serial_numbered: true
-    - name: Gold Refractor
-      print_run: 50
-      serial_numbered: true
-    - name: Autograph Red Refractor
-      print_run: 5
-      serial_numbered: true
-    - name: Red Refractor
-      print_run: 5
       serial_numbered: true
     - name: Autograph Gold Refractor
       print_run: 50
@@ -307,8 +314,23 @@ base_sets:
     - name: Autograph Orange Refractor
       print_run: 25
       serial_numbered: true
+    - name: Autograph Red Refractor
+      print_run: 5
+      serial_numbered: true
+    - name: Gold Refractor
+      print_run: 50
+      serial_numbered: true
+    - name: Green Refractor
+      print_run: 99
+      serial_numbered: true
     - name: Mini-Diamond Refractor
       print_run: 150
+      serial_numbered: true
+    - name: Orange Refractor
+      print_run: 25
+      serial_numbered: true
+    - name: Red Refractor
+      print_run: 5
       serial_numbered: true
     - name: SuperFractor
       print_run: 1
@@ -316,7 +338,7 @@ base_sets:
     subsets:
     - id: power-chords-autographs
       name: Power Chords Autographs
-      uuid: 57372ac6-8bfc-4679-bf2f-597bdddf6159
+      uuid: e9f80553-ef5f-4199-8091-24166a15f174
       type: autograph
       declared_card_count: 15
       parallels:
@@ -325,49 +347,49 @@ base_sets:
         serial_numbered: true
   - id: ultimate-autograph-booklet
     name: Ultimate Autograph Booklet
-    uuid: ceea2c53-da1c-41f4-aa91-5d3648440ac0
+    uuid: 0fb32f94-c923-4bec-b085-295d650442ec
     type: autograph
     declared_card_count: 1
   - id: under-the-radar
     name: Under The Radar
-    uuid: 76baedab-d921-467c-afb1-96bf1f9c1bdd
+    uuid: d107b9c1-8ab1-44e9-89f1-dc8e9c518e22
     type: insert
     declared_card_count: 20
     parallels:
-    - name: Red Refractor
-      print_run: 5
-      serial_numbered: true
-    - name: Autograph Red Refractor
-      print_run: 5
+    - name: Aqua Refractor
+      print_run: 125
       serial_numbered: true
     - name: Autograph Gold Refractor
       print_run: 50
       serial_numbered: true
-    - name: SuperFractor
-      print_run: 1
+    - name: Autograph Orange Refractor
+      print_run: 25
       serial_numbered: true
-    - name: Mini-Diamond Refractor
-      print_run: 150
-      serial_numbered: true
-    - name: Green Refractor
-      print_run: 99
+    - name: Autograph Red Refractor
+      print_run: 5
       serial_numbered: true
     - name: Gold Refractor
       print_run: 50
       serial_numbered: true
+    - name: Green Refractor
+      print_run: 99
+      serial_numbered: true
+    - name: Mini-Diamond Refractor
+      print_run: 150
+      serial_numbered: true
     - name: Orange Refractor
       print_run: 25
       serial_numbered: true
-    - name: Autograph Orange Refractor
-      print_run: 25
+    - name: Red Refractor
+      print_run: 5
       serial_numbered: true
-    - name: Aqua Refractor
-      print_run: 125
+    - name: SuperFractor
+      print_run: 1
       serial_numbered: true
     subsets:
     - id: under-the-radar-autographs
       name: Under The Radar Autographs
-      uuid: 31438de5-9725-4141-84fe-1cefa6e6fdf4
+      uuid: e6297d4f-0fe9-4b12-8ec6-b4a6ee954474
       type: autograph
       declared_card_count: 13
       parallels:
@@ -376,282 +398,282 @@ base_sets:
         serial_numbered: true
 - id: base-prospects
   name: Base Prospects
-  uuid: 9f84812d-a258-441e-860c-0ae8052eae8c
+  uuid: '0438c27f-56e6-4bd0-928a-d47a774e14fd'
   declared_card_count: 150
   parallels:
-  - name: Neon Green
-    print_run: 299
-    serial_numbered: true
-  - name: Green Pattern
-    print_run: 75
-    serial_numbered: true
-  - name: Fuchsia
-    print_run: 250
-    serial_numbered: true
-  - name: Yellow
-    print_run: 75
-    serial_numbered: true
-  - name: Gold Pattern
-    print_run: 50
-    serial_numbered: true
-  - name: Yellow Pattern
-    print_run: 75
-    serial_numbered: true
-  - name: Platinum
-    print_run: 1
-    serial_numbered: true
   - name: Black
     print_run: 10
     serial_numbered: true
   - name: Black Pattern
     print_run: 10
     serial_numbered: true
-  - name: Orange
-    print_run: 25
-    serial_numbered: true
-  - name: Pink
-    print_run: 150
-    serial_numbered: true
   - name: Blue
     print_run: 150
-    serial_numbered: true
-  - name: Purple Pattern
-    print_run: 175
-    serial_numbered: true
-  - name: Printing Plates
-    print_run: 4
     serial_numbered: true
   - name: Blue Pattern
     print_run: 99
     serial_numbered: true
   - name: Bowman Logo
-  - name: Sky Blue
-    print_run: 399
-    serial_numbered: true
-  - name: Green
-    print_run: 99
-    serial_numbered: true
-  - name: Orange Pattern
-    print_run: 25
-    serial_numbered: true
-  - name: Red
-    print_run: 5
+  - name: Fuchsia
+    print_run: 250
     serial_numbered: true
   - name: Gold
     print_run: 50
     serial_numbered: true
-  - name: Purple
-    print_run: 250
+  - name: Gold Pattern
+    print_run: 50
     serial_numbered: true
-  subsets:
-  - id: base-prospect-retail-autographs
-    name: Base Prospect Retail Autographs
-    uuid: fc4fa5fa-cf08-49c7-bad6-96348c4bd3de
-    type: autograph
-    declared_card_count: 31
-- id: chrome-prospects
-  name: Chrome Prospects
-  uuid: 8b1c2b09-2551-4496-9c2c-1d38ff731557
-  declared_card_count: 150
-  parallels:
-  - name: Speckle Refractor
+  - name: Green
+    print_run: 99
+    serial_numbered: true
+  - name: Green Pattern
+    print_run: 75
+    serial_numbered: true
+  - name: Neon Green
     print_run: 299
     serial_numbered: true
-  - name: Reptilian Refractor
-  - name: FireFractor
-    print_run: 3
-    serial_numbered: true
-  - name: Peanuts Refractor
-  - name: Rose Gold X-Fractor
-    print_run: 15
-    serial_numbered: true
-  - name: Gold Shimmer Refractor
-    print_run: 50
-    serial_numbered: true
-  - name: Yellow Refractor
-    print_run: 75
-    serial_numbered: true
-  - name: Reptilian Orange Refractor
+  - name: Orange
     print_run: 25
     serial_numbered: true
-  - name: Green Shimmer Refractor
-    print_run: 99
-    serial_numbered: true
-  - name: Orange Geometric Refractor
+  - name: Orange Pattern
     print_run: 25
     serial_numbered: true
-  - name: Refractor
-    print_run: 499
-    serial_numbered: true
-  - name: Green Refractor
-    print_run: 99
-    serial_numbered: true
-  - name: Purple Geometric Refractor
-    print_run: 250
-    serial_numbered: true
-  - name: Gold Geometric Refractor
-    print_run: 50
-    serial_numbered: true
-  - name: Red Geometric Refractor
-    print_run: 5
-    serial_numbered: true
-  - name: Orange Shimmer Refractor
-    print_run: 25
-    serial_numbered: true
-  - name: Sunflower Seeds Refractor
-  - name: Blue Geometric Refractor
+  - name: Pink
     print_run: 150
     serial_numbered: true
-  - name: X-Fractor
-  - name: Reptilian Fuschia Refractor
-    print_run: 199
-    serial_numbered: true
-  - name: Orange Refractor
-    print_run: 25
-    serial_numbered: true
-  - name: Mini-Diamond Refractor
-  - name: PackFractor
-    print_run: 89
-    serial_numbered: true
-  - name: Yellow Wave Refractor
-    print_run: 75
-    serial_numbered: true
-  - name: Laser Refractor
-  - name: Aqua Geometric Refractor
-    print_run: 125
-    serial_numbered: true
-  - name: Red Lava Refractor
-    print_run: 5
-    serial_numbered: true
-  - name: Green Geometric Refractor
-    print_run: 99
-    serial_numbered: true
-  - name: Bowman LogoFractor
-    print_run: 35
-    serial_numbered: true
-  - name: Black Geometric Refractor
-    print_run: 10
-    serial_numbered: true
-  - name: Reptilian Green Refractor
-    print_run: 99
-    serial_numbered: true
-  - name: Blue Refractor
-    print_run: 150
-    serial_numbered: true
-  - name: Fuschia Wave Refractor
-    print_run: 199
-    serial_numbered: true
-  - name: Yellow X-Fractor
-    print_run: 75
-    serial_numbered: true
-  - name: Gum Ball Refractor
-  - name: Fuschia Refractor
-    print_run: 199
-    serial_numbered: true
-  - name: Blue RayWave Refractor
-    print_run: 150
-    serial_numbered: true
-  - name: Black Refractor
-    print_run: 10
-    serial_numbered: true
-  - name: SuperFractor
+  - name: Platinum
     print_run: 1
-    serial_numbered: true
-  - name: Pop Corn Refractor
-  - name: Purple Refractor
-    print_run: 250
-    serial_numbered: true
-  - name: Reptilian Gold Refractor
-    print_run: 50
     serial_numbered: true
   - name: Printing Plates
     print_run: 4
     serial_numbered: true
-  - name: Red Refractor
+  - name: Purple
+    print_run: 250
+    serial_numbered: true
+  - name: Purple Pattern
+    print_run: 175
+    serial_numbered: true
+  - name: Red
     print_run: 5
     serial_numbered: true
-  - name: Black X-Fractor
-    print_run: 10
-    serial_numbered: true
-  - name: Aqua X-Fractor
-    print_run: 125
-    serial_numbered: true
-  - name: Wave Refractor
-    print_run: 350
-    serial_numbered: true
-  - name: LogoFractor
-  - name: Reptilian Red Refractor
-    print_run: 5
-    serial_numbered: true
-  - name: Gold Refractor
-    print_run: 50
-    serial_numbered: true
-  - name: Blue Shimmer Refractor
-    print_run: 150
-    serial_numbered: true
-  - name: Lava Refractor
+  - name: Sky Blue
     print_run: 399
     serial_numbered: true
-  - name: Rose Gold Refractor
-    print_run: 15
+  - name: Yellow
+    print_run: 75
+    serial_numbered: true
+  - name: Yellow Pattern
+    print_run: 75
+    serial_numbered: true
+  subsets:
+  - id: base-prospect-retail-autographs
+    name: Base Prospect Retail Autographs
+    uuid: 304d6ae4-9f94-40e8-b0ef-f545ff0bb90d
+    type: autograph
+    declared_card_count: 31
+- id: chrome-prospects
+  name: Chrome Prospects
+  uuid: 487aa2ee-8e5d-4a65-8aff-db1e78e14bf5
+  declared_card_count: 150
+  parallels:
+  - name: Aqua Geometric Refractor
+    print_run: 125
     serial_numbered: true
   - name: Aqua Shimmer Refractor
     print_run: 125
     serial_numbered: true
-  - name: Reptilian Blue Refractor
+  - name: Aqua X-Fractor
+    print_run: 125
+    serial_numbered: true
+  - name: Black Geometric Refractor
+    print_run: 10
+    serial_numbered: true
+  - name: Black Refractor
+    print_run: 10
+    serial_numbered: true
+  - name: Black X-Fractor
+    print_run: 10
+    serial_numbered: true
+  - name: Blue Geometric Refractor
     print_run: 150
     serial_numbered: true
-  - name: Purple RayWave Refractor
-    print_run: 250
+  - name: Blue RayWave Refractor
+    print_run: 150
     serial_numbered: true
-  - name: Steel Metal Refractor
-    print_run: 100
+  - name: Blue Refractor
+    print_run: 150
+    serial_numbered: true
+  - name: Blue Shimmer Refractor
+    print_run: 150
+    serial_numbered: true
+  - name: Bowman LogoFractor
+    print_run: 35
+    serial_numbered: true
+  - name: FireFractor
+    print_run: 3
+    serial_numbered: true
+  - name: Fuschia Refractor
+    print_run: 199
+    serial_numbered: true
+  - name: Fuschia Wave Refractor
+    print_run: 199
+    serial_numbered: true
+  - name: Gold Geometric Refractor
+    print_run: 50
+    serial_numbered: true
+  - name: Gold Refractor
+    print_run: 50
+    serial_numbered: true
+  - name: Gold Shimmer Refractor
+    print_run: 50
+    serial_numbered: true
+  - name: Green Geometric Refractor
+    print_run: 99
     serial_numbered: true
   - name: Green Grass Refractor
     print_run: 99
     serial_numbered: true
+  - name: Green Refractor
+    print_run: 99
+    serial_numbered: true
+  - name: Green Shimmer Refractor
+    print_run: 99
+    serial_numbered: true
+  - name: Gum Ball Refractor
+  - name: Laser Refractor
+  - name: Lava Refractor
+    print_run: 399
+    serial_numbered: true
+  - name: LogoFractor
+  - name: Mini-Diamond Refractor
+  - name: Orange Geometric Refractor
+    print_run: 25
+    serial_numbered: true
+  - name: Orange Refractor
+    print_run: 25
+    serial_numbered: true
+  - name: Orange Shimmer Refractor
+    print_run: 25
+    serial_numbered: true
+  - name: PackFractor
+    print_run: 89
+    serial_numbered: true
+  - name: Peanuts Refractor
+  - name: Pop Corn Refractor
+  - name: Printing Plates
+    print_run: 4
+    serial_numbered: true
+  - name: Purple Geometric Refractor
+    print_run: 250
+    serial_numbered: true
+  - name: Purple RayWave Refractor
+    print_run: 250
+    serial_numbered: true
+  - name: Purple Refractor
+    print_run: 250
+    serial_numbered: true
+  - name: Red Geometric Refractor
+    print_run: 5
+    serial_numbered: true
+  - name: Red Lava Refractor
+    print_run: 5
+    serial_numbered: true
+  - name: Red Refractor
+    print_run: 5
+    serial_numbered: true
+  - name: Refractor
+    print_run: 499
+    serial_numbered: true
+  - name: Reptilian Blue Refractor
+    print_run: 150
+    serial_numbered: true
+  - name: Reptilian Fuschia Refractor
+    print_run: 199
+    serial_numbered: true
+  - name: Reptilian Gold Refractor
+    print_run: 50
+    serial_numbered: true
+  - name: Reptilian Green Refractor
+    print_run: 99
+    serial_numbered: true
+  - name: Reptilian Orange Refractor
+    print_run: 25
+    serial_numbered: true
+  - name: Reptilian Red Refractor
+    print_run: 5
+    serial_numbered: true
+  - name: Reptilian Refractor
+  - name: Rose Gold Refractor
+    print_run: 15
+    serial_numbered: true
+  - name: Rose Gold X-Fractor
+    print_run: 15
+    serial_numbered: true
+  - name: Speckle Refractor
+    print_run: 299
+    serial_numbered: true
+  - name: Steel Metal Refractor
+    print_run: 100
+    serial_numbered: true
+  - name: Sunflower Seeds Refractor
+  - name: SuperFractor
+    print_run: 1
+    serial_numbered: true
+  - name: Wave Refractor
+    print_run: 350
+    serial_numbered: true
+  - name: X-Fractor
+  - name: Yellow Refractor
+    print_run: 75
+    serial_numbered: true
+  - name: Yellow Wave Refractor
+    print_run: 75
+    serial_numbered: true
+  - name: Yellow X-Fractor
+    print_run: 75
+    serial_numbered: true
   subsets:
   - id: chrome-prospect-autographs
     name: Chrome Prospect Autographs
-    uuid: a1d9ce29-180b-49eb-aa29-364ba287fa16
+    uuid: e3a5ee3a-af47-46a0-bd21-ca2e8a4d28ee
     type: autograph
     declared_card_count: 87
     parallels:
+    - name: Gold Ink
+      print_run: 15
+      serial_numbered: true
     - name: Speckle Refractor
       print_run: 299
       serial_numbered: true
     - name: Sunflower Seeds Refractor
       print_run: 5
       serial_numbered: true
-    - name: Gold Ink
-      print_run: 15
-      serial_numbered: true
     - name: SuperFractor
       print_run: 1
       serial_numbered: true
   - id: chrome-prospect-gold-ink-autographs
     name: Chrome Prospect Gold Ink Autographs
-    uuid: e3562052-c34d-4e18-a224-343c5df62cbc
+    uuid: c36f91c9-3bfa-48d7-baa1-2882f76e2ecd
     type: autograph
     declared_card_count: 47
   - id: chrome-prospect-packfractor-autographs
     name: Chrome Prospect Packfractor Autographs
-    uuid: 989d3c5d-6e11-4181-a8bc-9d47b80afb05
+    uuid: 8cc95f80-0b54-4925-9a7e-c7f6144ca975
     type: autograph
     declared_card_count: 39
   - id: chrome-prospects-etched-in-glass-variations
     name: Chrome Prospects - Etched In Glass Variations
-    uuid: 7d6ece78-81f3-4873-b309-e85fc9a4c353
+    uuid: e5cae530-4a02-4f14-af3e-c6fbaf0e2daf
     type: variation
     declared_card_count: 11
   - id: chrome-prospects-packfractor-variation
     name: Chrome Prospects Packfractor Variation
-    uuid: 4b6cb4ee-8333-45bd-b590-e6f4c86dc021
+    uuid: 24041b79-fee3-44e3-ac25-498295e5557d
     type: variation
     declared_card_count: 150
   - id: chrome-rookie-autographs
     name: Chrome Rookie Autographs
-    uuid: e4ba7ada-b8b8-447c-aea6-8721b8315b65
+    uuid: 4a8884cc-e7db-44ce-a381-2fd022817948
     type: autograph
     declared_card_count: 13
     parallels:

--- a/data/baseball/2026-bowman/set.yaml
+++ b/data/baseball/2026-bowman/set.yaml
@@ -1,0 +1,21 @@
+uuid: edb5a80d-2881-4ebb-9a64-67f594eb8c67
+set_id: 2026-bowman
+name: 2026 Bowman
+genre: Sports
+category:
+- MLB
+sports:
+- Baseball
+season: '2026'
+years:
+- 2026
+series: 2026 Bowman
+manufacturer: Topps
+release_date: '2026-05-13'
+description: 2026 Bowman is a 100-card set, supplemented by a 150-card Prospects set,
+  released May 13th. Each Hobby box will yield one autograph and 18 inserts. Hobby
+  Jumbo boxes will contain three autographs and 12 inserts.
+source:
+  name: BaseballCardpedia
+  url: https://baseballcardpedia.com/index.php/2026_Bowman#Checklist
+  file: import/2026-Bowman-Baseball-Checklist.xlsx

--- a/data/baseball/2026-bowman/set.yaml
+++ b/data/baseball/2026-bowman/set.yaml
@@ -9,7 +9,6 @@ sports:
 season: '2026'
 years:
 - 2026
-series: 2026 Bowman
 manufacturer: Topps
 release_date: '2026-05-13'
 description: 2026 Bowman is a 100-card set, supplemented by a 150-card Prospects set,


### PR DESCRIPTION
Converts jmurphyrum's **2026 Bowman** checklist (#19, exploded one-file-per-card) into the **v0.3 manifest form** — same real data, now compact and reviewable.

## The collapse
**17,928 card files → 32 files** (`set.yaml` + `manifest.yaml` + 30 checklists)

- **3 base sets**: Base Set (100), Base Prospects (150), Chrome Prospects (150)
- **27 nested subsets**, **1,240 committed rows**, **179 parallel declarations**

## "Bowman Scouts Top 100" — the one data defect, fixed
The importer expanded this insert's 7 refractors as *base-card parallels*, copying base subjects (Aaron Judge, an established star, onto a top-prospects insert). Those **700 refractor files had fabricated subjects but correct parallel metadata**, and the **100 base copies were pure duplicates**. Conversion:
- **700 refractor files → salvaged as 7 real parallels** on the subset (Mini-Diamond /150, Aqua /125, Green /99, Gold /50, Orange /25, Red /5, SuperFractor 1/1 — matches BaseballCardpedia).
- **100 fabricated base rows → dropped.**
- The real `BTP-1..100` checklist (correct prospects) is kept, so those 800 cards are now represented correctly (100 rows + 7 parallels).

## What's preserved vs. derived
- **Base-row UUIDs preserved** from the contributor's data (base #1 Aaron Judge keeps `bda5d046…`).
- **Parallel UUIDs derived**, not committed: `uuidv5(row.uuid, parallel.name)` — idempotent.
- **Node UUIDs** (base sets / subsets) are freshly-minted placeholders pending tcapi.
- **Card names derived** from `subjects` (e.g. `DPPA-BB` → *"Byron Buxton - Minnesota Twins / Kris Bryant - Chicago Cubs"*).

## Judgment calls — please review
1. **Standalone inserts nested under "Base Set"** (Anime, Patchwork, Draft Pick Pairings, …) by convention. They're really *product-level*. Open: allow product-level inserts vs. keep this nesting.
2. **Autographs / variations nested under their parent** (e.g. Bowman Sterling → Bowman Sterling Autographs).
3. **Node `type` inferred from names** (autograph / variation / relic / insert).

## ⚠️ Draft — dependencies
Cannot pass CI or merge until **#28** (v0.3 schema) is adopted and `validate.py` is ported to v0.3. Reviewable now. Supersedes #19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)