### PR TITLE
feat(data): 2026 Topps Series 2 in v0.3 manifest form (converted from #23)

### DIFF
--- a/data/baseball/2026-topps-series-2/checklists/1952-rookie-variation-autographs.yaml
+++ b/data/baseball/2026-topps-series-2/checklists/1952-rookie-variation-autographs.yaml
@@ -1,0 +1,190 @@
+- number: '129'
+  uuid: f902e57c-2a94-4540-9b2f-63c6471c143b
+  subjects:
+  - entities:
+    - role: player
+      name: Cole Young
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: '214'
+  uuid: 7edad94e-6770-44b9-8e61-4844a32800cb
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan McLean
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '339'
+  uuid: 5973dddc-0ac6-4977-bb32-f9dba55ab958
+  subjects:
+  - entities:
+    - role: player
+      name: Dylan Beavers
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '372'
+  uuid: bc6b04de-c395-46af-adf5-674a7134b39d
+  subjects:
+  - entities:
+    - role: player
+      name: Sal Stewart
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '406'
+  uuid: 132a5404-8f28-4d5a-babb-30bd5f579a2b
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Eldridge
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '435'
+  uuid: c6c14f7a-bb09-4346-a072-dd2266fa3c09
+  subjects:
+  - entities:
+    - role: player
+      name: Denzer Guzman
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: '456'
+  uuid: c656853d-e62b-4955-bb21-f7e04f13addd
+  subjects:
+  - entities:
+    - role: player
+      name: Justin Dean
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '458'
+  uuid: 00b9fdc6-404a-420a-9648-27cd56e64ec3
+  subjects:
+  - entities:
+    - role: player
+      name: Chase DeLauter
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '501'
+  uuid: 4aac3cff-5b73-4bf9-a4c6-bbbe46969ffc
+  subjects:
+  - entities:
+    - role: player
+      name: Connelly Early
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '530'
+  uuid: 12608d5f-f563-46f3-9917-bf527e6bf7bd
+  subjects:
+  - entities:
+    - role: player
+      name: Carter Jensen
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: '570'
+  uuid: 135411d8-d4e5-4994-a07a-0e6ea61f88c4
+  subjects:
+  - entities:
+    - role: player
+      name: Rolddy Muñoz
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: '578'
+  uuid: 76db4c97-1030-4c90-9a39-f828282f75b2
+  subjects:
+  - entities:
+    - role: player
+      name: Heriberto Hernández
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: '601'
+  uuid: d227877b-e961-4885-aec9-5519ea44a2db
+  subjects:
+  - entities:
+    - role: player
+      name: Zach Cole
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '603'
+  uuid: 156f4516-8701-4eec-8e24-61abd45cb2d1
+  subjects:
+  - entities:
+    - role: player
+      name: George Valera
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '620'
+  uuid: dc08287d-a7ab-45bb-b536-d4ae0caaa4e1
+  subjects:
+  - entities:
+    - role: player
+      name: Trey Yesavage
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '623'
+  uuid: 6c2164a6-faed-47ce-8100-d7c3cc408300
+  subjects:
+  - entities:
+    - role: player
+      name: Rafael Flores
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '659'
+  uuid: f6fdd5a7-8909-465f-a748-be06fc4092f5
+  subjects:
+  - entities:
+    - role: player
+      name: Harry Ford
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: '665'
+  uuid: 53ce279e-b1a3-4f42-9fd8-a757096e1207
+  subjects:
+  - entities:
+    - role: player
+      name: Jose Corniell
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: '674'
+  uuid: 3b7598ba-7e81-4afe-af9e-4f77c124e5d5
+  subjects:
+  - entities:
+    - role: player
+      name: Andre Granillo
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 

--- a/data/baseball/2026-topps-series-2/checklists/1991-topps-all-stars.yaml
+++ b/data/baseball/2026-topps-series-2/checklists/1991-topps-all-stars.yaml
@@ -1,0 +1,500 @@
+- number: 91AS-1
+  uuid: f8586094-2949-4d7e-b884-458832930aff
+  subjects:
+  - entities:
+    - role: player
+      name: Aaron Judge
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: 91AS-2
+  uuid: ff9948ee-c776-4743-91bb-0a7588e7f04d
+  subjects:
+  - entities:
+    - role: player
+      name: Adrian Beltré
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: 91AS-3
+  uuid: 79abfb1c-8925-4e14-bac9-a510ed9eab87
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Schwarber
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: 91AS-4
+  uuid: '0178b21a-7f03-4ba6-8aef-b0fcd2faa1b7'
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Trout
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: 91AS-5
+  uuid: b29f8949-308e-4abf-9a17-e068a3088467
+  subjects:
+  - entities:
+    - role: player
+      name: Sammy Sosa
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: 91AS-6
+  uuid: 855c91d8-4604-4181-aa18-e7b020cd12c8
+  subjects:
+  - entities:
+    - role: player
+      name: Tony Gwynn
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: 91AS-7
+  uuid: 80f50d9b-db2b-464f-9591-788df612052c
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Harper
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: 91AS-8
+  uuid: f52cc8b1-687b-479e-881d-c00751f81f1b
+  subjects:
+  - entities:
+    - role: player
+      name: Pedro Martínez
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: 91AS-9
+  uuid: 4f02ae20-cbde-46f7-920d-a3bf59d02c09
+  subjects:
+  - entities:
+    - role: player
+      name: Francisco Lindor
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: 91AS-10
+  uuid: b32ac92a-cc4a-48e4-9a52-06fa31615c9c
+  subjects:
+  - entities:
+    - role: player
+      name: Rickey Henderson
+      ref: 
+    - role: team
+      name: Oakland Athletics
+      ref: 
+- number: 91AS-11
+  uuid: 79e42a08-2778-4a73-8451-cdf6fc120b35
+  subjects:
+  - entities:
+    - role: player
+      name: Joe Mauer
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: 91AS-12
+  uuid: b79cd6d0-8247-4c69-914c-a83aba511aba
+  subjects:
+  - entities:
+    - role: player
+      name: Joey Votto
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: 91AS-13
+  uuid: fdda5dc7-6186-498a-bf7f-ad9e17dc2806
+  subjects:
+  - entities:
+    - role: player
+      name: Mookie Betts
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: 91AS-14
+  uuid: cb29a0e4-e09f-462c-9489-a7b9b24b40fb
+  subjects:
+  - entities:
+    - role: player
+      name: Reggie Jackson
+      ref: 
+    - role: team
+      name: Oakland Athletics
+      ref: 
+- number: 91AS-15
+  uuid: ef6b3b02-af7d-4575-9e4d-87b58962d56c
+  subjects:
+  - entities:
+    - role: player
+      name: Jackie Robinson
+      ref: 
+    - role: team
+      name: Brooklyn Dodgers
+      ref: 
+- number: 91AS-16
+  uuid: ed01d0be-e719-46b7-a4ca-6894b95601a8
+  subjects:
+  - entities:
+    - role: player
+      name: Christian Yelich
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: 91AS-17
+  uuid: 02e1452d-4e65-48de-8c02-92889354142f
+  subjects:
+  - entities:
+    - role: player
+      name: Elly De La Cruz
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: 91AS-18
+  uuid: f3b044f4-fbd0-45ba-b52f-f7c339ef5cc1
+  subjects:
+  - entities:
+    - role: player
+      name: Buster Posey
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: 91AS-19
+  uuid: b6dd0beb-2814-4975-a535-5c002bb8795a
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan Ryan
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: 91AS-20
+  uuid: 4bdd9c33-0f4e-475e-b9fe-f1108f5b53cb
+  subjects:
+  - entities:
+    - role: player
+      name: Randy Johnson
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: 91AS-21
+  uuid: 59f4db1b-80b0-43d6-ac39-75674216ffdf
+  subjects:
+  - entities:
+    - role: player
+      name: Vladimir Guerrero
+      ref: 
+    - role: team
+      name: Montréal Expos
+      ref: 
+- number: 91AS-22
+  uuid: 6355c1e3-8f8f-4c55-b321-5048078ee45d
+  subjects:
+  - entities:
+    - role: player
+      name: Freddie Freeman
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: 91AS-23
+  uuid: 15089dd0-abcf-4080-b588-627c825e1527
+  subjects:
+  - entities:
+    - role: player
+      name: Julio Rodríguez
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: 91AS-24
+  uuid: '0798a302-3fb1-448b-98c4-839d18356d48'
+  subjects:
+  - entities:
+    - role: player
+      name: Bobby Witt Jr.
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: 91AS-25
+  uuid: 9e7ece98-0fdc-463b-afdd-d94b0db058b7
+  subjects:
+  - entities:
+    - role: player
+      name: Roberto Clemente
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: 91AS-26
+  uuid: 208a7d29-b7c3-4c47-b59a-84838a85057f
+  subjects:
+  - entities:
+    - role: player
+      name: Albert Pujols
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: 91AS-27
+  uuid: 5fb0f31f-c88b-4ad0-9209-b732af7343a8
+  subjects:
+  - entities:
+    - role: player
+      name: José Ramírez
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: 91AS-28
+  uuid: 4e6ee3d6-8194-455f-8404-121a3ec5e952
+  subjects:
+  - entities:
+    - role: player
+      name: Ronald Acuña Jr.
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: 91AS-29
+  uuid: 351e48ce-2051-4995-a2c8-615ca457cfde
+  subjects:
+  - entities:
+    - role: player
+      name: Cal Ripken Jr.
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: 91AS-30
+  uuid: c58e2cf9-f012-4a1b-8179-dd347a99a894
+  subjects:
+  - entities:
+    - role: player
+      name: Clayton Kershaw
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: 91AS-31
+  uuid: 7bd53f34-fc1d-4e06-881a-4cf0b1ab07ca
+  subjects:
+  - entities:
+    - role: player
+      name: Ichiro
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: 91AS-32
+  uuid: 369507b0-f0cd-4113-9117-2ad8a0a3d920
+  subjects:
+  - entities:
+    - role: player
+      name: Derek Jeter
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: 91AS-33
+  uuid: 317c4bc5-74fa-4b26-b381-9e1db217ca82
+  subjects:
+  - entities:
+    - role: player
+      name: Frank Thomas
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: 91AS-34
+  uuid: 1fc6a9f4-5490-4ac3-aeb6-d0d7f4b26c86
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: 91AS-35
+  uuid: 8beedae5-94cc-4e98-b3e3-92630ae2fb29
+  subjects:
+  - entities:
+    - role: player
+      name: Ken Griffey Jr.
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: 91AS-36
+  uuid: afaf447b-7234-4db4-914a-9522bcbab1d2
+  subjects:
+  - entities:
+    - role: player
+      name: Fernando Tatis Jr.
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: 91AS-37
+  uuid: 93f5e2a9-d6c6-44f0-bce5-076e9f6f4a98
+  subjects:
+  - entities:
+    - role: player
+      name: Vladimir Guerrero Jr.
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: 91AS-38
+  uuid: 91aa4d69-8214-4893-ac64-d9d67345c61d
+  subjects:
+  - entities:
+    - role: player
+      name: Hank Aaron
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: 91AS-39
+  uuid: 2db896ff-9d82-4d31-b045-7daf4a880434
+  subjects:
+  - entities:
+    - role: player
+      name: Paul Skenes
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: 91AS-40
+  uuid: 7d1e5305-38c0-4df7-8007-7b3bfc8169a1
+  subjects:
+  - entities:
+    - role: player
+      name: Sandy Koufax
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: 91AS-41
+  uuid: 910235a9-b7e8-43fb-8362-356700bc7e7a
+  subjects:
+  - entities:
+    - role: player
+      name: George Brett
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: 91AS-42
+  uuid: a0f14414-70cc-47b4-80b2-f7a680ba1209
+  subjects:
+  - entities:
+    - role: player
+      name: James Wood
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: 91AS-43
+  uuid: 9a672078-d885-43e3-9ef8-45628cd82fab
+  subjects:
+  - entities:
+    - role: player
+      name: Gerrit Cole
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: 91AS-44
+  uuid: 37be76f2-0af7-4a32-8213-722bdf8acdce
+  subjects:
+  - entities:
+    - role: player
+      name: Mark McGwire
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: 91AS-45
+  uuid: 02bc4828-f516-4566-9d63-dd53bab3726d
+  subjects:
+  - entities:
+    - role: player
+      name: Kirby Puckett
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: 91AS-46
+  uuid: 5c5c78c8-2d6a-4770-a5da-34d8a1bff8d5
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Crow-Armstrong
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: 91AS-47
+  uuid: a1c5bbd4-be2a-46f2-a34d-8e01900cb8a0
+  subjects:
+  - entities:
+    - role: player
+      name: Johnny Bench
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: 91AS-48
+  uuid: ce316f6a-d160-4672-8554-5414afcfb926
+  subjects:
+  - entities:
+    - role: player
+      name: Rod Carew
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: 91AS-49
+  uuid: 7ad111c0-5fa2-42cf-99e1-7ed3e3333e77
+  subjects:
+  - entities:
+    - role: player
+      name: Gunnar Henderson
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: 91AS-50
+  uuid: 89cf95ab-f205-4c0a-92a5-916426fefbc7
+  subjects:
+  - entities:
+    - role: player
+      name: Shohei Ohtani
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 

--- a/data/baseball/2026-topps-series-2/checklists/1991-topps-baseball-all-star-autographs.yaml
+++ b/data/baseball/2026-topps-series-2/checklists/1991-topps-baseball-all-star-autographs.yaml
@@ -1,0 +1,710 @@
+- number: 91AS-ABE
+  uuid: e7713fc2-8672-478a-8321-96dceba3d9b1
+  subjects:
+  - entities:
+    - role: player
+      name: Adrian Beltré
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: 91AS-AD
+  uuid: e3d712e8-73a6-4dd5-8f83-eb5c68e5ffb5
+  subjects:
+  - entities:
+    - role: player
+      name: Andre Dawson
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: 91AS-AJ
+  uuid: 2390c49a-ced6-4963-ab88-e777373ae7fa
+  subjects:
+  - entities:
+    - role: player
+      name: Andruw Jones
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: 91AS-AP
+  uuid: b9e2f06b-f4f0-4ba5-87a2-c8ebc5cbb83c
+  subjects:
+  - entities:
+    - role: player
+      name: Albert Pujols
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: 91AS-AR
+  uuid: 184c7f8a-59e0-4d8a-a9de-fe55c5cb9f53
+  subjects:
+  - entities:
+    - role: player
+      name: Austin Riley
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: 91AS-ARU
+  uuid: 681b2665-506c-4298-9198-dafdd0d59edc
+  subjects:
+  - entities:
+    - role: player
+      name: Adley Rutschman
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: 91AS-BB
+  uuid: e19631a2-e9cf-43d7-b326-1ad824b82246
+  subjects:
+  - entities:
+    - role: player
+      name: Byron Buxton
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: 91AS-BH
+  uuid: 30052c8e-4e9d-4fae-9774-960f37c1650c
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Harper
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: 91AS-BL
+  uuid: a8447743-ebeb-4198-b93a-bbb4cb5762e9
+  subjects:
+  - entities:
+    - role: player
+      name: Barry Larkin
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: 91AS-BW
+  uuid: 5a59ecc3-90c6-456f-a139-2226e78974ab
+  subjects:
+  - entities:
+    - role: player
+      name: Bernie Williams
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: 91AS-CB
+  uuid: cbbd15bb-dd8a-4ae0-8c32-47b5de65b1d5
+  subjects:
+  - entities:
+    - role: player
+      name: Craig Biggio
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: 91AS-CC
+  uuid: c7105bd4-5d66-468e-b218-90cd6323c435
+  subjects:
+  - entities:
+    - role: player
+      name: Corbin Carroll
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: 91AS-CF
+  uuid: 0e01120c-1500-4127-8d32-8c3544b84443
+  subjects:
+  - entities:
+    - role: player
+      name: Carlton Fisk
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: 91AS-CJ
+  uuid: 87a19d85-ed40-4acb-b478-7da6731fdf16
+  subjects:
+  - entities:
+    - role: player
+      name: Chipper Jones
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: 91AS-CR
+  uuid: 38e66a96-d729-47e5-8a48-60f9b53d620a
+  subjects:
+  - entities:
+    - role: player
+      name: Cal Ripken Jr.
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: 91AS-CSA
+  uuid: 2b29cbd5-77d3-4722-bd47-fd6f3379767f
+  subjects:
+  - entities:
+    - role: player
+      name: CC Sabathia
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: 91AS-CU
+  uuid: 73b964b4-039a-4119-8925-693e9446f4ba
+  subjects:
+  - entities:
+    - role: player
+      name: Chase Utley
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: 91AS-CY
+  uuid: aef54aac-3ccc-4dfd-98a2-560ed773a84b
+  subjects:
+  - entities:
+    - role: player
+      name: Christian Yelich
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: 91AS-DE
+  uuid: 3ecad626-ea64-445c-a97d-a952ebc47a3b
+  subjects:
+  - entities:
+    - role: player
+      name: Dennis Eckersley
+      ref: 
+    - role: team
+      name: Oakland Athletics
+      ref: 
+- number: 91AS-DJ
+  uuid: c9d240b0-42d1-4708-86d6-335985433de4
+  subjects:
+  - entities:
+    - role: player
+      name: Derek Jeter
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: 91AS-DM
+  uuid: b940c309-db28-41c1-99e2-14bc03fb42f4
+  subjects:
+  - entities:
+    - role: player
+      name: Dale Murphy
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: 91AS-DMA
+  uuid: bb5cffc3-6c5c-433f-ba54-b893d8503ee0
+  subjects:
+  - entities:
+    - role: player
+      name: Don Mattingly
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: 91AS-DO
+  uuid: dfdfcf91-f621-4b0e-8d23-65b02326287a
+  subjects:
+  - entities:
+    - role: player
+      name: David Ortiz
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: 91AS-DS
+  uuid: 6a8baf24-8de8-4f3c-b49c-198c6f2b2756
+  subjects:
+  - entities:
+    - role: player
+      name: Darryl Strawberry
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: 91AS-DW
+  uuid: 4778d177-04cc-4b7c-9992-71d131d95c06
+  subjects:
+  - entities:
+    - role: player
+      name: Dave Winfield
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: 91AS-DWR
+  uuid: 8ca637be-e149-45ed-aca5-0cdb45eb6651
+  subjects:
+  - entities:
+    - role: player
+      name: David Wright
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: 91AS-ED
+  uuid: d4eef2d6-b69c-4f05-a6bd-26d992bc0b1b
+  subjects:
+  - entities:
+    - role: player
+      name: Elly De La Cruz
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: 91AS-EMA
+  uuid: 7ccef1f7-6a77-4479-9385-8092a89ffdb8
+  subjects:
+  - entities:
+    - role: player
+      name: Edgar Martinez
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: 91AS-FF
+  uuid: 2f442496-3ea2-45c7-8b5b-a1186131c67f
+  subjects:
+  - entities:
+    - role: player
+      name: Freddie Freeman
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: 91AS-FL
+  uuid: d880b565-0ae8-4f6d-b1b9-a62aa1e6d765
+  subjects:
+  - entities:
+    - role: player
+      name: Francisco Lindor
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: 91AS-FM
+  uuid: 6d198504-b190-4965-ac63-21e6831ce8a2
+  subjects:
+  - entities:
+    - role: player
+      name: Fred McGriff
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: 91AS-FT
+  uuid: b28a915e-fc11-496c-aac0-d5da5053093e
+  subjects:
+  - entities:
+    - role: player
+      name: Fernando Tatis Jr.
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: 91AS-FTH
+  uuid: 101c1ba0-c0e8-4398-bf46-7812917b4a96
+  subjects:
+  - entities:
+    - role: player
+      name: Frank Thomas
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: 91AS-GB
+  uuid: 64830cf5-e80d-4b11-94fe-884605dcc580
+  subjects:
+  - entities:
+    - role: player
+      name: George Brett
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: 91AS-GM
+  uuid: 6267f856-0e90-48aa-a4b9-95ba569921b0
+  subjects:
+  - entities:
+    - role: player
+      name: Greg Maddux
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: 91AS-HM
+  uuid: c1ce5742-1614-41b7-a3c8-9f6bd5ab79f6
+  subjects:
+  - entities:
+    - role: player
+      name: Hideki Matsui
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: 91AS-I
+  uuid: b2c03a65-01be-4672-bcdf-bebbd7291537
+  subjects:
+  - entities:
+    - role: player
+      name: Ichiro
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: 91AS-JB
+  uuid: 58d9739d-5190-4052-931e-d0d94551a54c
+  subjects:
+  - entities:
+    - role: player
+      name: Jeff Bagwell
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: 91AS-JBE
+  uuid: fbbadf9c-c50f-4b29-aaf8-b7953018f416
+  subjects:
+  - entities:
+    - role: player
+      name: Johnny Bench
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: 91AS-JC
+  uuid: 78f6d712-af0e-4662-a8e5-8213ec89dba3
+  subjects:
+  - entities:
+    - role: player
+      name: Jazz Chisholm Jr.
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: 91AS-JCA
+  uuid: 2a89f595-10b8-43d8-a634-7fed978f28c1
+  subjects:
+  - entities:
+    - role: player
+      name: Jose Canseco
+      ref: 
+    - role: team
+      name: Oakland Athletics
+      ref: 
+- number: 91AS-JD
+  uuid: e630d119-b875-46b9-b73c-731ae58cdc19
+  subjects:
+  - entities:
+    - role: player
+      name: Jarren Duran
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: 91AS-JME
+  uuid: 2ae527b5-ab54-4361-8116-0e23256706f6
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Merrill
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: 91AS-JMI
+  uuid: e44595c7-fac2-419c-a07d-a253af1c8e49
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Misiorowski
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: 91AS-JS
+  uuid: '08dddcfb-e0ac-4562-8fcc-7450f0b3a6cf'
+  subjects:
+  - entities:
+    - role: player
+      name: John Smoltz
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: 91AS-JV
+  uuid: 337488f8-18f1-4ffc-b280-ff6ea6dd8660
+  subjects:
+  - entities:
+    - role: player
+      name: Joey Votto
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: 91AS-JW
+  uuid: 25cc8b77-beb9-4016-8be3-e0ce1a99b925
+  subjects:
+  - entities:
+    - role: player
+      name: James Wood
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: 91AS-JWI
+  uuid: 470b00ce-5e2b-4790-9b24-d0333f44cdb1
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Wilson
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: 91AS-MM
+  uuid: d82066d7-b33c-4f83-bf43-863861aa8542
+  subjects:
+  - entities:
+    - role: player
+      name: Mark McGwire
+      ref: 
+    - role: team
+      name: Oakland Athletics
+      ref: 
+- number: 91AS-MMA
+  uuid: 1fdcb896-d0b5-4a30-80c9-f335a379cf33
+  subjects:
+  - entities:
+    - role: player
+      name: Manny Machado
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: 91AS-MO
+  uuid: 04ca1c0a-cf2a-4604-9cb8-e829ed7586d9
+  subjects:
+  - entities:
+    - role: player
+      name: Matt Olson
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: 91AS-MS
+  uuid: 4fc91279-3d7b-4877-bc31-80cceb1e6ea4
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Schmidt
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: 91AS-MT
+  uuid: 358bd233-a8a6-4c4b-9fe1-8ae81e057cbb
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Trout
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: 91AS-NR
+  uuid: 55742a99-725d-4208-be7b-92f0462f3e62
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan Ryan
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: 91AS-NRY
+  uuid: 222e0209-13b4-4514-954b-6f3d895ab9ed
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan Ryan
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: 91AS-OS
+  uuid: 4490b471-4e74-46de-a500-5320d0e09b42
+  subjects:
+  - entities:
+    - role: player
+      name: Ozzie Smith
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: 91AS-PM
+  uuid: a271a3f1-9bd9-4bc5-bd1e-a6623ea8c747
+  subjects:
+  - entities:
+    - role: player
+      name: Paul Molitor
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: 91AS-RA
+  uuid: 1a569f9e-f401-4625-baae-826096e1db09
+  subjects:
+  - entities:
+    - role: player
+      name: Ronald Acuña Jr.
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: 91AS-RC
+  uuid: b92f684e-d677-4b43-9d16-ad4ae333e030
+  subjects:
+  - entities:
+    - role: player
+      name: Roger Clemens
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: 91AS-RG
+  uuid: 6fe77e0a-1870-4806-8508-349399473d4f
+  subjects:
+  - entities:
+    - role: player
+      name: Riley Greene
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: 91AS-RH
+  uuid: 1253e3fc-8eb8-4eac-a524-7a4b2bea1069
+  subjects:
+  - entities:
+    - role: player
+      name: Ryan Howard
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: 91AS-RJ
+  uuid: 9b98cb19-7900-4acd-a273-65294a3d1a9b
+  subjects:
+  - entities:
+    - role: player
+      name: Randy Johnson
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: 91AS-RY
+  uuid: 3991a64f-5f23-4315-b942-f4df9f9e3659
+  subjects:
+  - entities:
+    - role: player
+      name: Robin Yount
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: 91AS-SC
+  uuid: ffff313b-fd63-41ce-88ba-e2b247064d1b
+  subjects:
+  - entities:
+    - role: player
+      name: Steve Carlton
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: 91AS-SK
+  uuid: e6557736-e668-4e75-a81f-835ea63d1f5b
+  subjects:
+  - entities:
+    - role: player
+      name: Sandy Koufax
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: 91AS-SSO
+  uuid: 659ab459-51c8-400d-9e7e-639414a26d9c
+  subjects:
+  - entities:
+    - role: player
+      name: Sammy Sosa
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: 91AS-TG
+  uuid: 39cc9195-9ec2-4b33-a778-799de524cd16
+  subjects:
+  - entities:
+    - role: player
+      name: Tom Glavine
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: 91AS-TT
+  uuid: 9ba45a5e-7cfc-47c1-964d-ea74756f03e8
+  subjects:
+  - entities:
+    - role: player
+      name: Trea Turner
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: 91AS-VG
+  uuid: b15d20d5-b62b-425c-994f-db20f4977c6a
+  subjects:
+  - entities:
+    - role: player
+      name: Vladimir Guerrero
+      ref: 
+    - role: team
+      name: Montréal Expos
+      ref: 
+- number: 91AS-WB
+  uuid: b1cea139-4632-4fa3-acf8-b0edaaa2589c
+  subjects:
+  - entities:
+    - role: player
+      name: Wade Boggs
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: 91AS-WC
+  uuid: 5d0e2071-c8a7-49be-8f47-bebd982f715d
+  subjects:
+  - entities:
+    - role: player
+      name: Will Clark
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 

--- a/data/baseball/2026-topps-series-2/checklists/1991-topps-baseball-all-star-relics.yaml
+++ b/data/baseball/2026-topps-series-2/checklists/1991-topps-baseball-all-star-relics.yaml
@@ -1,0 +1,500 @@
+- number: 91ASR-AJ
+  uuid: f695b517-4eec-4149-80d3-4bc5d940d322
+  subjects:
+  - entities:
+    - role: player
+      name: Aaron Judge
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: 91ASR-AM
+  uuid: 98de2f49-782f-4702-9047-f05c313e4ee2
+  subjects:
+  - entities:
+    - role: player
+      name: Andrew McCutchen
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: 91ASR-AP
+  uuid: c58acd13-7140-4143-97d9-b9c0a4439fa3
+  subjects:
+  - entities:
+    - role: player
+      name: Albert Pujols
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: 91ASR-AR
+  uuid: 5272c27b-0077-4099-af9b-3a9080d3dd86
+  subjects:
+  - entities:
+    - role: player
+      name: Alex Rodriguez
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: 91ASR-BBX
+  uuid: f8670a09-64af-44f6-9918-6a8ff621531d
+  subjects:
+  - entities:
+    - role: player
+      name: Byron Buxton
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: 91ASR-BH
+  uuid: fd43a7ea-8a8a-4a9b-b348-4b065f069eac
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Harper
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: 91ASR-BW
+  uuid: 748abfb1-8e43-4489-a7ce-508540075ba4
+  subjects:
+  - entities:
+    - role: player
+      name: Bobby Witt Jr.
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: 91ASR-CC
+  uuid: e9329fed-edcf-4b81-99d8-62104b06ae88
+  subjects:
+  - entities:
+    - role: player
+      name: Corbin Carroll
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: 91ASR-CJ
+  uuid: fc45b7b6-e54b-41c2-a280-72e97552b94a
+  subjects:
+  - entities:
+    - role: player
+      name: Chipper Jones
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: 91ASR-CK
+  uuid: acc27190-2be9-4be2-a270-2329910a93c8
+  subjects:
+  - entities:
+    - role: player
+      name: Clayton Kershaw
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: 91ASR-CR
+  uuid: 77b141f5-8132-4910-8f4e-52150a528002
+  subjects:
+  - entities:
+    - role: player
+      name: Cal Ripken Jr.
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: 91ASR-CS
+  uuid: 131a3f51-887c-4136-94f2-c014f019a5d8
+  subjects:
+  - entities:
+    - role: player
+      name: Chris Sale
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: 91ASR-CY
+  uuid: b8fa7ee2-8190-4ab1-8d59-1bad7c79534b
+  subjects:
+  - entities:
+    - role: player
+      name: Christian Yelich
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: 91ASR-DJ
+  uuid: 41c40ced-9cb5-4820-91b0-04cb50bd532a
+  subjects:
+  - entities:
+    - role: player
+      name: Derek Jeter
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: 91ASR-DO
+  uuid: 8921abb2-3340-4528-b10b-c31210850ade
+  subjects:
+  - entities:
+    - role: player
+      name: David Ortiz
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: 91ASR-ED
+  uuid: e6d0be63-bbe2-43b1-a039-16947bee0975
+  subjects:
+  - entities:
+    - role: player
+      name: Elly De La Cruz
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: 91ASR-FF
+  uuid: 5c3f655c-ebf8-4a28-b6ac-9ae6502b63b4
+  subjects:
+  - entities:
+    - role: player
+      name: Freddie Freeman
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: 91ASR-FL
+  uuid: d83960f6-f69f-4843-8e4d-3a5dd540c0cb
+  subjects:
+  - entities:
+    - role: player
+      name: Francisco Lindor
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: 91ASR-FT
+  uuid: 1cff2a10-f373-42e4-8000-f52d4ca9c7f2
+  subjects:
+  - entities:
+    - role: player
+      name: Fernando Tatis Jr.
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: 91ASR-FTH
+  uuid: f11af176-dee5-45cf-b167-7480de617c26
+  subjects:
+  - entities:
+    - role: player
+      name: Frank Thomas
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: 91ASR-GH
+  uuid: 3aeecc6c-103c-4495-9683-312820df191f
+  subjects:
+  - entities:
+    - role: player
+      name: Gunnar Henderson
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: 91ASR-I
+  uuid: 3580199f-64a0-41c6-ab71-cc3a32a562fa
+  subjects:
+  - entities:
+    - role: player
+      name: Ichiro
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: 91ASR-JA
+  uuid: b7697355-ebae-44b3-a6d2-2eb76cbdcff1
+  subjects:
+  - entities:
+    - role: player
+      name: Jose Altuve
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: 91ASR-JM
+  uuid: '0081ab76-9989-4ea1-aefc-aa86cc039160'
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Merrill
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: 91ASR-JMI
+  uuid: a6662d34-0a20-4ab4-ab37-0e27ef228447
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Misiorowski
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: 91ASR-JR
+  uuid: a171a60f-fe94-4722-9731-fc3635d7300d
+  subjects:
+  - entities:
+    - role: player
+      name: Julio Rodríguez
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: 91ASR-JS
+  uuid: c199a92c-85a2-44a8-8dcb-379bd15c6efd
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: 91ASR-JW
+  uuid: 37a06fd0-8ca1-4155-8307-5186f0f48531
+  subjects:
+  - entities:
+    - role: player
+      name: James Wood
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: 91ASR-JWI
+  uuid: 7305557e-806b-4c62-a44e-7cf80b90feee
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Wilson
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: 91ASR-KG
+  uuid: 6878b61a-5200-457d-9451-cee65dd86551
+  subjects:
+  - entities:
+    - role: player
+      name: Ken Griffey Jr.
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: 91ASR-KP
+  uuid: 3dec483e-56a0-4ffe-861d-3f35560087af
+  subjects:
+  - entities:
+    - role: player
+      name: Kirby Puckett
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: 91ASR-KS
+  uuid: f26556ce-6e3e-4638-af3c-42b6aa288357
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Schwarber
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: 91ASR-MB
+  uuid: 61e95ee9-d23a-4447-89ae-1c38921c7d51
+  subjects:
+  - entities:
+    - role: player
+      name: Mookie Betts
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: 91ASR-MC
+  uuid: 060a781c-0ae8-42bf-8d10-8115e1d56fb0
+  subjects:
+  - entities:
+    - role: player
+      name: Miguel Cabrera
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: 91ASR-MM
+  uuid: 46f916ea-6f86-494c-98a1-e05f81b79430
+  subjects:
+  - entities:
+    - role: player
+      name: Manny Machado
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: 91ASR-MO
+  uuid: 57eabc69-2e1d-4158-82b1-ca7b1695952b
+  subjects:
+  - entities:
+    - role: player
+      name: Matt Olson
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: 91ASR-MP
+  uuid: dd035909-acc4-4cb0-b4c0-aa44a1736f05
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Piazza
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: 91ASR-MR
+  uuid: 1feeb07a-bc02-4cee-b57b-3f51a5bf1006
+  subjects:
+  - entities:
+    - role: player
+      name: Mariano Rivera
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: 91ASR-MS
+  uuid: 53a05b30-c966-4e50-ad05-42035c98908e
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Schmidt
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: 91ASR-MT
+  uuid: 43286991-b490-4c43-80e5-25e56dae1bb2
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Trout
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: 91ASR-NA
+  uuid: fd853241-ecd3-4573-a62f-d343b65ba7e3
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan Arenado
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: 91ASR-PC
+  uuid: 39e59e84-e247-4370-8b90-fbe96414155a
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Crow-Armstrong
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: 91ASR-PS
+  uuid: 233773eb-99e7-4c11-be32-234e30ad0085
+  subjects:
+  - entities:
+    - role: player
+      name: Paul Skenes
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: 91ASR-RA
+  uuid: 6f1d366d-751f-47c3-b636-9fa74a633728
+  subjects:
+  - entities:
+    - role: player
+      name: Ronald Acuña Jr.
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: 91ASR-SO
+  uuid: 1abe05c2-cb7a-4c51-b198-c8f1d3b25149
+  subjects:
+  - entities:
+    - role: player
+      name: Shohei Ohtani
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: 91ASR-SS
+  uuid: 75e546de-f464-4935-b46b-89c36f5be007
+  subjects:
+  - entities:
+    - role: player
+      name: Sammy Sosa
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: 91ASR-TG
+  uuid: 8bc03f88-a96c-4b90-9ae5-a15bf06f926c
+  subjects:
+  - entities:
+    - role: player
+      name: Tony Gwynn
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: 91ASR-TT
+  uuid: 8b043f28-c7a3-4540-b791-10d7682f2900
+  subjects:
+  - entities:
+    - role: player
+      name: Trea Turner
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: 91ASR-VG
+  uuid: 0a4b05a6-c97b-40fe-9632-b2f614545f3a
+  subjects:
+  - entities:
+    - role: player
+      name: Vladimir Guerrero Jr.
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: 91ASR-VGU
+  uuid: ef77c53d-83c2-4af2-b4c8-1432a8a62886
+  subjects:
+  - entities:
+    - role: player
+      name: Vladimir Guerrero
+      ref: 
+    - role: team
+      name: Montréal Expos
+      ref: 

--- a/data/baseball/2026-topps-series-2/checklists/1991-topps-baseball-autographs.yaml
+++ b/data/baseball/2026-topps-series-2/checklists/1991-topps-baseball-autographs.yaml
@@ -1,0 +1,900 @@
+- number: 91A-ABR
+  uuid: a3a8533c-55ae-4cdb-bade-7253c64542a7
+  subjects:
+  - entities:
+    - role: player
+      name: Alex Bregman
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: 91A-AG
+  uuid: b7c6f291-8307-46a0-be9f-99680c211090
+  subjects:
+  - entities:
+    - role: player
+      name: Alex Gordon
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: 91A-ALE
+  uuid: 8b430e70-f7fe-4489-9645-27a98c5ebfef
+  subjects:
+  - entities:
+    - role: player
+      name: Alec Bohm
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: 91A-AM
+  uuid: ce896736-0329-4caf-803a-9d44b928ba13
+  subjects:
+  - entities:
+    - role: player
+      name: Andrew McCutchen
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: 91A-AN
+  uuid: 06c911e5-4039-43a6-a5c1-b5b3318151a1
+  subjects:
+  - entities:
+    - role: player
+      name: Aaron Nola
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: 91A-AND
+  uuid: 0c8bd1a1-0357-4539-9686-3a8572e6838b
+  subjects:
+  - entities:
+    - role: player
+      name: Andry Lara
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: 91A-APA
+  uuid: eb9878cb-9afc-41ef-9cfc-156fa2da2bb0
+  subjects:
+  - entities:
+    - role: player
+      name: Andrew Painter
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: 91A-ARO
+  uuid: e94ec00d-b794-48f4-8a0e-b7481f342432
+  subjects:
+  - entities:
+    - role: player
+      name: Alex Rodriguez
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: 91A-AROZ
+  uuid: 84850258-4914-4f0f-b5d2-b92b454a6a21
+  subjects:
+  - entities:
+    - role: player
+      name: Randy Arozarena
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: 91A-BEL
+  uuid: e69e1cb2-b782-4e3e-835d-177b903b43bc
+  subjects:
+  - entities:
+    - role: player
+      name: Carlos Beltrán
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: 91A-BON
+  uuid: 88c55eaa-98f0-4317-81ba-57be28d52140
+  subjects:
+  - entities:
+    - role: player
+      name: Barry Bonds
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: 91A-BROD
+  uuid: 2ab46f68-5a40-490e-a357-c576ab15fd6b
+  subjects:
+  - entities:
+    - role: player
+      name: Bradgley Rodriguez
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: 91A-CAR
+  uuid: 6e82f426-400b-43b9-a857-34f67fc85a51
+  subjects:
+  - entities:
+    - role: player
+      name: Carson Seymour
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: 91A-CHA
+  uuid: 8893eb47-ee57-4b5b-baea-68718039e4d1
+  subjects:
+  - entities:
+    - role: player
+      name: Matt Chapman
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: 91A-CIV
+  uuid: 9188569b-e6a6-4133-b0d2-0ec3cc7e8c9c
+  subjects:
+  - entities:
+    - role: player
+      name: Aaron Civale
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: 91A-CR
+  uuid: 807c078d-0a40-4685-bfdb-6973cbfb0f5f
+  subjects:
+  - entities:
+    - role: player
+      name: Cal Ripken Jr.
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: 91A-DAS
+  uuid: b89ef1b2-6ac5-416f-96b2-8b094834d318
+  subjects:
+  - entities:
+    - role: player
+      name: Dave Stieb
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: 91A-DR
+  uuid: f45aef96-984f-4473-a2d4-05712f450804
+  subjects:
+  - entities:
+    - role: player
+      name: Dalton Rushing
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: 91A-DS
+  uuid: 941168d1-ad4a-411f-888f-126637982ffc
+  subjects:
+  - entities:
+    - role: player
+      name: Dansby Swanson
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: 91A-ED
+  uuid: 20717cd6-4534-4d02-9cd1-f8383df10aa8
+  subjects:
+  - entities:
+    - role: player
+      name: Elly De La Cruz
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: 91A-EL
+  uuid: ac319faf-d726-4a67-8f9c-b0fbac432aef
+  subjects:
+  - entities:
+    - role: player
+      name: Evan Longoria
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: 91A-JA
+  uuid: 5d021c73-4df3-4ff9-a1cf-e1d1ce33da8d
+  subjects:
+  - entities:
+    - role: player
+      name: Jose Altuve
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: 91A-JEF
+  uuid: 3914ebbb-8180-4388-97af-22aa7ca0e7e2
+  subjects:
+  - entities:
+    - role: player
+      name: Ryan Jeffers
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: 91A-JHL
+  uuid: 462ddabc-8da3-4b5d-abc9-b00d33c2ab5a
+  subjects:
+  - entities:
+    - role: player
+      name: Jung Hoo Lee
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: 91A-JJW
+  uuid: a0557a18-93c5-4953-9613-6735f927f3d8
+  subjects:
+  - entities:
+    - role: player
+      name: JJ Wetherholt
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: 91A-JM
+  uuid: '09351251-b7a5-45d8-8cc7-50441acc7566'
+  subjects:
+  - entities:
+    - role: player
+      name: Joe Mauer
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: 91A-JME
+  uuid: e5211cd5-f251-4c14-87bc-40c9e73b2abe
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Merrill
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: 91A-JMO
+  uuid: 96f2d4ea-6d6d-4a79-822c-a43580c89d7f
+  subjects:
+  - entities:
+    - role: player
+      name: Justin Morneau
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: 91A-JROL
+  uuid: 36c73d8c-fe97-4cb0-81a5-df17ee971ef7
+  subjects:
+  - entities:
+    - role: player
+      name: Jimmy Rollins
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: 91A-JUS
+  uuid: c34e4cc6-6319-4231-8e05-e5b45eed40ca
+  subjects:
+  - entities:
+    - role: player
+      name: David Justice
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: 91A-MBA
+  uuid: 33c94025-7570-4df7-8693-3ca9f6e87236
+  subjects:
+  - entities:
+    - role: player
+      name: Moisés Ballesteros
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: 91A-MO
+  uuid: c06da61e-6bec-40c0-8ab1-05e5fdc91f83
+  subjects:
+  - entities:
+    - role: player
+      name: Matt Olson
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: 91A-MSE
+  uuid: 419cb419-3b02-4ead-afb7-d05219436433
+  subjects:
+  - entities:
+    - role: player
+      name: Marcus Semien
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: 91A-MW
+  uuid: 8b50695a-40fa-45b5-8723-f209a89a27cd
+  subjects:
+  - entities:
+    - role: player
+      name: Matt Williams
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: 91A-MWI
+  uuid: d9e42f37-5531-4c74-b1bb-a943118c16b9
+  subjects:
+  - entities:
+    - role: player
+      name: Masyn Winn
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: 91A-MY
+  uuid: c81f229a-1c3b-4415-a85c-95d6b2b07611
+  subjects:
+  - entities:
+    - role: player
+      name: Masataka Yoshida
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: 91A-MYO
+  uuid: b9f71e96-117a-4d7e-b366-b6c30f99f8bf
+  subjects:
+  - entities:
+    - role: player
+      name: Michael Young
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: 91A-NK
+  uuid: 5e3d24c9-d720-40c4-87a2-1de6509d372f
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Kurtz
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: 91A-NS
+  uuid: c5928e1a-e165-437a-bd92-e1f29f191946
+  subjects:
+  - entities:
+    - role: player
+      name: Noah Schultz
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: 91A-PS
+  uuid: b998d15a-bf4c-44f0-a30f-9a7132c6db9d
+  subjects:
+  - entities:
+    - role: player
+      name: Paul Skenes
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: 91A-RA
+  uuid: 1fb88505-d5fd-4770-8110-d5d59a194581
+  subjects:
+  - entities:
+    - role: player
+      name: Ronald Acuña Jr.
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: 91A-RAF
+  uuid: 54fc76ee-9fbf-4981-b76a-2839be1a6f06
+  subjects:
+  - entities:
+    - role: player
+      name: Ceddanne Rafaela
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: 91A-RD
+  uuid: d2e49af3-0e94-4a7e-a33d-76ba929c1b5a
+  subjects:
+  - entities:
+    - role: player
+      name: Rafael Devers
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: 91A-RIL
+  uuid: e39703e4-aa3f-46d6-95dc-de694c7422a1
+  subjects:
+  - entities:
+    - role: player
+      name: Austin Riley
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: 91A-ROKI
+  uuid: 386fdc84-6a7c-4c98-b337-1a5707541c40
+  subjects:
+  - entities:
+    - role: player
+      name: Roki Sasaki
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: 91A-SG
+  uuid: 657c5ce6-5676-478f-9a38-ca1dbf14d5b5
+  subjects:
+  - entities:
+    - role: player
+      name: Steve Garvey
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: 91A-SI
+  uuid: ee702efd-63d9-4a54-8605-6f02abee190f
+  subjects:
+  - entities:
+    - role: player
+      name: Shota Imanaga
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: 91A-SST
+  uuid: 87107d4e-5592-4876-a742-44c40dd1448e
+  subjects:
+  - entities:
+    - role: player
+      name: Spencer Steer
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: 91A-TC
+  uuid: c1e5a997-4e27-4946-a85a-b31c86b00647
+  subjects:
+  - entities:
+    - role: player
+      name: Triston Casas
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: 91A-TOR
+  uuid: 041e9ea8-feef-4cf0-9c2c-f90a851bbe42
+  subjects:
+  - entities:
+    - role: player
+      name: Torii Hunter
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: 91A-WIK
+  uuid: 65e8055b-3254-4d75-a497-eb76566e70ee
+  subjects:
+  - entities:
+    - role: player
+      name: Wikelman González
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: 91A-ZW
+  uuid: 0ee8aebe-6740-43e6-9c26-039edb03cdda
+  subjects:
+  - entities:
+    - role: player
+      name: Zack Wheeler
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: 91B2-AG
+  uuid: 4231c49c-738c-4e34-9495-1fc71ee6dfd0
+  subjects:
+  - entities:
+    - role: player
+      name: Andre Granillo
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: 91B2-AGA
+  uuid: f88156ff-86e2-492a-8217-f1cc38df1631
+  subjects:
+  - entities:
+    - role: player
+      name: Andres Galarraga
+      ref: 
+    - role: team
+      name: Montréal Expos
+      ref: 
+- number: 91B2-BC
+  uuid: 5ec1083e-2bee-4e48-a6b3-7e04a273cc01
+  subjects:
+  - entities:
+    - role: player
+      name: Bubba Chandler
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: 91B2-BG
+  uuid: 148c3272-eb9e-4649-8be1-724587990cff
+  subjects:
+  - entities:
+    - role: player
+      name: Brandyn Garcia
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: 91B2-BH
+  uuid: 7cc2534d-9c1f-478b-b8f7-d75fb45978e0
+  subjects:
+  - entities:
+    - role: player
+      name: Brady House
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: 91B2-BSA
+  uuid: ee05019b-62c1-454b-a5b5-ab6cec8c3c8d
+  subjects:
+  - entities:
+    - role: player
+      name: Bret Saberhagen
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: 91B2-CB
+  uuid: 1f1f5966-a1d4-47a7-b230-27ee4a3dfe87
+  subjects:
+  - entities:
+    - role: player
+      name: Chase Burns
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: 91B2-CBL
+  uuid: fa8c0481-7769-492a-a91d-3dfb1433d56b
+  subjects:
+  - entities:
+    - role: player
+      name: Charlie Blackmon
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: 91B2-CC
+  uuid: 0f3d058c-565a-4581-a67a-ad149bc0469d
+  subjects:
+  - entities:
+    - role: player
+      name: Carlos Cortes
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: 91B2-CD
+  uuid: 1edeb2a9-37b0-4c6a-b752-bacbee400c51
+  subjects:
+  - entities:
+    - role: player
+      name: Chase DeLauter
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: 91B2-CK
+  uuid: 32c801a0-d979-4f5e-8f1f-d0791bffc606
+  subjects:
+  - entities:
+    - role: player
+      name: C.J. Kayfus
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: 91B2-CLE
+  uuid: 9923d8b4-bc26-4959-88a8-f9e3c8720c27
+  subjects:
+  - entities:
+    - role: player
+      name: Cliff Lee
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: 91B2-CMO
+  uuid: 11178793-34cb-47a2-aea8-682dd51d58cc
+  subjects:
+  - entities:
+    - role: player
+      name: Christian Moore
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: 91B2-CO
+  uuid: 4809183e-dd44-4214-ba71-4529a22b6e70
+  subjects:
+  - entities:
+    - role: player
+      name: Jose Corniell
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: 91B2-CS
+  uuid: fb7af350-1989-45e4-a9e4-6f9ee797e1f9
+  subjects:
+  - entities:
+    - role: player
+      name: Cam Schlittler
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: 91B2-CT
+  uuid: aa9fa2cc-ea40-4b18-9d7a-1d7504fa627c
+  subjects:
+  - entities:
+    - role: player
+      name: Colby Thomas
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: 91B2-GUZ
+  uuid: c02db3da-68f2-4d1c-b637-a7da91eff90a
+  subjects:
+  - entities:
+    - role: player
+      name: Denzer Guzman
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: 91B2-IP
+  uuid: 4730acb3-53ce-4c21-a3a2-0ee4f0dc3a5f
+  subjects:
+  - entities:
+    - role: player
+      name: Isaac Paredes
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: 91B2-JC
+  uuid: 8a3d439f-2de7-417c-a8dc-2689749a3459
+  subjects:
+  - entities:
+    - role: player
+      name: Justin Crawford
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: 91B2-JCA
+  uuid: 10e46a4a-3046-4f26-8654-3980c98e037f
+  subjects:
+  - entities:
+    - role: player
+      name: Jac Caglianone
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: 91B2-JJ
+  uuid: 9339962c-d05c-4c51-9544-293ca4abb417
+  subjects:
+  - entities:
+    - role: player
+      name: Jeremiah Jackson
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: 91B2-JM
+  uuid: 9c4d43aa-39c5-40ed-a65f-39583a72d7f8
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Misiorowski
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: 91B2-JMA
+  uuid: 0c6d22c9-57f0-4e97-880d-ae0557b3d961
+  subjects:
+  - entities:
+    - role: player
+      name: Jakob Marsee
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: 91B2-JR
+  uuid: 79c05d52-d976-465d-a08d-a852498c6365
+  subjects:
+  - entities:
+    - role: player
+      name: Jim Rice
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: 91B2-JT
+  uuid: 1b868592-a752-4e83-bdd6-5d4b142ec03b
+  subjects:
+  - entities:
+    - role: player
+      name: Jonah Tong
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: 91B2-KAZ
+  uuid: fe2c4edf-ae37-4429-a1e6-7c666484a0d8
+  subjects:
+  - entities:
+    - role: player
+      name: Kazuma Okamoto
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: 91B2-KG
+  uuid: '08aca440-06ad-4182-9520-1d89a4a5f8d8'
+  subjects:
+  - entities:
+    - role: player
+      name: Kirk Gibson
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: 91B2-KGI
+  uuid: 2fed3b41-7e33-40c4-9577-0941caa5dc81
+  subjects:
+  - entities:
+    - role: player
+      name: Kirk Gibson
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: 91B2-KMC
+  uuid: f0ecf3a8-f884-47e0-92f2-5402a8875344
+  subjects:
+  - entities:
+    - role: player
+      name: Kevin McGonigle
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: 91B2-MUR
+  uuid: 1c20e473-a9f7-4a70-b2e1-4b18dcc529be
+  subjects:
+  - entities:
+    - role: player
+      name: Munetaka Murakami
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: 91B2-NC
+  uuid: 33cded21-e6ee-40df-82dd-3c0c0eb5a9f0
+  subjects:
+  - entities:
+    - role: player
+      name: Nathan Church
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: 91B2-NM
+  uuid: e782e4f0-c58f-4388-8fd6-d246a31abf8b
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan McLean
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: 91B2-RA
+  uuid: b73fc806-6134-4b23-9369-9514d785f4a0
+  subjects:
+  - entities:
+    - role: player
+      name: Roman Anthony
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: 91B2-SB
+  uuid: a58fddf2-fd9c-4c18-aaf0-e1d94522de33
+  subjects:
+  - entities:
+    - role: player
+      name: Samuel Basallo
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: 91B2-SS
+  uuid: 324b4bbb-73c2-4e7e-9922-3d01e524704d
+  subjects:
+  - entities:
+    - role: player
+      name: Sal Stewart
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: 91B2-TO
+  uuid: cbccfebc-3884-49cd-b4fb-84694f05e90a
+  subjects:
+  - entities:
+    - role: player
+      name: Tony Oliva
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: 91B2-TP
+  uuid: 1f078768-f557-4312-9b19-ae17e78b5827
+  subjects:
+  - entities:
+    - role: player
+      name: Tony Pérez
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: 91B2-ZC
+  uuid: 991a8720-efe4-467b-9fbc-a09843150664
+  subjects:
+  - entities:
+    - role: player
+      name: Zach Cole
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 

--- a/data/baseball/2026-topps-series-2/checklists/1991-topps-baseball-chrome-all-star-autographs.yaml
+++ b/data/baseball/2026-topps-series-2/checklists/1991-topps-baseball-chrome-all-star-autographs.yaml
@@ -1,0 +1,430 @@
+- number: 91ASC-1
+  uuid: a2dec66f-375e-4891-9fca-78d5938adb0c
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Trout
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: 91ASC-2
+  uuid: 250fa885-91dc-44a3-8ac5-6868feeef1b2
+  subjects:
+  - entities:
+    - role: player
+      name: Sandy Koufax
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: 91ASC-3
+  uuid: 3381b47c-2e7f-47a4-83b8-fed71fcc34ed
+  subjects:
+  - entities:
+    - role: player
+      name: Chipper Jones
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: 91ASC-4
+  uuid: 40c2811e-664d-469d-a94b-a54afb655000
+  subjects:
+  - entities:
+    - role: player
+      name: David Ortiz
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: 91ASC-5
+  uuid: 3092eb47-1700-49ac-b018-ceb14464e14a
+  subjects:
+  - entities:
+    - role: player
+      name: George Brett
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: 91ASC-6
+  uuid: 40d99146-4b5f-4e08-b151-7a472317cf2b
+  subjects:
+  - entities:
+    - role: player
+      name: Sammy Sosa
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: 91ASC-7
+  uuid: 9f784aa3-366d-4f29-bbdc-5cfcb47654f1
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan Ryan
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: 91ASC-8
+  uuid: 1a278f53-aea9-41ef-8e19-37cff7f30e38
+  subjects:
+  - entities:
+    - role: player
+      name: Corbin Carroll
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: 91ASC-9
+  uuid: d8f605eb-7f09-482c-a3d7-08cec926d839
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: 91ASC-10
+  uuid: bf6f5af6-9c47-4515-9ce4-e7b34e30ab9c
+  subjects:
+  - entities:
+    - role: player
+      name: Francisco Lindor
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: 91ASC-11
+  uuid: 04c651bd-0b9b-493e-ac00-271fc199ae8c
+  subjects:
+  - entities:
+    - role: player
+      name: Frank Thomas
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: 91ASC-12
+  uuid: 62219be2-4b3a-4b86-91b5-6465743dadac
+  subjects:
+  - entities:
+    - role: player
+      name: Jarren Duran
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: 91ASC-13
+  uuid: 1cf00849-d638-4f60-b424-3372ccde7ae4
+  subjects:
+  - entities:
+    - role: player
+      name: Ichiro
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: 91ASC-14
+  uuid: 1eef72ef-6561-4ac1-91ed-e49a0d1c7a32
+  subjects:
+  - entities:
+    - role: player
+      name: Randy Johnson
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: 91ASC-15
+  uuid: 6b4349ee-7484-40d1-b6d9-77b41f49c36f
+  subjects:
+  - entities:
+    - role: player
+      name: Derek Jeter
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: 91ASC-16
+  uuid: 7d448ea3-6495-41d4-8010-a9a112c449b1
+  subjects:
+  - entities:
+    - role: player
+      name: Albert Pujols
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: 91ASC-17
+  uuid: 32c7eaf7-ecea-4344-b660-37b32fc0f15c
+  subjects:
+  - entities:
+    - role: player
+      name: Fernando Tatis Jr.
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: 91ASC-18
+  uuid: d6e1df81-89c0-41bc-b480-ce4fda5e49b3
+  subjects:
+  - entities:
+    - role: player
+      name: José Ramírez
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: 91ASC-19
+  uuid: 9f022a82-1a67-48eb-8c2b-fedd389898d5
+  subjects:
+  - entities:
+    - role: player
+      name: Elly De La Cruz
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: 91ASC-20
+  uuid: ac33e789-f753-4ac1-adf1-fea62bb1f14e
+  subjects:
+  - entities:
+    - role: player
+      name: Tarik Skubal
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: 91ASC-21
+  uuid: bdce9b7d-23f7-4a5d-989a-df31733012c7
+  subjects:
+  - entities:
+    - role: player
+      name: Ozzie Smith
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: 91ASC-22
+  uuid: bcaa9fd7-5184-4614-b4a1-fe0c7c2d059b
+  subjects:
+  - entities:
+    - role: player
+      name: Ryne Sandberg
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: 91ASC-23
+  uuid: 9f09f103-8953-4f1e-a362-56ea205b7d85
+  subjects:
+  - entities:
+    - role: player
+      name: Bobby Witt Jr.
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: 91ASC-24
+  uuid: 88f88188-2f4f-444a-9eeb-f3efa3f0e931
+  subjects:
+  - entities:
+    - role: player
+      name: Will Clark
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: 91ASC-25
+  uuid: c0cf41ba-a223-4623-bcae-bd69cd4760d6
+  subjects:
+  - entities:
+    - role: player
+      name: Manny Machado
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: 91ASC-27
+  uuid: b40fe43c-ff35-43ed-96dd-27f6ed5c8563
+  subjects:
+  - entities:
+    - role: player
+      name: Paul Skenes
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: 91ASC-28
+  uuid: b0ece01a-173f-4065-88b5-db1c2b2f1847
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Schmidt
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: 91ASC-29
+  uuid: 34d1f1f9-4c1e-476b-8987-e1552390747c
+  subjects:
+  - entities:
+    - role: player
+      name: Byron Buxton
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: 91ASC-30
+  uuid: bc8e37d9-05be-4818-b3a4-7daf6db09fce
+  subjects:
+  - entities:
+    - role: player
+      name: Freddie Freeman
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: 91ASC-31
+  uuid: d304f144-d330-4944-8b64-434bee84f3e4
+  subjects:
+  - entities:
+    - role: player
+      name: Corey Seager
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: 91ASC-32
+  uuid: 0f913219-9473-4b97-b8df-0d437bfd6319
+  subjects:
+  - entities:
+    - role: player
+      name: Julio Rodríguez
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: 91ASC-33
+  uuid: c915fcd1-ac6c-47ff-ae0a-3862421a4913
+  subjects:
+  - entities:
+    - role: player
+      name: Clayton Kershaw
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: 91ASC-34
+  uuid: 50a7fa46-a80a-448b-9fed-1681591977b2
+  subjects:
+  - entities:
+    - role: player
+      name: Ronald Acuña Jr.
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: 91ASC-35
+  uuid: 5ed35dd7-cf3c-41d0-8612-72810c830533
+  subjects:
+  - entities:
+    - role: player
+      name: Don Mattingly
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: 91ASC-36
+  uuid: 231203ab-4265-4b41-b261-b89a0bfc47d6
+  subjects:
+  - entities:
+    - role: player
+      name: Christian Yelich
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: 91ASC-39
+  uuid: e43c8e3f-a3cd-48d0-8779-d5900603f1b2
+  subjects:
+  - entities:
+    - role: player
+      name: Mark McGwire
+      ref: 
+    - role: team
+      name: Oakland Athletics
+      ref: 
+- number: 91ASC-41
+  uuid: 36ff0cfe-fe5d-4e68-b084-37deefe32056
+  subjects:
+  - entities:
+    - role: player
+      name: Vladimir Guerrero Jr.
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: 91ASC-42
+  uuid: 7ea13021-7a3f-4c32-b648-43de8b3ca1dc
+  subjects:
+  - entities:
+    - role: player
+      name: Aaron Judge
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: 91ASC-44
+  uuid: 1701d924-ec5d-40b3-94b7-5ab074f41c95
+  subjects:
+  - entities:
+    - role: player
+      name: James Wood
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: 91ASC-45
+  uuid: fea0ed0b-a358-4a83-bd52-1867d6906474
+  subjects:
+  - entities:
+    - role: player
+      name: Ken Griffey Jr.
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: 91ASC-46
+  uuid: f3f05799-4871-42b7-bd8e-e2b05b99cc50
+  subjects:
+  - entities:
+    - role: player
+      name: Miguel Cabrera
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: 91ASC-48
+  uuid: d778d6ca-8b1c-4cd9-9200-c710031cba40
+  subjects:
+  - entities:
+    - role: player
+      name: Greg Maddux
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: 91ASC-49
+  uuid: df17062d-1c57-4d4d-bfb7-ff3cb1177ec4
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Misiorowski
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 

--- a/data/baseball/2026-topps-series-2/checklists/1991-topps-baseball-chrome-all-stars.yaml
+++ b/data/baseball/2026-topps-series-2/checklists/1991-topps-baseball-chrome-all-stars.yaml
@@ -1,0 +1,500 @@
+- number: 91ASC-1
+  uuid: e7bd2b84-4ff7-4f86-a529-f64ffb34b240
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Trout
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: 91ASC-2
+  uuid: 88e70bc6-048a-4177-95bc-beea28313753
+  subjects:
+  - entities:
+    - role: player
+      name: Sandy Koufax
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: 91ASC-3
+  uuid: b9996e34-6ec2-466e-87f0-61ac0b347ec9
+  subjects:
+  - entities:
+    - role: player
+      name: Chipper Jones
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: 91ASC-4
+  uuid: b172869a-bcd9-4d00-ab43-7b691669435d
+  subjects:
+  - entities:
+    - role: player
+      name: David Ortiz
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: 91ASC-5
+  uuid: 91fa4eb1-46e7-4fcb-aa0e-f1c73cdf1803
+  subjects:
+  - entities:
+    - role: player
+      name: George Brett
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: 91ASC-6
+  uuid: ca9edbab-72e0-4a5b-a3c0-6d42f3f678df
+  subjects:
+  - entities:
+    - role: player
+      name: Sammy Sosa
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: 91ASC-7
+  uuid: b2d9f2a5-dcd0-42e8-8e0d-48560ad81a18
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan Ryan
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: 91ASC-8
+  uuid: fc0b1bbf-6d76-4d66-82ab-3f45a46fa1a1
+  subjects:
+  - entities:
+    - role: player
+      name: Corbin Carroll
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: 91ASC-9
+  uuid: afa353f1-6e68-491c-922f-efa4228b0927
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: 91ASC-10
+  uuid: e1ab9464-62d2-4504-ac29-dbd2138e4433
+  subjects:
+  - entities:
+    - role: player
+      name: Francisco Lindor
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: 91ASC-11
+  uuid: 0a41d42e-273e-420b-99db-064933b6c738
+  subjects:
+  - entities:
+    - role: player
+      name: Frank Thomas
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: 91ASC-12
+  uuid: 136da2e7-eb01-49c3-9b85-facadf00a639
+  subjects:
+  - entities:
+    - role: player
+      name: Jarren Duran
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: 91ASC-13
+  uuid: a15987a5-7e5a-4e0e-8768-1741ced175ec
+  subjects:
+  - entities:
+    - role: player
+      name: Ichiro
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: 91ASC-14
+  uuid: 826e2370-fa9a-49ef-bf79-c8e0e452c599
+  subjects:
+  - entities:
+    - role: player
+      name: Randy Johnson
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: 91ASC-15
+  uuid: b1f018e9-9fc2-4410-9b57-7091f0d92307
+  subjects:
+  - entities:
+    - role: player
+      name: Derek Jeter
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: 91ASC-16
+  uuid: a6cdde3b-378c-4a18-bf75-3e7e5f118d07
+  subjects:
+  - entities:
+    - role: player
+      name: Albert Pujols
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: 91ASC-17
+  uuid: afae2675-e283-4b2f-bc7c-11ed62f5933b
+  subjects:
+  - entities:
+    - role: player
+      name: Fernando Tatis Jr.
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: 91ASC-18
+  uuid: b2bc8f71-e1b0-4102-9ff1-da28245fc10f
+  subjects:
+  - entities:
+    - role: player
+      name: José Ramírez
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: 91ASC-19
+  uuid: 626acd4e-432b-47f8-9687-6d08f250c2c5
+  subjects:
+  - entities:
+    - role: player
+      name: Elly De La Cruz
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: 91ASC-20
+  uuid: a36203d5-2b5f-43f2-8e08-9c237b15a840
+  subjects:
+  - entities:
+    - role: player
+      name: Tarik Skubal
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: 91ASC-21
+  uuid: c721d34e-14e7-4ccb-9cdf-f645b02f6934
+  subjects:
+  - entities:
+    - role: player
+      name: Ozzie Smith
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: 91ASC-22
+  uuid: 33663683-9b92-4309-a044-af836e9406aa
+  subjects:
+  - entities:
+    - role: player
+      name: Ryne Sandberg
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: 91ASC-23
+  uuid: 2c97f502-caba-4b96-a131-d6112f35cf8d
+  subjects:
+  - entities:
+    - role: player
+      name: Bobby Witt Jr.
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: 91ASC-24
+  uuid: 3f340130-dd9d-40c9-9efa-b3712cfab1c3
+  subjects:
+  - entities:
+    - role: player
+      name: Will Clark
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: 91ASC-25
+  uuid: e197bdb1-00fa-47fe-835b-f6bbd5673361
+  subjects:
+  - entities:
+    - role: player
+      name: Manny Machado
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: 91ASC-26
+  uuid: fa6c6998-da1f-4cef-9096-a01b8fe9ab18
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Crow-Armstrong
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: 91ASC-27
+  uuid: 9a9ad1c0-ffb2-47c1-8bc5-4ac28175abae
+  subjects:
+  - entities:
+    - role: player
+      name: Paul Skenes
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: 91ASC-28
+  uuid: cc63bb69-3f65-4c43-bdbd-a42bb3902328
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Schmidt
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: 91ASC-29
+  uuid: c635e799-5c16-41d6-9a33-7e833cdaca9d
+  subjects:
+  - entities:
+    - role: player
+      name: Byron Buxton
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: 91ASC-30
+  uuid: d5930393-f00b-4aae-bf83-9e931d533e74
+  subjects:
+  - entities:
+    - role: player
+      name: Freddie Freeman
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: 91ASC-31
+  uuid: a4f9893c-b96a-4d56-b0d7-dd425a67be3c
+  subjects:
+  - entities:
+    - role: player
+      name: Corey Seager
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: 91ASC-32
+  uuid: c47511b4-ad96-4325-9252-52c03a635400
+  subjects:
+  - entities:
+    - role: player
+      name: Julio Rodríguez
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: 91ASC-33
+  uuid: c7c04320-b09b-4f76-a360-40d5e937da62
+  subjects:
+  - entities:
+    - role: player
+      name: Clayton Kershaw
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: 91ASC-34
+  uuid: e5d525c0-00b8-4451-b50c-2e48f7385454
+  subjects:
+  - entities:
+    - role: player
+      name: Ronald Acuña Jr.
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: 91ASC-35
+  uuid: 6afb7da4-0fb0-465c-b37b-a54b79a28717
+  subjects:
+  - entities:
+    - role: player
+      name: Don Mattingly
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: 91ASC-36
+  uuid: acd70bf9-6921-4cc9-88af-074d0c18ff8a
+  subjects:
+  - entities:
+    - role: player
+      name: Christian Yelich
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: 91ASC-37
+  uuid: cd60aca7-07ea-431f-bb8c-bd35d00e10d0
+  subjects:
+  - entities:
+    - role: player
+      name: Cal Raleigh
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: 91ASC-38
+  uuid: a4142bf4-ed23-493e-958b-182a0254c228
+  subjects:
+  - entities:
+    - role: player
+      name: Gunnar Henderson
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: 91ASC-39
+  uuid: 89ae22c9-6888-4f91-a762-84214952ca9f
+  subjects:
+  - entities:
+    - role: player
+      name: Mark McGwire
+      ref: 
+    - role: team
+      name: Oakland Athletics
+      ref: 
+- number: 91ASC-40
+  uuid: f045af5d-b74b-4920-a882-f6d9dec9dd10
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Harper
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: 91ASC-41
+  uuid: e7fe80c3-97c1-4f0a-a294-2e425019be91
+  subjects:
+  - entities:
+    - role: player
+      name: Vladimir Guerrero Jr.
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: 91ASC-42
+  uuid: 2ed84ad6-d0a5-4b4c-9ba6-b88dc25e305a
+  subjects:
+  - entities:
+    - role: player
+      name: Aaron Judge
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: 91ASC-43
+  uuid: e8a97fc1-45bd-406d-8ce4-c5b7ef7c88ec
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Wilson
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: 91ASC-44
+  uuid: 3d22341b-9261-434c-baca-d97b54538f53
+  subjects:
+  - entities:
+    - role: player
+      name: James Wood
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: 91ASC-45
+  uuid: e6fe7fbb-67eb-4857-b855-ed6d67e9d39f
+  subjects:
+  - entities:
+    - role: player
+      name: Ken Griffey Jr.
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: 91ASC-46
+  uuid: e70aa903-304b-4f3a-8b0e-bfccdac44795
+  subjects:
+  - entities:
+    - role: player
+      name: Miguel Cabrera
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: 91ASC-47
+  uuid: 9d7339db-7fda-44d9-8385-4f3a8d60e457
+  subjects:
+  - entities:
+    - role: player
+      name: Mookie Betts
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: 91ASC-48
+  uuid: 26e49ffe-8b9b-4931-a4dd-475478947fcb
+  subjects:
+  - entities:
+    - role: player
+      name: Greg Maddux
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: 91ASC-49
+  uuid: 1896de70-9a46-4a03-894d-31e7a8640612
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Misiorowski
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: 91ASC-50
+  uuid: 11f8416a-6d87-4220-92e1-4e845257a5e4
+  subjects:
+  - entities:
+    - role: player
+      name: Shohei Ohtani
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 

--- a/data/baseball/2026-topps-series-2/checklists/1991-topps-baseball-chrome-autographs.yaml
+++ b/data/baseball/2026-topps-series-2/checklists/1991-topps-baseball-chrome-autographs.yaml
@@ -1,0 +1,440 @@
+- number: 91C2-1
+  uuid: fb92b0df-c490-4466-85bb-05e2f7e1dd12
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Alonso
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: 91C2-3
+  uuid: 68824d32-3d92-4212-9b87-1c15459ee760
+  subjects:
+  - entities:
+    - role: player
+      name: Cam Schlittler
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: 91C2-4
+  uuid: 1052bef9-dfa7-4e0a-97e3-84933e53a96f
+  subjects:
+  - entities:
+    - role: player
+      name: Denzer Guzman
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: 91C2-6
+  uuid: 8a5866fd-9261-43ec-a1f5-0999e56260e8
+  subjects:
+  - entities:
+    - role: player
+      name: Mariano Rivera
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: 91C2-7
+  uuid: 83b5f423-50b1-4f96-9fe3-6639ec4fdb57
+  subjects:
+  - entities:
+    - role: player
+      name: Adley Rutschman
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: 91C2-9
+  uuid: be830c79-3d78-491c-80be-567e2e864f5a
+  subjects:
+  - entities:
+    - role: player
+      name: Rafael Flores
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: 91C2-10
+  uuid: 78a50415-3e07-44b7-bf4c-f6d10e4da027
+  subjects:
+  - entities:
+    - role: player
+      name: Alex Freeland
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: 91C2-12
+  uuid: 27871fbd-299a-439f-af48-7470a36be7cb
+  subjects:
+  - entities:
+    - role: player
+      name: Colson Montgomery
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: 91C2-13
+  uuid: 88fbfaff-aae9-438d-8f90-e0896bea5375
+  subjects:
+  - entities:
+    - role: player
+      name: Chase DeLauter
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: 91C2-14
+  uuid: b31111ca-8a2e-4dd0-b17c-5db2fd088b7b
+  subjects:
+  - entities:
+    - role: player
+      name: Blake Snell
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: 91C2-15
+  uuid: 8043ebd2-4587-4bc7-bdec-e35682a038ad
+  subjects:
+  - entities:
+    - role: player
+      name: Connelly Early
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: 91C2-16
+  uuid: b58b80c9-2b64-49f3-919e-dc8260156ec9
+  subjects:
+  - entities:
+    - role: player
+      name: Brandon Sproat
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: 91C2-18
+  uuid: 351d396f-9a83-4009-8b82-547c7990fb92
+  subjects:
+  - entities:
+    - role: player
+      name: Jimmy Crooks
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: 91C2-19
+  uuid: 8af72d45-3383-4f55-8f48-bb985a95553a
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Chourio
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: 91C2-20
+  uuid: 78300d4e-3a40-4847-a71b-9b01868fa618
+  subjects:
+  - entities:
+    - role: player
+      name: Munetaka Murakami
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: 91C2-21
+  uuid: 628b99af-56d0-483c-b910-6ef1965985c5
+  subjects:
+  - entities:
+    - role: player
+      name: Hunter Barco
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: 91C2-22
+  uuid: f966b38b-7439-4109-a8b1-02aeb4a1a30f
+  subjects:
+  - entities:
+    - role: player
+      name: Zach Neto
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: 91C2-23
+  uuid: 36f25fb5-0a66-4521-bdb1-1b1e1e60cc6e
+  subjects:
+  - entities:
+    - role: player
+      name: Roki Sasaki
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: 91C2-24
+  uuid: '059f8a61-3d07-4734-ada3-27798458b614'
+  subjects:
+  - entities:
+    - role: player
+      name: Jac Caglianone
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: 91C2-25
+  uuid: c5523bd7-a1c6-4838-9976-3be1f4385a95
+  subjects:
+  - entities:
+    - role: player
+      name: Chris Sale
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: 91C2-26
+  uuid: 20a69cdd-1c95-42d4-a365-3e998422a8d8
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan McLean
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: 91C2-27
+  uuid: 6ca8e7f1-72d6-47ed-b4b3-e222fc4b469c
+  subjects:
+  - entities:
+    - role: player
+      name: Sal Stewart
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: 91C2-28
+  uuid: 3756974d-9caf-4209-9cf9-48b25ca79b23
+  subjects:
+  - entities:
+    - role: player
+      name: Zach Cole
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: 91C2-30
+  uuid: 32e072e4-4248-43c8-9456-a3836eb33ca8
+  subjects:
+  - entities:
+    - role: player
+      name: Dylan Beavers
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: 91C2-31
+  uuid: 425d85b3-ab19-4e96-9aa8-ac2934e9c801
+  subjects:
+  - entities:
+    - role: player
+      name: Payton Tolle
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: 91C2-32
+  uuid: 39420ee3-28a2-4162-9c92-cbe26e59a248
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Eldridge
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: 91C2-33
+  uuid: 96edddbf-54dc-4b7f-b4de-54c3d877aea2
+  subjects:
+  - entities:
+    - role: player
+      name: Cade Horton
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: 91C2-34
+  uuid: 2edd9897-9bb3-41a7-a2f3-fc1344a2fb04
+  subjects:
+  - entities:
+    - role: player
+      name: Chase Burns
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: 91C2-35
+  uuid: 8e52e139-f4ae-41c2-93a3-98c89f581b39
+  subjects:
+  - entities:
+    - role: player
+      name: Tatsuya Imai
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: 91C2-36
+  uuid: b7c40824-1867-4d70-852f-a0b4ae223522
+  subjects:
+  - entities:
+    - role: player
+      name: Carter Jensen
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: 91C2-37
+  uuid: 5d4447b0-89a3-45e1-a2ef-d18ccb55dd9a
+  subjects:
+  - entities:
+    - role: player
+      name: Samuel Basallo
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: 91C2-38
+  uuid: 22aa3876-3cb5-4676-911c-a178b23ecc5a
+  subjects:
+  - entities:
+    - role: player
+      name: Carson Williams
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: 91C2-39
+  uuid: 59662382-7e7f-48a9-b277-5ad32727abb0
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Merrill
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: 91C2-40
+  uuid: 848e5357-b409-4247-8236-7a8e0f9d6b97
+  subjects:
+  - entities:
+    - role: player
+      name: Austin Riley
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: 91C2-41
+  uuid: 72a4b1d6-78c9-437e-b66c-13e23d9953d1
+  subjects:
+  - entities:
+    - role: player
+      name: Jazz Chisholm Jr.
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: 91C2-42
+  uuid: 2ac457f4-b125-4495-a1c7-ad75d46a7f21
+  subjects:
+  - entities:
+    - role: player
+      name: Joe Mauer
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: 91C2-43
+  uuid: b9328107-8f78-4353-8648-22093299c2d5
+  subjects:
+  - entities:
+    - role: player
+      name: Kazuma Okamoto
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: 91C2-44
+  uuid: 6b3ae7e3-7e1d-489e-b84c-0a964e5bd467
+  subjects:
+  - entities:
+    - role: player
+      name: C.J. Kayfus
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: 91C2-45
+  uuid: 230fc437-db0f-4f22-8c9b-7c08b0df14c2
+  subjects:
+  - entities:
+    - role: player
+      name: Roman Anthony
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: 91C2-46
+  uuid: 26eeb2b4-a384-48ee-803a-24fd91d533b0
+  subjects:
+  - entities:
+    - role: player
+      name: Trey Yesavage
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: 91C2-47
+  uuid: 7635fb98-7442-47a7-a724-1c476a65617e
+  subjects:
+  - entities:
+    - role: player
+      name: Harry Ford
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: 91C2-48
+  uuid: 659a5ddb-8a56-46c8-b0c8-12c01ff04709
+  subjects:
+  - entities:
+    - role: player
+      name: Lawrence Butler
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: 91C2-49
+  uuid: 9c6a17f7-09f8-4ea7-891d-2b0022c794be
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan Ryan
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: 91C2-50
+  uuid: 7c8a5e26-a567-4c27-a874-d01e62dff96c
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Kurtz
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 

--- a/data/baseball/2026-topps-series-2/checklists/1991-topps-baseball-chrome.yaml
+++ b/data/baseball/2026-topps-series-2/checklists/1991-topps-baseball-chrome.yaml
@@ -1,0 +1,500 @@
+- number: 91C2-1
+  uuid: 6d90d864-86de-4a31-9554-6e1a1eafdbbc
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Alonso
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: 91C2-2
+  uuid: e44928f9-5c29-4487-b2a9-f9e2fbb9dc15
+  subjects:
+  - entities:
+    - role: player
+      name: Cole Young
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: 91C2-3
+  uuid: 1b682ac9-bf27-4f40-8252-1136cc3ba7d2
+  subjects:
+  - entities:
+    - role: player
+      name: Cam Schlittler
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: 91C2-4
+  uuid: c37947f3-4e84-4825-9c6a-8bb5ad59603c
+  subjects:
+  - entities:
+    - role: player
+      name: Denzer Guzman
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: 91C2-5
+  uuid: d6a22083-1caa-4c25-903c-0a61cd9f448d
+  subjects:
+  - entities:
+    - role: player
+      name: Jakob Marsee
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: 91C2-6
+  uuid: 8f7e4709-8ebe-4573-a80f-fe531813c4ab
+  subjects:
+  - entities:
+    - role: player
+      name: Mariano Rivera
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: 91C2-7
+  uuid: f6568bd1-3f43-4942-84b1-b15b01755cef
+  subjects:
+  - entities:
+    - role: player
+      name: Adley Rutschman
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: 91C2-8
+  uuid: 1b0f2a09-6d64-4c8b-8ccb-4f443d11a8c6
+  subjects:
+  - entities:
+    - role: player
+      name: Bo Bichette
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: 91C2-9
+  uuid: c5b48be7-fa3b-4d35-a3fc-45deb636aab9
+  subjects:
+  - entities:
+    - role: player
+      name: Rafael Flores
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: 91C2-10
+  uuid: 2bd1418a-c357-4bde-a590-53049fdd51ec
+  subjects:
+  - entities:
+    - role: player
+      name: Alex Freeland
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: 91C2-11
+  uuid: 49064650-f06b-4e17-a135-5c2fd60cc5bf
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Schwarber
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: 91C2-12
+  uuid: ef90b0a9-32b8-43c3-94b8-0d992184af6e
+  subjects:
+  - entities:
+    - role: player
+      name: Colson Montgomery
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: 91C2-13
+  uuid: ed6de94b-8209-4aee-a25c-7f5bd0784bd2
+  subjects:
+  - entities:
+    - role: player
+      name: Chase DeLauter
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: 91C2-14
+  uuid: 857fc59e-f5c0-4eae-bb25-b2a96b3633c0
+  subjects:
+  - entities:
+    - role: player
+      name: Blake Snell
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: 91C2-15
+  uuid: f22a05b1-3dc4-42a1-823e-cc0102d680c2
+  subjects:
+  - entities:
+    - role: player
+      name: Connelly Early
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: 91C2-16
+  uuid: 1aa8ec47-577d-42cd-b08f-d6f66b23cc8e
+  subjects:
+  - entities:
+    - role: player
+      name: Brandon Sproat
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: 91C2-17
+  uuid: 417f9ac2-5456-4eb2-ad10-081a24397729
+  subjects:
+  - entities:
+    - role: player
+      name: Seiya Suzuki
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: 91C2-18
+  uuid: 366a79b2-5108-4224-aa54-65ecec56bfb9
+  subjects:
+  - entities:
+    - role: player
+      name: Jimmy Crooks
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: 91C2-19
+  uuid: 9c2a1e1c-b285-45bb-b6b0-4d97f37d8764
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Chourio
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: 91C2-20
+  uuid: 01c6fe6a-c017-4da3-8866-c93037437b7f
+  subjects:
+  - entities:
+    - role: player
+      name: Munetaka Murakami
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: 91C2-21
+  uuid: c2403868-be99-4610-aa8e-4e838ce80ee3
+  subjects:
+  - entities:
+    - role: player
+      name: Hunter Barco
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: 91C2-22
+  uuid: 7cb56846-3c26-41b3-bb2d-8439a88dac56
+  subjects:
+  - entities:
+    - role: player
+      name: Zach Neto
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: 91C2-23
+  uuid: a2d703e6-915f-4049-849c-4e3c2c2fb06d
+  subjects:
+  - entities:
+    - role: player
+      name: Roki Sasaki
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: 91C2-24
+  uuid: 32d9048f-0397-4e49-ae98-f05fe3d12006
+  subjects:
+  - entities:
+    - role: player
+      name: Jac Caglianone
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: 91C2-25
+  uuid: 5cb4ff0f-4372-4a57-8e8c-3cca75e0ccdc
+  subjects:
+  - entities:
+    - role: player
+      name: Chris Sale
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: 91C2-26
+  uuid: 5a0529a2-0ae2-4133-8f8c-00364f28d528
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan McLean
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: 91C2-27
+  uuid: b01e9410-a0e9-452a-9b1e-3ca9c6076415
+  subjects:
+  - entities:
+    - role: player
+      name: Sal Stewart
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: 91C2-28
+  uuid: a98bbfd3-759f-4a9d-a52f-98caf994cb86
+  subjects:
+  - entities:
+    - role: player
+      name: Zach Cole
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: 91C2-29
+  uuid: 04a80510-9eda-4ac8-b484-438ba4e15a92
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob deGrom
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: 91C2-30
+  uuid: 067c70f1-ca67-422d-8dc5-94d0d00eb1b1
+  subjects:
+  - entities:
+    - role: player
+      name: Dylan Beavers
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: 91C2-31
+  uuid: fadb00d5-3ae3-4803-9390-2c431baf8d0b
+  subjects:
+  - entities:
+    - role: player
+      name: Payton Tolle
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: 91C2-32
+  uuid: 69f17f9e-7cba-4d35-8c62-02f624e3f734
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Eldridge
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: 91C2-33
+  uuid: 69243b5e-7f3a-4401-94e6-4fcee58c3be9
+  subjects:
+  - entities:
+    - role: player
+      name: Cade Horton
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: 91C2-34
+  uuid: 0ae96d68-ac64-40b9-a9e8-d4b0ddb60336
+  subjects:
+  - entities:
+    - role: player
+      name: Chase Burns
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: 91C2-35
+  uuid: 3c3fd7f0-cef8-4f56-9f67-c55a02e09a58
+  subjects:
+  - entities:
+    - role: player
+      name: Tatsuya Imai
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: 91C2-36
+  uuid: c8c26fa4-447b-45f9-ba7a-66c40afea310
+  subjects:
+  - entities:
+    - role: player
+      name: Carter Jensen
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: 91C2-37
+  uuid: 40140894-e8bc-43cb-b5aa-a13e53e492a0
+  subjects:
+  - entities:
+    - role: player
+      name: Samuel Basallo
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: 91C2-38
+  uuid: c60d0410-8b2b-4c5a-ad60-74e2d2d3bcd6
+  subjects:
+  - entities:
+    - role: player
+      name: Carson Williams
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: 91C2-39
+  uuid: 066dd2a0-10e4-4264-b22f-156cc5065018
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Merrill
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: 91C2-40
+  uuid: e24ff9fb-f795-4eb6-b2e4-8aa814f6b01f
+  subjects:
+  - entities:
+    - role: player
+      name: Austin Riley
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: 91C2-41
+  uuid: 1d51e52f-9970-4ce8-b1ea-9051b3eceb51
+  subjects:
+  - entities:
+    - role: player
+      name: Jazz Chisholm Jr.
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: 91C2-42
+  uuid: 0a0ff59c-1840-4851-acbc-190ee9f0987f
+  subjects:
+  - entities:
+    - role: player
+      name: Joe Mauer
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: 91C2-43
+  uuid: fbcfbf66-a406-4f09-8379-1e03136e9553
+  subjects:
+  - entities:
+    - role: player
+      name: Kazuma Okamoto
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: 91C2-44
+  uuid: 59048725-5fce-486f-aeb4-5d3b18b6cbde
+  subjects:
+  - entities:
+    - role: player
+      name: C.J. Kayfus
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: 91C2-45
+  uuid: 4fe1a133-1cab-4772-a291-c1a0ad7a63ac
+  subjects:
+  - entities:
+    - role: player
+      name: Roman Anthony
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: 91C2-46
+  uuid: a1e2f353-43e5-4782-b971-092c3e7e5769
+  subjects:
+  - entities:
+    - role: player
+      name: Trey Yesavage
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: 91C2-47
+  uuid: '01380c0e-18e5-4a0d-8a2f-21ed865f5038'
+  subjects:
+  - entities:
+    - role: player
+      name: Harry Ford
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: 91C2-48
+  uuid: cc3c4540-1a40-4043-9cdf-4167947c31ff
+  subjects:
+  - entities:
+    - role: player
+      name: Lawrence Butler
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: 91C2-49
+  uuid: 6c78601c-aac1-4d43-b7b9-aae922638cbd
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan Ryan
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: 91C2-50
+  uuid: 8f10f305-500a-4769-ac70-ba703b0ad66f
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Kurtz
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 

--- a/data/baseball/2026-topps-series-2/checklists/1991-topps-baseball-relics.yaml
+++ b/data/baseball/2026-topps-series-2/checklists/1991-topps-baseball-relics.yaml
@@ -1,0 +1,500 @@
+- number: 91R2-AF
+  uuid: ecd00426-369e-46b3-af00-19cec356f776
+  subjects:
+  - entities:
+    - role: player
+      name: Alex Freeland
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: 91R2-AJ
+  uuid: 682686dc-1ffe-4749-a3c2-5f6c85c7563e
+  subjects:
+  - entities:
+    - role: player
+      name: Aaron Judge
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: 91R2-AV
+  uuid: c8296608-b560-4e48-8a75-0ddf0255baa7
+  subjects:
+  - entities:
+    - role: player
+      name: Anthony Volpe
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: 91R2-BC
+  uuid: 67598890-9f0c-4d40-b847-8e3884ba2717
+  subjects:
+  - entities:
+    - role: player
+      name: Bubba Chandler
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: 91R2-BE
+  uuid: 3f3ca510-951e-40ee-afd8-a9a66955f950
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Eldridge
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: 91R2-BH
+  uuid: cdc914f7-a8f9-4260-b2d6-bf89d9e77232
+  subjects:
+  - entities:
+    - role: player
+      name: Brady House
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: 91R2-CB
+  uuid: a0bd0767-36ec-4ec6-89b4-6dc639117e4c
+  subjects:
+  - entities:
+    - role: player
+      name: Chase Burns
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: 91R2-CBE
+  uuid: 206c60cb-071a-435a-9c15-2aeead61d677
+  subjects:
+  - entities:
+    - role: player
+      name: Cody Bellinger
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: 91R2-CD
+  uuid: 0d21edb7-2620-4315-92da-34d62b865212
+  subjects:
+  - entities:
+    - role: player
+      name: Chase DeLauter
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: 91R2-CH
+  uuid: '0686dec4-f63d-4652-9240-6fd4a3f6383b'
+  subjects:
+  - entities:
+    - role: player
+      name: Cade Horton
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: 91R2-CJ
+  uuid: 0a7a758c-9bb4-4c3f-acb9-a00f218b6ff1
+  subjects:
+  - entities:
+    - role: player
+      name: Carter Jensen
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: 91R2-CK
+  uuid: cdd04b5b-af31-405d-8c7d-0b6eec5a6228
+  subjects:
+  - entities:
+    - role: player
+      name: C.J. Kayfus
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: 91R2-CM
+  uuid: 48d0711e-4f5a-441c-bc8b-e09aa9b8243e
+  subjects:
+  - entities:
+    - role: player
+      name: Colson Montgomery
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: 91R2-CMO
+  uuid: 32b086f0-28eb-4efe-88f4-9d18add06072
+  subjects:
+  - entities:
+    - role: player
+      name: Christian Moore
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: 91R2-CS
+  uuid: 99fe1d22-3c9d-41b9-93fe-96072bc09a54
+  subjects:
+  - entities:
+    - role: player
+      name: Cam Schlittler
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: 91R2-CW
+  uuid: e2610965-eb6a-4ab8-9284-5d7f20023c84
+  subjects:
+  - entities:
+    - role: player
+      name: Carson Williams
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: 91R2-DB
+  uuid: 95f10d8c-78d0-46b9-97f0-873a1e86ca05
+  subjects:
+  - entities:
+    - role: player
+      name: Dylan Beavers
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: 91R2-FT
+  uuid: dc0f1bfb-f06f-4c93-8e6f-b86fb213afd9
+  subjects:
+  - entities:
+    - role: player
+      name: Fernando Tatis Jr.
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: 91R2-GS
+  uuid: 3661ef5d-7ab6-4f14-84a8-de81d242f182
+  subjects:
+  - entities:
+    - role: player
+      name: Giancarlo Stanton
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: 91R2-GSP
+  uuid: ffe5e8cd-ea02-4b02-ac19-e7077b87703e
+  subjects:
+  - entities:
+    - role: player
+      name: George Springer
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: 91R2-JC
+  uuid: 73555a7f-8beb-4db1-be3e-0e46fd6e3df5
+  subjects:
+  - entities:
+    - role: player
+      name: Jac Caglianone
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: 91R2-JM
+  uuid: 82310a20-8b6b-4149-b267-b419af67af37
+  subjects:
+  - entities:
+    - role: player
+      name: Jakob Marsee
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: 91R2-JP
+  uuid: c084a8fe-08ce-47b8-82ce-08ccdc7fa7c2
+  subjects:
+  - entities:
+    - role: player
+      name: Jeremy Peña
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: 91R2-JS
+  uuid: 879eb0a4-9082-4625-aefe-ae7d86706ad2
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: 91R2-JT
+  uuid: e0a6ff54-a432-4067-bbbf-8b8ffe821885
+  subjects:
+  - entities:
+    - role: player
+      name: Jonah Tong
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: 91R2-JW
+  uuid: 1ae27fad-7c67-4c2d-8ee1-ebda52f3740c
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Wilson
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: 91R2-KT
+  uuid: 05eb8f15-6ed6-4be3-88e5-2d92dc096dc9
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Teel
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: 91R2-MF
+  uuid: 207454de-6dcc-4147-9dc6-e22ca27666a3
+  subjects:
+  - entities:
+    - role: player
+      name: Max Fried
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: 91R2-MM
+  uuid: 0c27b383-b3f2-4c79-bb95-63a60a6e8002
+  subjects:
+  - entities:
+    - role: player
+      name: Manny Machado
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: 91R2-MMU
+  uuid: fb61e25a-671b-4d83-ad81-fad993920d60
+  subjects:
+  - entities:
+    - role: player
+      name: Max Muncy
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: 91R2-MT
+  uuid: 9674c2c7-5598-4cc3-9544-8049a96d60cf
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Trout
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: 91R2-NK
+  uuid: 1bd581e8-b0b3-4c19-8570-c724fdf2f0f6
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Kurtz
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: 91R2-NM
+  uuid: ee534d2e-a93b-460c-a2e8-8c54943efa5e
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan McLean
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: 91R2-PA
+  uuid: 5d9c1ac7-62ea-4f72-8fda-9a97e80bc6c8
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Alonso
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: 91R2-PS
+  uuid: c98ec4f4-4a94-49c2-9a1b-1f40b9b68494
+  subjects:
+  - entities:
+    - role: player
+      name: Paul Skenes
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: 91R2-PT
+  uuid: c9055fdf-237b-4f2d-b2c0-c0261a3dccf8
+  subjects:
+  - entities:
+    - role: player
+      name: Payton Tolle
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: 91R2-RA
+  uuid: 47bbb05b-d5e7-4dda-87c8-179f65c8bad9
+  subjects:
+  - entities:
+    - role: player
+      name: Roman Anthony
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: 91R2-RAJ
+  uuid: 5d4f220b-fa8a-4733-8574-7f21a60c21b5
+  subjects:
+  - entities:
+    - role: player
+      name: Ronald Acuña Jr.
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: 91R2-RL
+  uuid: dae626df-8483-40df-9023-4205353a5dc2
+  subjects:
+  - entities:
+    - role: player
+      name: Royce Lewis
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: 91R2-RS
+  uuid: 5aef3eed-4f7f-4179-b4eb-c32aed12b0e5
+  subjects:
+  - entities:
+    - role: player
+      name: Roki Sasaki
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: 91R2-SB
+  uuid: a5a200db-4471-497b-89f9-05663468203c
+  subjects:
+  - entities:
+    - role: player
+      name: Samuel Basallo
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: 91R2-SI
+  uuid: 7b3b5220-7eee-4dba-9ffb-4d90e55f61dd
+  subjects:
+  - entities:
+    - role: player
+      name: Shota Imanaga
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: 91R2-SS
+  uuid: b3e272fe-12ce-49c5-b2f4-ed96d7541a70
+  subjects:
+  - entities:
+    - role: player
+      name: Seiya Suzuki
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: 91R2-SSC
+  uuid: 3f3f49c9-796e-4e5b-a1fb-eaa40ec4bd63
+  subjects:
+  - entities:
+    - role: player
+      name: Spencer Schwellenbach
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: 91R2-SST
+  uuid: bf456600-2076-44f5-8a27-aeabf0356593
+  subjects:
+  - entities:
+    - role: player
+      name: Sal Stewart
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: 91R2-TS
+  uuid: d462a76f-d362-41e0-88b5-daf2c0a78bb6
+  subjects:
+  - entities:
+    - role: player
+      name: Trevor Story
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: 91R2-TY
+  uuid: d2f50d68-833c-455e-bdde-a76141b9db96
+  subjects:
+  - entities:
+    - role: player
+      name: Trey Yesavage
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: 91R2-WS
+  uuid: 9edd6fb1-6743-4e22-a406-286331762a7a
+  subjects:
+  - entities:
+    - role: player
+      name: Will Smith
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: 91R2-YD
+  uuid: 2433c57d-8926-46d9-9f6f-1b24701fec33
+  subjects:
+  - entities:
+    - role: player
+      name: Yu Darvish
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: 91R2-ZW
+  uuid: 00b0435b-4ba9-4662-8e9a-04428faef212
+  subjects:
+  - entities:
+    - role: player
+      name: Zack Wheeler
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 

--- a/data/baseball/2026-topps-series-2/checklists/1991-topps-baseball.yaml
+++ b/data/baseball/2026-topps-series-2/checklists/1991-topps-baseball.yaml
@@ -1,0 +1,500 @@
+- number: 91B2-1
+  uuid: 97331153-7ce3-4b8e-a97f-4061ccbf0c14
+  subjects:
+  - entities:
+    - role: player
+      name: Shohei Ohtani
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: 91B2-2
+  uuid: 2c7edf5b-d022-4c3b-9429-d225985fdc7a
+  subjects:
+  - entities:
+    - role: player
+      name: Harry Ford
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: 91B2-3
+  uuid: efd803b6-3a64-44c8-9723-885392167640
+  subjects:
+  - entities:
+    - role: player
+      name: Trea Turner
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: 91B2-4
+  uuid: ff097db0-9e27-42c4-91ee-2e75c4f59837
+  subjects:
+  - entities:
+    - role: player
+      name: Carter Jensen
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: 91B2-5
+  uuid: 286b1da0-dc92-4eab-be48-f71b9c3d6454
+  subjects:
+  - entities:
+    - role: player
+      name: Blake Snell
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: 91B2-6
+  uuid: af185944-4ac8-4f8e-946d-a78147c4c016
+  subjects:
+  - entities:
+    - role: player
+      name: Satchel Paige
+      ref: 
+    - role: team
+      name: St. Louis Browns
+      ref: 
+- number: 91B2-7
+  uuid: d0f40f17-4f62-441e-8cfa-e577c3f66b62
+  subjects:
+  - entities:
+    - role: player
+      name: Bo Bichette
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: 91B2-8
+  uuid: 386cf454-e343-47a6-82bb-00f4437a7bf2
+  subjects:
+  - entities:
+    - role: player
+      name: Brandon Sproat
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: 91B2-9
+  uuid: 140c02c2-57d0-4043-ac82-63c00ded0bcf
+  subjects:
+  - entities:
+    - role: player
+      name: Salvador Perez
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: 91B2-10
+  uuid: 259a7c0e-cd32-4501-ba12-3d77b59f186d
+  subjects:
+  - entities:
+    - role: player
+      name: Ty Cobb
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: 91B2-11
+  uuid: f6385109-e924-444e-8d22-2f84f8f97568
+  subjects:
+  - entities:
+    - role: player
+      name: Roman Anthony
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: 91B2-12
+  uuid: 79f52a23-85ed-448c-9b9f-12a05b69577e
+  subjects:
+  - entities:
+    - role: player
+      name: Munetaka Murakami
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: 91B2-13
+  uuid: ebdd8a65-0e02-4dc9-a119-53d599c32af6
+  subjects:
+  - entities:
+    - role: player
+      name: Sal Stewart
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: 91B2-14
+  uuid: 8bbcfa08-8d7a-4195-9c2c-48c7c966fcee
+  subjects:
+  - entities:
+    - role: player
+      name: Jonah Tong
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: 91B2-15
+  uuid: cb102064-fbbc-410c-9b7c-ff733086adc1
+  subjects:
+  - entities:
+    - role: player
+      name: Hunter Barco
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: 91B2-16
+  uuid: 8ddc731d-d418-4a1b-bad0-8044d9310e34
+  subjects:
+  - entities:
+    - role: player
+      name: Brent Rooker
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: 91B2-17
+  uuid: 1be5c173-6b4b-4c02-804a-7a69ea5c2ae7
+  subjects:
+  - entities:
+    - role: player
+      name: Willie Mays
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: 91B2-18
+  uuid: 36e3fab1-6e17-4587-a62b-33a471541db4
+  subjects:
+  - entities:
+    - role: player
+      name: Chase DeLauter
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: 91B2-19
+  uuid: 904ff088-860d-47de-826f-a438382c502b
+  subjects:
+  - entities:
+    - role: player
+      name: Jackie Robinson
+      ref: 
+    - role: team
+      name: Brooklyn Dodgers
+      ref: 
+- number: 91B2-20
+  uuid: ebbb57db-86fe-487c-997e-94888a5d14cc
+  subjects:
+  - entities:
+    - role: player
+      name: Mariano Rivera
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: 91B2-21
+  uuid: 6791bfff-356f-4b56-8277-ccf2a5c1da96
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Eldridge
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: 91B2-22
+  uuid: 6d65d993-b2fc-4eea-8b8e-240eb74fffb4
+  subjects:
+  - entities:
+    - role: player
+      name: Greg Maddux
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: 91B2-23
+  uuid: 14698c54-cf24-4101-9a8b-0830a6036626
+  subjects:
+  - entities:
+    - role: player
+      name: Jhostynxon Garcia
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: 91B2-24
+  uuid: d7de9675-3501-4c09-af2b-94ffe1887a79
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Kurtz
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: 91B2-25
+  uuid: db45c30b-3f33-4b65-89a4-7fe80dff123e
+  subjects:
+  - entities:
+    - role: player
+      name: Ketel Marte
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: 91B2-26
+  uuid: b2ec8039-744b-488c-b59c-a6259d5baf9a
+  subjects:
+  - entities:
+    - role: player
+      name: Craig Biggio
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: 91B2-27
+  uuid: 0f70a000-4d19-4ad4-b438-b37b30b41178
+  subjects:
+  - entities:
+    - role: player
+      name: Connelly Early
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: 91B2-28
+  uuid: e4ae88cb-da87-432b-908c-1a03066cfde4
+  subjects:
+  - entities:
+    - role: player
+      name: Ernie Banks
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: 91B2-29
+  uuid: 0c504c16-488d-4e04-a9df-81cea60106ad
+  subjects:
+  - entities:
+    - role: player
+      name: Samuel Basallo
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: 91B2-30
+  uuid: c4f0ea68-5a8b-4476-b8af-dacab68af551
+  subjects:
+  - entities:
+    - role: player
+      name: Lou Gehrig
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: 91B2-31
+  uuid: 775688ed-122c-40f9-8427-31163022e0f8
+  subjects:
+  - entities:
+    - role: player
+      name: Christy Mathewson
+      ref: 
+    - role: team
+      name: New York Giants
+      ref: 
+- number: 91B2-32
+  uuid: 114d683c-d86a-40d4-b15f-63ff7a95d51a
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Alonso
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: 91B2-33
+  uuid: 70b88cdf-f599-4fa4-9f76-8cd09c4a5cf4
+  subjects:
+  - entities:
+    - role: player
+      name: Trey Yesavage
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: 91B2-34
+  uuid: db00e30d-8d88-48a4-a981-7b26974c56d6
+  subjects:
+  - entities:
+    - role: player
+      name: Stan Musial
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: 91B2-35
+  uuid: b74ad3f3-49fa-4b65-9f0b-3f82ff12f958
+  subjects:
+  - entities:
+    - role: player
+      name: Jarren Duran
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: 91B2-36
+  uuid: 353149b8-075f-4d93-89a0-65b7ddf016e3
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan Ryan
+      ref: 
+    - role: team
+      name: California Angels
+      ref: 
+- number: 91B2-37
+  uuid: 0cb292f8-9b93-45a9-9d10-d400b171592c
+  subjects:
+  - entities:
+    - role: player
+      name: Honus Wagner
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: 91B2-38
+  uuid: 68949e39-852c-49c2-a29a-96503db946d7
+  subjects:
+  - entities:
+    - role: player
+      name: Dale Murphy
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: 91B2-39
+  uuid: 9f8d3760-c80a-44f6-a647-9c66f569e481
+  subjects:
+  - entities:
+    - role: player
+      name: Zach Neto
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: 91B2-40
+  uuid: 3e100e4f-cc31-44a0-afd1-376a2564bd86
+  subjects:
+  - entities:
+    - role: player
+      name: Drew Gilbert
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: 91B2-41
+  uuid: 3b155b9e-42aa-40ef-ae59-18717d1fef99
+  subjects:
+  - entities:
+    - role: player
+      name: Carlos Correa
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: 91B2-42
+  uuid: a86cd6f6-6abf-4c9d-93a9-27bc9ea46b27
+  subjects:
+  - entities:
+    - role: player
+      name: Adley Rutschman
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: 91B2-43
+  uuid: 0a8d070a-beb9-4b79-b1eb-5f63f7e676c0
+  subjects:
+  - entities:
+    - role: player
+      name: Jac Caglianone
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: 91B2-44
+  uuid: 35afb142-dffc-4cac-a76e-eb8460ef5a43
+  subjects:
+  - entities:
+    - role: player
+      name: Austin Riley
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: 91B2-45
+  uuid: e3a0086d-702f-4dd4-8b06-c65130f8a85d
+  subjects:
+  - entities:
+    - role: player
+      name: Jakob Marsee
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: 91B2-46
+  uuid: 4c846e08-f304-454e-b9a9-35b1381281e4
+  subjects:
+  - entities:
+    - role: player
+      name: Ted Williams
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: 91B2-47
+  uuid: ce70beb2-3ffa-4f66-8ba2-63189e6bc91e
+  subjects:
+  - entities:
+    - role: player
+      name: Hunter Greene
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: 91B2-48
+  uuid: 3962e420-e3ae-4cd0-bff7-0555c1282ab1
+  subjects:
+  - entities:
+    - role: player
+      name: Wyatt Langford
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: 91B2-49
+  uuid: 3c616481-054b-4256-8561-198f430d4119
+  subjects:
+  - entities:
+    - role: player
+      name: Joe DiMaggio
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: 91B2-50
+  uuid: 162fdc04-4c76-4cfb-bb62-66cb5819a85e
+  subjects:
+  - entities:
+    - role: player
+      name: Babe Ruth
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 

--- a/data/baseball/2026-topps-series-2/checklists/75-years-of-topps-die-cut-autographs.yaml
+++ b/data/baseball/2026-topps-series-2/checklists/75-years-of-topps-die-cut-autographs.yaml
@@ -1,0 +1,110 @@
+- number: 75YA-BB
+  uuid: 85e5d3a7-dcd1-48d7-be0d-cdf7e45c1d1e
+  subjects:
+  - entities:
+    - role: player
+      name: Byron Buxton
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: 75YA-BP
+  uuid: '08fcc413-e1dc-460f-a721-b54562fe6f58'
+  subjects:
+  - entities:
+    - role: player
+      name: Buster Posey
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: 75YA-GH
+  uuid: 67c87946-16a0-47cd-9cd6-1c3c5a0b62c6
+  subjects:
+  - entities:
+    - role: player
+      name: Gunnar Henderson
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: 75YA-JMA
+  uuid: d4fa2840-67ba-47f5-bace-d20f707cdbdb
+  subjects:
+  - entities:
+    - role: player
+      name: Joe Mauer
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: 75YA-JSO
+  uuid: 0bc5f56a-5fbd-4f60-a245-30d3f31fbb56
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: 75YA-MC
+  uuid: c191f13a-8742-49b6-8d05-b7bd414753d6
+  subjects:
+  - entities:
+    - role: player
+      name: Miguel Cabrera
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: 75YA-NR
+  uuid: 3613227f-d589-4e94-85c1-0071dd6bd2e4
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan Ryan
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: 75YA-RG
+  uuid: c148a910-3f0d-4022-b80d-fb5a60942577
+  subjects:
+  - entities:
+    - role: player
+      name: Riley Greene
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: 75YA-SI
+  uuid: f07d44e6-a8e8-4a67-9f55-80bc74d489a7
+  subjects:
+  - entities:
+    - role: player
+      name: Shota Imanaga
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: 75YA-SKO
+  uuid: 2da73944-87d1-401e-825e-6ddb45d4d2ab
+  subjects:
+  - entities:
+    - role: player
+      name: Sandy Koufax
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: 75YA-TH
+  uuid: f595085f-c55b-48b8-b668-d8b810374716
+  subjects:
+  - entities:
+    - role: player
+      name: Torii Hunter
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 

--- a/data/baseball/2026-topps-series-2/checklists/all-aces.yaml
+++ b/data/baseball/2026-topps-series-2/checklists/all-aces.yaml
@@ -1,0 +1,100 @@
+- number: AA-11
+  uuid: fb891978-a129-41e9-9f7c-cde28a4bb4c7
+  subjects:
+  - entities:
+    - role: player
+      name: Yoshinobu Yamamoto
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: AA-12
+  uuid: 61b97f7c-db03-4072-a14b-0562ce5045a9
+  subjects:
+  - entities:
+    - role: player
+      name: Greg Maddux
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: AA-13
+  uuid: 52456614-e7ec-47d0-adba-883540f8989f
+  subjects:
+  - entities:
+    - role: player
+      name: Randy Johnson
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: AA-14
+  uuid: 73d4f3ca-db81-4131-84e5-e1bb44654fbd
+  subjects:
+  - entities:
+    - role: player
+      name: Christy Mathewson
+      ref: 
+    - role: team
+      name: New York Giants
+      ref: 
+- number: AA-15
+  uuid: 66f5c0cf-35d9-4042-b35e-cc8d3451e27d
+  subjects:
+  - entities:
+    - role: player
+      name: Roki Sasaki
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: AA-16
+  uuid: bbfc8e5a-2ee3-46a8-bb62-8ceac81b7267
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan Ryan
+      ref: 
+    - role: team
+      name: California Angels
+      ref: 
+- number: AA-17
+  uuid: '096dc873-af57-4dc8-9add-d119b2539963'
+  subjects:
+  - entities:
+    - role: player
+      name: Garrett Crochet
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: AA-18
+  uuid: 0afb238f-1e18-4505-a881-343c2d051450
+  subjects:
+  - entities:
+    - role: player
+      name: Cam Schlittler
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: AA-19
+  uuid: 936f9a4e-0184-43ae-a1e2-d20cf4b6566d
+  subjects:
+  - entities:
+    - role: player
+      name: Payton Tolle
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: AA-20
+  uuid: 26c77420-684c-4fb1-831f-a7eaeed6466e
+  subjects:
+  - entities:
+    - role: player
+      name: Trey Yesavage
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 

--- a/data/baseball/2026-topps-series-2/checklists/all-kings.yaml
+++ b/data/baseball/2026-topps-series-2/checklists/all-kings.yaml
@@ -1,0 +1,150 @@
+- number: AK-16
+  uuid: 1469e3e3-4524-4a64-a284-c2c5fc8738db
+  subjects:
+  - entities:
+    - role: player
+      name: Ryne Sandberg
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: AK-17
+  uuid: 14534487-cde4-4482-8fcf-672de2d304ad
+  subjects:
+  - entities:
+    - role: player
+      name: Derek Jeter
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: AK-18
+  uuid: d3c42081-7b3e-411e-8723-fd62ad4abfc9
+  subjects:
+  - entities:
+    - role: player
+      name: Jackie Robinson
+      ref: 
+    - role: team
+      name: Brooklyn Dodgers
+      ref: 
+- number: AK-19
+  uuid: d9aed058-5925-45a5-87e4-2a2f2975dea2
+  subjects:
+  - entities:
+    - role: player
+      name: Mickey Mantle
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: AK-20
+  uuid: 8bc971dd-6b79-471c-a7b7-aee23e41ee12
+  subjects:
+  - entities:
+    - role: player
+      name: Ken Griffey Jr.
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: AK-21
+  uuid: d8cba4ec-38ac-4408-b43e-085ed5111d5e
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Chourio
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: AK-22
+  uuid: 27d20a58-6eb4-4e11-8817-235a48e3aa45
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: AK-23
+  uuid: b1b2a999-b9f7-4156-8cbf-15199bb3da79
+  subjects:
+  - entities:
+    - role: player
+      name: Cal Raleigh
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: AK-24
+  uuid: fd70b08e-61cd-444b-9d81-bacb909d0d6f
+  subjects:
+  - entities:
+    - role: player
+      name: Vladimir Guerrero Jr.
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: AK-25
+  uuid: c9064c1f-5d1f-4811-affb-ce79cf693529
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Kurtz
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: AK-26
+  uuid: 8e52d2bc-22c0-43a4-92c3-951ed8a48918
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Eldridge
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: AK-27
+  uuid: fc73608a-f56f-4acb-af3f-b1ff2ae636a1
+  subjects:
+  - entities:
+    - role: player
+      name: Carson Williams
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: AK-28
+  uuid: 842dd8b2-fef2-4e40-b4d3-fc0f52c51499
+  subjects:
+  - entities:
+    - role: player
+      name: Samuel Basallo
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: AK-29
+  uuid: 8b6b535b-6ba1-4c80-8cea-0dcc387387ac
+  subjects:
+  - entities:
+    - role: player
+      name: Munetaka Murakami
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: AK-30
+  uuid: c6d993c5-abf4-4633-80c4-344bb0e51794
+  subjects:
+  - entities:
+    - role: player
+      name: Roberto Clemente
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 

--- a/data/baseball/2026-topps-series-2/checklists/apple-foil-variations.yaml
+++ b/data/baseball/2026-topps-series-2/checklists/apple-foil-variations.yaml
@@ -1,0 +1,1000 @@
+- number: '352'
+  uuid: 05c61e54-750c-4269-ab9f-7820dd7af82f
+  subjects:
+  - entities:
+    - role: player
+      name: Spencer Torkelson
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '355'
+  uuid: 56c12300-4bed-4cb1-8e3a-8e92151c149c
+  subjects:
+  - entities:
+    - role: player
+      name: Nathan Eovaldi
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: '358'
+  uuid: bdaaf881-21dc-46a3-add9-5a200c2f9964
+  subjects:
+  - entities:
+    - role: player
+      name: Adley Rutschman
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '363'
+  uuid: cce9bed8-ddf7-4222-9f41-b2dc9621e5af
+  subjects:
+  - entities:
+    - role: player
+      name: J.T. Realmuto
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: '365'
+  uuid: 536fd4e6-7600-44ee-a3d9-89dfd307b108
+  subjects:
+  - entities:
+    - role: player
+      name: Spencer Steer
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '367'
+  uuid: 521edeaf-a26d-4950-b0dd-8035fbfce78a
+  subjects:
+  - entities:
+    - role: player
+      name: Robbie Ray
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '368'
+  uuid: db401b7d-6fb2-4e79-8ecb-5e4e689a4c58
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Tucker
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '371'
+  uuid: 28cece32-d6c2-4764-9a0d-253c12ce53f4
+  subjects:
+  - entities:
+    - role: player
+      name: Brent Rooker
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: '372'
+  uuid: 0d7fba25-141b-44ad-9090-4747c7001fe6
+  subjects:
+  - entities:
+    - role: player
+      name: Sal Stewart
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '382'
+  uuid: 396cd196-a39f-4518-b27c-3374feb691b5
+  subjects:
+  - entities:
+    - role: player
+      name: Hunter Greene
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '383'
+  uuid: cc9a32cb-6a04-49cc-968c-b80f15df316d
+  subjects:
+  - entities:
+    - role: player
+      name: Wyatt Langford
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: '386'
+  uuid: 21fd4bb2-bb7c-40a9-a088-57975906323b
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Curvelo
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: '387'
+  uuid: 00b10771-3b39-49b9-99cb-c1224f6f940d
+  subjects:
+  - entities:
+    - role: player
+      name: Drew Sommers
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '393'
+  uuid: b59d9871-d80a-4668-82d8-7146b4a70a3e
+  subjects:
+  - entities:
+    - role: player
+      name: Jazz Chisholm Jr.
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '395'
+  uuid: 4f26420d-7a68-4fc5-95f1-b255eec4b75e
+  subjects:
+  - entities:
+    - role: player
+      name: Josh Naylor
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: '398'
+  uuid: 174a79bc-272f-4f16-9fca-83a626a6f8a7
+  subjects:
+  - entities:
+    - role: player
+      name: Hunter Barco
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '400'
+  uuid: 9f162333-509e-4837-b6cd-00bc17bf8f42
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Alonso
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '406'
+  uuid: 31b124a1-e1bf-424b-8eed-4e14dcd124dc
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Eldridge
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '410'
+  uuid: 950c1b17-a471-41ab-a056-dc0c38b3e7a0
+  subjects:
+  - entities:
+    - role: player
+      name: Hayden Harris
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: '415'
+  uuid: 4ec5d890-c83e-4879-a648-1a8fce4c1343
+  subjects:
+  - entities:
+    - role: player
+      name: Justin Verlander
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '422'
+  uuid: 017603b6-2598-4509-a099-280f6b753ab3
+  subjects:
+  - entities:
+    - role: player
+      name: Shane Bieber
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '423'
+  uuid: 516d5f6f-4dca-42c5-86ba-474b0a815af8
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Robert Jr.
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '425'
+  uuid: fa483587-ee45-4a12-887c-7104a2ad0ad7
+  subjects:
+  - entities:
+    - role: player
+      name: Trent Grisham
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '427'
+  uuid: 2bc520ff-f6b6-4383-a559-2c11a29d4780
+  subjects:
+  - entities:
+    - role: player
+      name: Chris Sale
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: '431'
+  uuid: 8f5ecd33-3406-4dc7-9c95-5d4e63c9d35e
+  subjects:
+  - entities:
+    - role: player
+      name: Randy Arozarena
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: '435'
+  uuid: 2f3310d0-d514-44ee-9a3c-a38514edb3f1
+  subjects:
+  - entities:
+    - role: player
+      name: Denzer Guzman
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: '439'
+  uuid: b47f1296-a52b-4a67-a93a-230505f30c03
+  subjects:
+  - entities:
+    - role: player
+      name: Gleyber Torres
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '441'
+  uuid: 02bce34b-4cfc-4c7b-91af-7483da2606cd
+  subjects:
+  - entities:
+    - role: player
+      name: Lars Nootbaar
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: '446'
+  uuid: '049c167d-7af6-4364-b295-166cfc6affb8'
+  subjects:
+  - entities:
+    - role: player
+      name: Eugenio Suárez
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '448'
+  uuid: a95d9f5e-e9ea-465a-bddd-3fce26629c54
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Chourio
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: '450'
+  uuid: 11928547-4bbb-47d9-9208-9e4d2506eba7
+  subjects:
+  - entities:
+    - role: player
+      name: Gerrit Cole
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '455'
+  uuid: ee4b4a11-2541-428f-a4c8-52eaa24da8f9
+  subjects:
+  - entities:
+    - role: player
+      name: George Springer
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '458'
+  uuid: 5bdeeb2d-55db-4681-b08b-69bd00ac6de9
+  subjects:
+  - entities:
+    - role: player
+      name: Chase DeLauter
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '459'
+  uuid: 6b1beafe-6c01-4a7f-8d9d-c8e10370e18f
+  subjects:
+  - entities:
+    - role: player
+      name: Ketel Marte
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: '463'
+  uuid: 3faad8bd-f144-4872-9224-f4aba35b7395
+  subjects:
+  - entities:
+    - role: player
+      name: Aaron Nola
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: '468'
+  uuid: 7052f20c-16a8-4b56-84d4-f46d5bb28906
+  subjects:
+  - entities:
+    - role: player
+      name: Yordan Alvarez
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '470'
+  uuid: da08fb7d-86e0-4cf6-a74e-7bce98fed481
+  subjects:
+  - entities:
+    - role: player
+      name: Brandon Nimmo
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: '471'
+  uuid: 89a5654f-d4be-41f5-8502-e6cb034d40e5
+  subjects:
+  - entities:
+    - role: player
+      name: J.P. Crawford
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: '473'
+  uuid: 7cca0f88-cfbd-43dd-beaa-1fae885a3bd3
+  subjects:
+  - entities:
+    - role: player
+      name: Bo Bichette
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '483'
+  uuid: 0cdd3e30-299f-4eca-8669-bc762878e69e
+  subjects:
+  - entities:
+    - role: player
+      name: Logan O'Hoppe
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: '493'
+  uuid: 1f31eaf3-5b8d-47d5-9169-cc5b111f2d7a
+  subjects:
+  - entities:
+    - role: player
+      name: George Kirby
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: '500'
+  uuid: 67aa98bd-141e-4118-a538-60b78848068f
+  subjects:
+  - entities:
+    - role: player
+      name: Shohei Ohtani
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '501'
+  uuid: 9e07a374-eaa1-4476-af80-4f6a2ff65493
+  subjects:
+  - entities:
+    - role: player
+      name: Connelly Early
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '503'
+  uuid: dccc37e7-48be-4359-9142-ef4d15c6117b
+  subjects:
+  - entities:
+    - role: player
+      name: Munetaka Murakami
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: '507'
+  uuid: e12b444d-39e2-4f92-a33b-cef42c6142a0
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Castillo
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: '510'
+  uuid: 3ef42c0c-535f-45d9-9ae0-241ba33a4db7
+  subjects:
+  - entities:
+    - role: player
+      name: Philip Abner
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: '520'
+  uuid: 2f72e97c-b9ca-4d7b-af80-a9205ef65781
+  subjects:
+  - entities:
+    - role: player
+      name: Andrew Alvarez
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: '526'
+  uuid: 45660db7-6b6c-4b03-8ddf-f6d5a09027d7
+  subjects:
+  - entities:
+    - role: player
+      name: Masyn Winn
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: '530'
+  uuid: 6af11645-1710-4dce-ab11-f4bc4198478c
+  subjects:
+  - entities:
+    - role: player
+      name: Carter Jensen
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: '533'
+  uuid: 71242e6e-8696-47ff-9870-f92ff8818c9f
+  subjects:
+  - entities:
+    - role: player
+      name: Jasson Domínguez
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '534'
+  uuid: 26aa12bf-df71-41f1-b681-21202c0c073b
+  subjects:
+  - entities:
+    - role: player
+      name: Brandon Sproat
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: '536'
+  uuid: d6b3a37b-e21a-4ed5-be7b-90adf4d92bed
+  subjects:
+  - entities:
+    - role: player
+      name: Trevor Story
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '541'
+  uuid: 373dddf0-7be3-4d0f-ab10-451219d5a623
+  subjects:
+  - entities:
+    - role: player
+      name: Jung Hoo Lee
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '547'
+  uuid: 43245ab7-d192-461b-a399-ab92257d8d5a
+  subjects:
+  - entities:
+    - role: player
+      name: Dylan Cease
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '550'
+  uuid: fe89aa14-c4d6-4776-80af-e190f8540fa0
+  subjects:
+  - entities:
+    - role: player
+      name: Dansby Swanson
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '551'
+  uuid: c312a05d-732d-41e1-af64-be55a1ee7e70
+  subjects:
+  - entities:
+    - role: player
+      name: Taylor Ward
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '560'
+  uuid: dc89e4ce-036d-4705-9ae7-d7affa107408
+  subjects:
+  - entities:
+    - role: player
+      name: Jarren Duran
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '561'
+  uuid: 49d09420-8411-4ce8-ac2d-751af47ffdc4
+  subjects:
+  - entities:
+    - role: player
+      name: Matt Chapman
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '562'
+  uuid: 31f2d856-ab60-44d3-8f62-63f5ba24320c
+  subjects:
+  - entities:
+    - role: player
+      name: Bryson Stott
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: '564'
+  uuid: e7ccd1d9-ce87-44b4-bc1d-91f77bd62844
+  subjects:
+  - entities:
+    - role: player
+      name: Tyler Soderstrom
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: '568'
+  uuid: 8ccf4398-aad7-4488-bff0-d46cf2df8bc7
+  subjects:
+  - entities:
+    - role: player
+      name: Ozzie Albies
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: '569'
+  uuid: 44ec746c-825f-4bbb-a166-93ae36bcbb3a
+  subjects:
+  - entities:
+    - role: player
+      name: Max Scherzer
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '570'
+  uuid: 6638843c-847b-487a-adc2-8815a938c9a3
+  subjects:
+  - entities:
+    - role: player
+      name: Rolddy Muñoz
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: '578'
+  uuid: 382d21a5-8640-4538-85f8-c5f4730749a2
+  subjects:
+  - entities:
+    - role: player
+      name: Heriberto Hernández
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: '585'
+  uuid: d481a28b-1438-47dd-9658-31a6f71bdc91
+  subjects:
+  - entities:
+    - role: player
+      name: Ian Happ
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '586'
+  uuid: 4d8788e3-cf92-4acf-a245-bc4782aa6ff2
+  subjects:
+  - entities:
+    - role: player
+      name: Marcus Semien
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '594'
+  uuid: 6ecda202-4f84-4cc3-a185-6a92ecacbc5a
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Gil
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '597'
+  uuid: 850b9cb8-866f-40c0-a598-596e9a101b59
+  subjects:
+  - entities:
+    - role: player
+      name: Paul Goldschmidt
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '598'
+  uuid: 36529100-7aa9-4121-918c-6430b3519638
+  subjects:
+  - entities:
+    - role: player
+      name: Jack Winkler
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '600'
+  uuid: 7ee74fa7-46e4-4284-b8e6-a7561effc078
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '601'
+  uuid: f783ef61-e75a-4b4a-8edd-94518176871e
+  subjects:
+  - entities:
+    - role: player
+      name: Zach Cole
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '603'
+  uuid: 0161cf50-8c78-4b05-89c7-7629e5feb5a9
+  subjects:
+  - entities:
+    - role: player
+      name: George Valera
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '607'
+  uuid: 3922e875-e54c-4d65-ac16-2f3a7efbea15
+  subjects:
+  - entities:
+    - role: player
+      name: Cody Bellinger
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '611'
+  uuid: 5e09bf58-943a-4f8e-be0b-99faa3b1b024
+  subjects:
+  - entities:
+    - role: player
+      name: Paul Gervase
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '613'
+  uuid: 6229c270-7ac3-4265-97f7-8e4eea85d8e5
+  subjects:
+  - entities:
+    - role: player
+      name: Jordan Westburg
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '614'
+  uuid: a5b8a842-5bb3-47d0-8629-edb54a237617
+  subjects:
+  - entities:
+    - role: player
+      name: Manny Machado
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: '618'
+  uuid: c5166140-3fa6-46f2-aa11-1c4b3ca643d5
+  subjects:
+  - entities:
+    - role: player
+      name: Tanner Bibee
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '620'
+  uuid: c2e11735-179b-4bcb-9bde-61765acbd561
+  subjects:
+  - entities:
+    - role: player
+      name: Trey Yesavage
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '623'
+  uuid: bb998d07-72bf-44ad-b865-622189a3eb2d
+  subjects:
+  - entities:
+    - role: player
+      name: Rafael Flores
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '629'
+  uuid: 7bbcf78f-5356-46d2-ae6b-b36082b9d7fe
+  subjects:
+  - entities:
+    - role: player
+      name: Tyler Glasnow
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '631'
+  uuid: a5f800e7-192f-4b59-b5ef-946c259a2111
+  subjects:
+  - entities:
+    - role: player
+      name: Will Smith
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '632'
+  uuid: 1d7cca0e-5daa-42f9-a0b9-2578091cbda8
+  subjects:
+  - entities:
+    - role: player
+      name: Cade Horton
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '633'
+  uuid: 18baef21-72bb-4f6e-9a90-838f7c5a0bd2
+  subjects:
+  - entities:
+    - role: player
+      name: Salvador Perez
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: '643'
+  uuid: 42dc599c-6021-4944-aae8-e247a38884d0
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Lodolo
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '646'
+  uuid: 10e43820-81dc-42b3-88ca-5871c9ececbb
+  subjects:
+  - entities:
+    - role: player
+      name: Mark Vientos
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '650'
+  uuid: 85d1b1ce-6252-4840-b9b4-e89360fcb38b
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Schwarber
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: '656'
+  uuid: 113dfd3f-77a2-4aee-b84e-18cd50623bc4
+  subjects:
+  - entities:
+    - role: player
+      name: Aroldis Chapman
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '658'
+  uuid: 9df417be-1a62-4178-93a1-a82a272c4688
+  subjects:
+  - entities:
+    - role: player
+      name: Jack Flaherty
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '659'
+  uuid: 49266693-6de0-4e7b-854d-f0b744def2e5
+  subjects:
+  - entities:
+    - role: player
+      name: Harry Ford
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: '665'
+  uuid: 51b544e9-8c55-4181-b306-895f52fee1d1
+  subjects:
+  - entities:
+    - role: player
+      name: Jose Corniell
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: '667'
+  uuid: fe2fa83b-ca84-4abc-b544-cfe13d81a1e3
+  subjects:
+  - entities:
+    - role: player
+      name: Kodai Senga
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '668'
+  uuid: 51e30bd8-3584-498d-8b7c-2834037da7e8
+  subjects:
+  - entities:
+    - role: player
+      name: Petey Halpin
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '674'
+  uuid: 80120238-9715-49a6-a890-243d98af56e2
+  subjects:
+  - entities:
+    - role: player
+      name: Andre Granillo
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: '675'
+  uuid: 3f24ceb4-c2b1-4c3a-91cb-78c49c038d1e
+  subjects:
+  - entities:
+    - role: player
+      name: Steven Kwan
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '677'
+  uuid: 65bb956d-2156-49bd-aa14-d792178f84ac
+  subjects:
+  - entities:
+    - role: player
+      name: Wilyer Abreu
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '680'
+  uuid: b3098bdd-d570-441b-a824-b10d54707935
+  subjects:
+  - entities:
+    - role: player
+      name: Carlos Correa
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '685'
+  uuid: 14771214-ad88-41ba-8c98-97cf51967acb
+  subjects:
+  - entities:
+    - role: player
+      name: Seiya Suzuki
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '692'
+  uuid: 8cbcfa7e-4f12-4cc1-afd9-b7c657597941
+  subjects:
+  - entities:
+    - role: player
+      name: Drake Baldwin
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: '697'
+  uuid: 694d3786-d6af-48bc-b594-ffabe4591ce4
+  subjects:
+  - entities:
+    - role: player
+      name: Bryan Reynolds
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '700'
+  uuid: '085eba64-c344-4a4a-8701-c9c216983a65'
+  subjects:
+  - entities:
+    - role: player
+      name: Freddie Freeman
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 

--- a/data/baseball/2026-topps-series-2/checklists/base-1952-variations.yaml
+++ b/data/baseball/2026-topps-series-2/checklists/base-1952-variations.yaml
@@ -1,0 +1,200 @@
+- number: '372'
+  uuid: b00e6999-45d6-424c-81b5-75a55c9f9cd5
+  subjects:
+  - entities:
+    - role: player
+      name: Sal Stewart
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '398'
+  uuid: 5d9e6f29-717e-48ce-8406-6aa01a76a79f
+  subjects:
+  - entities:
+    - role: player
+      name: Hunter Barco
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '406'
+  uuid: 0c86c7c8-c437-4750-b60e-bbe68d5abe20
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Eldridge
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '435'
+  uuid: 2288feba-3d5a-4d70-a5a9-0a410f8b70e2
+  subjects:
+  - entities:
+    - role: player
+      name: Denzer Guzman
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: '443'
+  uuid: '02084587-21df-4f82-94f7-ba42367782b9'
+  subjects:
+  - entities:
+    - role: player
+      name: Kazuma Okamoto
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '458'
+  uuid: 4b3d535a-80a5-45a2-9b88-3b65d77eb8f8
+  subjects:
+  - entities:
+    - role: player
+      name: Chase DeLauter
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '501'
+  uuid: e8a85597-78cd-48dc-b277-0ce3b56c9547
+  subjects:
+  - entities:
+    - role: player
+      name: Connelly Early
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '503'
+  uuid: 1502e552-08b8-4954-877c-16ce1fca08c2
+  subjects:
+  - entities:
+    - role: player
+      name: Munetaka Murakami
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: '513'
+  uuid: 8109f0b7-de0c-4451-8253-eedc2de4a903
+  subjects:
+  - entities:
+    - role: player
+      name: Tatsuya Imai
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '530'
+  uuid: 416aecb6-4a9a-427e-a6f3-5600d39c4704
+  subjects:
+  - entities:
+    - role: player
+      name: Carter Jensen
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: '534'
+  uuid: c9bda97a-bcb8-4153-9d71-04208abeeee4
+  subjects:
+  - entities:
+    - role: player
+      name: Brandon Sproat
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: '570'
+  uuid: c52b8142-a37c-4bf9-9bf9-b9dcdd608444
+  subjects:
+  - entities:
+    - role: player
+      name: Rolddy Muñoz
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: '578'
+  uuid: 8d1f7286-187e-44ad-be3c-696073b6e0a0
+  subjects:
+  - entities:
+    - role: player
+      name: Heriberto Hernández
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: '601'
+  uuid: 76a68068-e10f-4dd3-9fa2-75c760dffc3d
+  subjects:
+  - entities:
+    - role: player
+      name: Zach Cole
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '603'
+  uuid: a4644167-602a-4b11-b7f1-1fbeff75ae1c
+  subjects:
+  - entities:
+    - role: player
+      name: George Valera
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '620'
+  uuid: 217a6967-bb3e-42ff-a0c0-24e58e4bef4d
+  subjects:
+  - entities:
+    - role: player
+      name: Trey Yesavage
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '623'
+  uuid: ca641f0d-35cf-4bc3-aca7-6ab934a6c9d2
+  subjects:
+  - entities:
+    - role: player
+      name: Rafael Flores
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '659'
+  uuid: 25f3bb14-ca62-463b-b2bb-e8b2c6143d78
+  subjects:
+  - entities:
+    - role: player
+      name: Harry Ford
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: '665'
+  uuid: a608817b-22e7-401b-ae96-dd006ea1364c
+  subjects:
+  - entities:
+    - role: player
+      name: Jose Corniell
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: '668'
+  uuid: ccbf4c5f-38e4-42f1-a587-22810a93c726
+  subjects:
+  - entities:
+    - role: player
+      name: Petey Halpin
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 

--- a/data/baseball/2026-topps-series-2/checklists/base-funko-pop-cards.yaml
+++ b/data/baseball/2026-topps-series-2/checklists/base-funko-pop-cards.yaml
@@ -1,0 +1,50 @@
+- number: '41'
+  uuid: 6926adcb-9b1f-4233-bfab-3c645534c44a
+  subjects:
+  - entities:
+    - role: player
+      name: Mookie Betts
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '46'
+  uuid: 382d419f-0953-4f4e-9ede-2556beeedb92
+  subjects:
+  - entities:
+    - role: player
+      name: Gunnar Henderson
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '50'
+  uuid: bd1a7790-5f18-4ddc-ae15-901d133a964f
+  subjects:
+  - entities:
+    - role: player
+      name: Ronald Acuña Jr.
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: '123'
+  uuid: c2edd459-d159-4978-90a8-bc3c1c935517
+  subjects:
+  - entities:
+    - role: player
+      name: Francisco Lindor
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '278'
+  uuid: 454551bb-8df0-46ef-82ef-dda9b56aad08
+  subjects:
+  - entities:
+    - role: player
+      name: Jose Altuve
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 

--- a/data/baseball/2026-topps-series-2/checklists/base-short-print-rookie-cards.yaml
+++ b/data/baseball/2026-topps-series-2/checklists/base-short-print-rookie-cards.yaml
@@ -1,0 +1,40 @@
+- number: '697'
+  uuid: 48f7637c-db5b-41a2-b176-0cc12d40df6c
+  subjects:
+  - entities:
+    - role: player
+      name: Kevin McGonigle
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '698'
+  uuid: b02ed8e5-ba66-443f-9a84-6f9dd02e6ad3
+  subjects:
+  - entities:
+    - role: player
+      name: JJ Wetherholt
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: '699'
+  uuid: beb826ce-f8e8-4cf1-a2a7-012c9b8e404f
+  subjects:
+  - entities:
+    - role: player
+      name: Carson Benge
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '700'
+  uuid: c900a54b-e2ed-4517-9fab-6af40aa1e7e1
+  subjects:
+  - entities:
+    - role: player
+      name: Justin Crawford
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 

--- a/data/baseball/2026-topps-series-2/checklists/base.yaml
+++ b/data/baseball/2026-topps-series-2/checklists/base.yaml
@@ -1,0 +1,3552 @@
+- number: '351'
+  uuid: aac89e2d-bf41-4c63-9eef-299c1c99c464
+  subjects:
+  - entities:
+    - role: player
+      name: Dillon Dingler
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '352'
+  uuid: dcd75209-27c6-4e43-adad-b6a1857cdef1
+  subjects:
+  - entities:
+    - role: player
+      name: Spencer Torkelson
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '353'
+  uuid: f08a5858-50a7-4c1d-9858-e04c440e7f50
+  subjects:
+  - entities:
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: '354'
+  uuid: 25ba6063-a13e-45bc-b3fc-1e7b2eb879b2
+  subjects:
+  - entities:
+    - role: player
+      name: Gabriel Arias
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '355'
+  uuid: 1ef6a25f-0e75-4cbf-a920-a1c347a7091a
+  subjects:
+  - entities:
+    - role: player
+      name: Nathan Eovaldi
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: '356'
+  uuid: 9841dd3d-93ea-45dd-b520-73b57e940a79
+  subjects:
+  - entities:
+    - role: player
+      name: Vladimir Guerrero Jr.
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '357'
+  uuid: 9f0184b5-ca89-42ee-abf7-424404d06473
+  subjects:
+  - entities:
+    - role: player
+      name: Gavin Lux
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: '358'
+  uuid: dff2dabc-181f-4ef6-88ce-2b53ba6241d2
+  subjects:
+  - entities:
+    - role: player
+      name: Adley Rutschman
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '359'
+  uuid: aabf0426-8a68-4915-a5a4-c6ea72a41430
+  subjects:
+  - entities:
+    - role: player
+      name: Adael Amador
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: '360'
+  uuid: ea551165-d347-4b87-8ab5-c8b7cb69a47a
+  subjects:
+  - entities:
+    - role: player
+      name: Ben Joyce
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: '361'
+  uuid: 75f1168e-3c58-405a-a092-e58db04738cc
+  subjects:
+  - entities:
+    - role: player
+      name: Davis Schneider
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '362'
+  uuid: c5c1df9c-f752-4548-8672-18dfc588e63e
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Severino
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: '363'
+  uuid: 6ee52ee6-638c-492c-b2e9-3f90a823822b
+  subjects:
+  - entities:
+    - role: player
+      name: J.T. Realmuto
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: '364'
+  uuid: 03143ca0-edf6-4025-88cc-47ff004793d5
+  subjects:
+  - entities:
+    - role: player
+      name: Luis García Jr.
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: '365'
+  uuid: e3839944-0fa2-46a0-b401-ec763ab3539d
+  subjects:
+  - entities:
+    - role: player
+      name: Spencer Steer
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '366'
+  uuid: 2558208f-254b-4d63-881e-8fd00fa8e725
+  subjects:
+  - entities:
+    - role: player
+      name: Isaac Paredes
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '367'
+  uuid: 55566eef-dca9-4ee0-9dd7-dd296b3eb654
+  subjects:
+  - entities:
+    - role: player
+      name: Robbie Ray
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '368'
+  uuid: a3758ceb-8101-48ac-bc67-4b6d7d735cff
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Tucker
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '369'
+  uuid: 5c7a715f-4ba6-43b4-ae38-d19a0c35e3d3
+  subjects:
+  - entities:
+    - role: player
+      name: Julio Rodríguez
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: '370'
+  uuid: 50788daa-0982-45df-a842-c2c82fda144d
+  subjects:
+  - entities:
+    - role: player
+      name: Brayan Rocchio
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '371'
+  uuid: 47e31e67-357a-4005-88eb-749427288955
+  subjects:
+  - entities:
+    - role: player
+      name: Brent Rooker
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: '372'
+  uuid: 10ebe3df-be36-48cf-b478-18722e4074db
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Sal Stewart
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '373'
+  uuid: cd5aafe6-00a3-43e6-87a5-42df09576c14
+  subjects:
+  - entities:
+    - role: player
+      name: Cam Smith
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '374'
+  uuid: 8b487db0-6480-4873-ad76-55442a1bd3c5
+  subjects:
+  - entities:
+    - role: player
+      name: Kevin Alcántara
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '375'
+  uuid: d49abec3-fa4a-47ee-9d82-75f42cc7cab9
+  subjects:
+  - entities:
+    - role: player
+      name: Denzel Clarke
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: '376'
+  uuid: 270861ab-7ecd-4c07-8221-e927f226c728
+  subjects:
+  - entities:
+    - role: player
+      name: Christian Encarnacion-Strand
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '377'
+  uuid: 70c842ae-c075-4a2a-a515-dd77c395b1f7
+  subjects:
+  - entities:
+    - role: player
+      name: Alec Bohm
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: '378'
+  uuid: fe53096e-c147-4ea9-ae4f-cd09b23db079
+  subjects:
+  - entities:
+    - role: player
+      name: Kyren Paris
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: '379'
+  uuid: 46fd8ad2-2247-48e6-b1b2-a46fc7c9fc66
+  subjects:
+  - entities:
+    - role: player
+      name: Blake Perkins
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: '380'
+  uuid: 3c05e33e-cfb4-4772-8c33-c39feafdf524
+  subjects:
+  - entities:
+    - role: player
+      name: Framber Valdez
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '381'
+  uuid: 575d8529-7e6e-4a7e-9e4f-a09d93788ca6
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Brian Van Belle
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: '382'
+  uuid: 463d48af-ba90-41f3-a50e-766bbcb69ac7
+  subjects:
+  - entities:
+    - role: player
+      name: Hunter Greene
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '383'
+  uuid: 6fdbec0c-55e7-41e4-9d22-bc0c048f3b83
+  subjects:
+  - entities:
+    - role: player
+      name: Wyatt Langford
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: '384'
+  uuid: e213403f-99e2-419f-b4d2-4c0fb0922628
+  subjects:
+  - entities:
+    - role: player
+      name: Taijuan Walker
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: '385'
+  uuid: 5bc6a142-630f-495f-a6a9-fc4d34421a2b
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Raquet
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: '386'
+  uuid: d34d2363-9b72-495c-bca6-081b9d5a6d99
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Curvelo
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: '387'
+  uuid: 323677d8-b30b-4bf3-b2ef-a039d58af534
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Drew Sommers
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '388'
+  uuid: f3548bd9-b575-42e0-a457-bcfce20ac67e
+  subjects:
+  - entities:
+    - role: player
+      name: Yandy Díaz
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: '389'
+  uuid: 497e3ec5-224f-4848-b497-63a221d78503
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Allen
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '390'
+  uuid: f2ea8c5e-5a39-4a3d-a2f6-b5c87762fc4d
+  subjects:
+  - entities:
+    - role: player
+      name: Jack Dreyer
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '391'
+  uuid: b8773506-6606-4974-8b51-bcccfd8b648f
+  subjects:
+  - entities:
+    - role: player
+      name: Justin Wrobleski
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '392'
+  uuid: 672f3c4d-b1d8-40f6-8ec2-a31042dcdcb9
+  subjects:
+  - entities:
+    - role: player
+      name: Xavier Edwards
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: '393'
+  uuid: 0e61d505-4ad5-48e9-b7bd-2c0612bff47d
+  subjects:
+  - entities:
+    - role: player
+      name: Jazz Chisholm Jr.
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '394'
+  uuid: 9626a2d7-c548-45e6-a554-3cd5a51919dc
+  subjects:
+  - entities:
+    - role: player
+      name: Eric Wagaman
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: '395'
+  uuid: e4fdd7b7-b417-4d67-93f9-99768e98b9cd
+  subjects:
+  - entities:
+    - role: player
+      name: Josh Naylor
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: '396'
+  uuid: cf4d17db-b6a1-4bed-b45f-20fd67fc6867
+  subjects:
+  - entities:
+    - role: player
+      name: Raisel Iglesias
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: '397'
+  uuid: 233977d8-2e6a-4b29-b594-731e8eedaa24
+  subjects:
+  - entities:
+    - role: player
+      name: Jordan Lawlar
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: '398'
+  uuid: 8d10a029-0baf-42fd-9de0-5cecd46e6556
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Hunter Barco
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '399'
+  uuid: 6594e331-67da-4b2f-bd83-fc5484d25e9f
+  subjects:
+  - entities:
+    - role: player
+      name: Javier Sanoja
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: '400'
+  uuid: bcc006c7-8e2d-4e50-98a8-3182a0f45265
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Alonso
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '401'
+  uuid: 76da529b-7f7c-43fd-a2e3-e65836652d24
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Eduarniel Núñez
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: '402'
+  uuid: 134f242b-a3bf-4793-841b-996ccb6728f1
+  subjects:
+  - entities:
+    - role: player
+      name: Anthony Santander
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '403'
+  uuid: 8a7a956b-4e7a-4b50-a3a9-3e85b1401302
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Johnson
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: '404'
+  uuid: 3decd395-e85b-4a76-b0e9-c156db2537c4
+  subjects:
+  - entities:
+    - role: player
+      name: Parker Meadows
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '405'
+  uuid: 203d02c5-0879-4dc4-82bf-b3e2326feb60
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: PJ Poulin
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: '406'
+  uuid: d35b1304-45f0-4b04-b4a0-7bda248c5f44
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Eldridge
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '407'
+  uuid: 206a2651-60a9-4053-bc8e-b27a15edde51
+  subjects:
+  - entities:
+    - role: player
+      name: Hurston Waldrep
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: '408'
+  uuid: 534952ba-8650-40c5-811e-df2c3ee229a0
+  subjects:
+  - entities:
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: '409'
+  uuid: 88fe83e1-2159-42fb-9461-5b34fd98e832
+  subjects:
+  - entities:
+    - role: player
+      name: Logan Henderson
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: '410'
+  uuid: 0f1fee16-e71b-4b88-a6a3-6ff70d814cae
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Hayden Harris
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: '411'
+  uuid: c0db38da-075c-4afb-9f16-2a3af3868cf0
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Tauchman
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '412'
+  uuid: 7150e322-8aa4-4082-b4e1-5d814626363f
+  subjects:
+  - entities:
+    - role: player
+      name: Robert Stephenson
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: '413'
+  uuid: 3425e3ab-6a39-4d67-981e-c44f46ba3fef
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Burrows
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '414'
+  uuid: 8b078675-da56-47ea-bf2e-3afa2f42e601
+  subjects:
+  - entities:
+    - role: player
+      name: Andy Pages
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '415'
+  uuid: c0b0ae25-4aa6-47b1-a4ca-7b1ae0231bca
+  subjects:
+  - entities:
+    - role: player
+      name: Justin Verlander
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '416'
+  uuid: 2861c142-b2f8-4afb-95d5-9504978f0dad
+  subjects:
+  - entities:
+    - role: player
+      name: Austin Martin
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: '417'
+  uuid: 4d2aeaa9-2ca4-4f89-97b4-6fd4488b2eb1
+  subjects:
+  - entities:
+    - role: player
+      name: Eduardo Rodriguez
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: '418'
+  uuid: 508f8015-a9c6-47e5-9852-6a909c0d72be
+  subjects:
+  - entities:
+    - role: player
+      name: Cade Cavalli
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: '419'
+  uuid: 8fa94b33-20c3-4b36-8083-99b51bd1eacb
+  subjects:
+  - entities:
+    - role: player
+      name: Jared Jones
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '420'
+  uuid: 78d06b5b-3110-41cc-a62a-0974b33f6765
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Arraez
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '421'
+  uuid: 9a768035-0cf5-444b-aef3-5d0d778f716e
+  subjects:
+  - entities:
+    - role: player
+      name: Taylor Walls
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: '422'
+  uuid: 92a6339e-9535-44ac-bf0e-ec1c2788ed2e
+  subjects:
+  - entities:
+    - role: player
+      name: Shane Bieber
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '423'
+  uuid: 324ca93c-9f7f-4389-999a-23cf15bffea0
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Robert Jr.
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '424'
+  uuid: b4ca7bfc-4097-4534-b3fd-fb3781642b80
+  subjects:
+  - entities:
+    - role: player
+      name: Zack Gelof
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: '425'
+  uuid: b385f136-ed74-46ea-a54e-9b20a6b80ef3
+  subjects:
+  - entities:
+    - role: player
+      name: Trent Grisham
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '426'
+  uuid: 4500432a-ee7f-4040-b205-35f3d47faeff
+  subjects:
+  - entities:
+    - role: player
+      name: Matt Wallner
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: '427'
+  uuid: 80c81d97-f0ea-4d4f-8e88-97de0cc0a125
+  subjects:
+  - entities:
+    - role: player
+      name: Chris Sale
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: '428'
+  uuid: 11d7423f-da08-4959-a4c8-67d333d9681a
+  subjects:
+  - entities:
+    - role: player
+      name: Kris Bryant
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: '429'
+  uuid: 3e4bcc9d-d867-4b33-9244-16225ffd3318
+  subjects:
+  - entities:
+    - role: player
+      name: Logan Allen
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '430'
+  uuid: 36958182-f7c6-4090-b55d-7a9765c4a7e0
+  subjects:
+  - entities:
+    - role: player
+      name: Tyler Locklear
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: '431'
+  uuid: 3bcb1ebd-0303-48cd-a30c-a68c0a400dc4
+  subjects:
+  - entities:
+    - role: player
+      name: Randy Arozarena
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: '432'
+  uuid: 04f8b22a-0e61-4065-8d4c-cb47d3be3fef
+  subjects:
+  - entities:
+    - role: player
+      name: Ryan Feltner
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: '433'
+  uuid: 99dc256a-0d04-4db7-8344-493aeb49a2ca
+  subjects:
+  - entities:
+    - role: player
+      name: Tyler O'Neill
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '434'
+  uuid: 136e31c6-5d2b-45c9-9cc6-fd5cda3f50de
+  subjects:
+  - entities:
+    - role: player
+      name: Graham Pauley
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: '435'
+  uuid: e397636c-ed90-4b66-af1f-2ae763b8dd88
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Denzer Guzman
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: '436'
+  uuid: ee7f0bcb-57f4-4e19-8d1d-da335e6b34a7
+  subjects:
+  - entities:
+    - role: player
+      name: Mitch Keller
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '437'
+  uuid: 48df517b-f908-4824-90cd-1cf3b261d496
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Castellanos
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: '438'
+  uuid: 2de992f2-b508-4aa0-b931-d2e0867d7bb9
+  subjects:
+  - entities:
+    - role: player
+      name: Jake Cronenworth
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: '439'
+  uuid: ec186172-9235-4629-8528-cedb0d0109e1
+  subjects:
+  - entities:
+    - role: player
+      name: Gleyber Torres
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '440'
+  uuid: 21dbbeff-5505-4b6a-9d80-7101a6b7c4f9
+  subjects:
+  - entities:
+    - role: player
+      name: Ranger Suárez
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '441'
+  uuid: a3bfe116-c29b-4dc1-be01-77da14f301e8
+  subjects:
+  - entities:
+    - role: player
+      name: Lars Nootbaar
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: '442'
+  uuid: 7d96293a-5d12-4574-9b43-cafd797b77e0
+  subjects:
+  - entities:
+    - role: player
+      name: Ryan O'Hearn
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '443'
+  uuid: 04011344-8fd3-4783-bec3-e36e70183745
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Kazuma Okamoto
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '444'
+  uuid: 3cbfa877-45ec-45a5-bdae-1ca008689d8e
+  subjects:
+  - entities:
+    - role: player
+      name: Tanner Gordon
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: '445'
+  uuid: 16ffbaff-44f3-4c47-853f-cc7143dac9d1
+  subjects:
+  - entities:
+    - role: player
+      name: Michael Massey
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: '446'
+  uuid: 4e92b38c-cb0e-4f1c-804e-1adc87dd91eb
+  subjects:
+  - entities:
+    - role: player
+      name: Eugenio Suárez
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '447'
+  uuid: 86ae4544-a631-4061-bf05-d4833d4a88c4
+  subjects:
+  - entities:
+    - role: player
+      name: Joe Boyle
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: '448'
+  uuid: f4d9d7a2-d173-4584-8bb4-3c21ef02f02a
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Chourio
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: '449'
+  uuid: 4d00af44-0de9-4854-a0d5-cc6e80abd81b
+  subjects:
+  - entities:
+    - role: player
+      name: Sandy Alcantara
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: '450'
+  uuid: 52653fda-41a0-441f-9c26-098df598f4f3
+  subjects:
+  - entities:
+    - role: player
+      name: Gerrit Cole
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '451'
+  uuid: aeef04b9-51fc-490e-ac07-22c85fd74505
+  subjects:
+  - entities:
+    - role: player
+      name: Jake Burger
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: '452'
+  uuid: de578e7b-b546-40a5-81e2-4b3ffd327e95
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Loftin
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: '453'
+  uuid: 53f7faa4-cb9a-4221-8c88-02d8a796e08d
+  subjects:
+  - entities:
+    - role: player
+      name: Chase Dollander
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: '454'
+  uuid: eb02f577-0cd2-43bb-a77e-51a65cac2a10
+  subjects:
+  - entities:
+    - role: player
+      name: Josh Hader
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '455'
+  uuid: 73fc94fe-4b58-4640-8b0c-0f486905a94b
+  subjects:
+  - entities:
+    - role: player
+      name: George Springer
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '456'
+  uuid: fefa494e-9b61-41e9-b2a4-37d9cbd5c3b6
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Justin Dean
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '457'
+  uuid: 52a9c215-a014-4cff-a352-c400b63aa8df
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Yorke
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '458'
+  uuid: cbbfed70-8b56-4d18-8804-0bd1262de50f
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Chase DeLauter
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '459'
+  uuid: 7939ce33-6fb3-4187-980c-064f6c08656b
+  subjects:
+  - entities:
+    - role: player
+      name: Ketel Marte
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: '460'
+  uuid: 16bb7a78-209e-4d78-8836-5e3901f70207
+  subjects:
+  - entities:
+    - role: player
+      name: Adrian Del Castillo
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: '461'
+  uuid: 1180459d-423b-4afc-a827-d650ddac049e
+  subjects:
+  - entities:
+    - role: player
+      name: Noah Cameron
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: '462'
+  uuid: 41bee18e-e4be-407c-b948-8579a80256d4
+  subjects:
+  - entities:
+    - role: player
+      name: Andrés Chaparro
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: '463'
+  uuid: fc1f0b9d-dd75-4ac9-bd7e-ef37271c64ac
+  subjects:
+  - entities:
+    - role: player
+      name: Aaron Nola
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: '464'
+  uuid: 773f9759-2194-4efb-b4fe-610131d8ee3b
+  subjects:
+  - entities:
+    - role: player
+      name: Triston Casas
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '465'
+  uuid: 66d97245-cc7d-4063-8c79-4bb51217168f
+  subjects:
+  - entities:
+    - role: player
+      name: Lourdes Gurriel Jr.
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: '466'
+  uuid: 7b0f410b-90fe-483d-9954-be3be5c1fe26
+  subjects:
+  - entities:
+    - role: player
+      name: Trevor McDonald
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '467'
+  uuid: 72464aca-9657-4764-b89f-ac11af6d41d3
+  subjects:
+  - entities:
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '468'
+  uuid: a2eb1b32-19ec-4448-8c58-f917ca40afd6
+  subjects:
+  - entities:
+    - role: player
+      name: Yordan Alvarez
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '469'
+  uuid: fbd3398c-3cd5-42c3-971c-acc19f17fc82
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Jonathan Pintaro
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '470'
+  uuid: 4aa7b98d-629d-42ad-a0cf-967156a31bfc
+  subjects:
+  - entities:
+    - role: player
+      name: Brandon Nimmo
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: '471'
+  uuid: 94ef8781-9267-49e4-9625-d369267b1f8f
+  subjects:
+  - entities:
+    - role: player
+      name: J.P. Crawford
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: '472'
+  uuid: 6783eb37-dc77-452b-b2bd-5ba2820028fd
+  subjects:
+  - entities:
+    - role: player
+      name: Christian Koss
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '473'
+  uuid: 688fa68f-b1bc-4c10-ad09-80bf040a1d1f
+  subjects:
+  - entities:
+    - role: player
+      name: Bo Bichette
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '474'
+  uuid: 6e57d6de-afc4-455a-83d3-83bbcf3f3742
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Joel Peguero
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '475'
+  uuid: 51726bf9-fa4b-4e17-819b-a659bf35b509
+  subjects:
+  - entities:
+    - role: player
+      name: Shane Baz
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '476'
+  uuid: 4d4448cb-ef88-4867-a925-03f2700ea1e9
+  subjects:
+  - entities:
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: '477'
+  uuid: dd9d2c8f-0888-4559-ba86-417a60b34a7a
+  subjects:
+  - entities:
+    - role: player
+      name: Jesús Sánchez
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '478'
+  uuid: a6f3b65f-17ec-4172-a85b-ce2cd310d2ff
+  subjects:
+  - entities:
+    - role: player
+      name: Tyler Wells
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '479'
+  uuid: 4edda851-5a20-4a0e-809a-0186cc7cad89
+  subjects:
+  - entities:
+    - role: player
+      name: Aaron Judge
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '480'
+  uuid: 9e6335bf-9715-4461-8bf2-0f9b8fc4d13e
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Torrens
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '481'
+  uuid: 1773fda9-a6b5-4c84-ba41-20f48c1a196b
+  subjects:
+  - entities:
+    - role: player
+      name: Tyrone Taylor
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '482'
+  uuid: f5799283-5ac9-454f-a8a6-69b55c6c0e91
+  subjects:
+  - entities:
+    - role: player
+      name: Alek Thomas
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: '483'
+  uuid: aa442da5-5606-4313-9df2-258624cfdd86
+  subjects:
+  - entities:
+    - role: player
+      name: Logan O'Hoppe
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: '484'
+  uuid: 98d53e89-aad4-49f3-8501-d0c9e2f79151
+  subjects:
+  - entities:
+    - role: player
+      name: Cole Ragans
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: '485'
+  uuid: e4786c14-995a-4548-8c79-a1fde10a432f
+  subjects:
+  - entities:
+    - role: player
+      name: Jake Mangum
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '486'
+  uuid: 7e89adfe-ad7d-44a2-9930-d776ca9176d3
+  subjects:
+  - entities:
+    - role: player
+      name: Justin Steele
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '487'
+  uuid: effe4d2d-fcba-4f5c-be06-388ae4ef1530
+  subjects:
+  - entities:
+    - role: player
+      name: Jake Irvin
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: '488'
+  uuid: 8edf8308-6cf0-4ad3-9e7b-daaae969706f
+  subjects:
+  - entities:
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '489'
+  uuid: 527862cc-8e7c-4087-80c6-eb6b80faeadd
+  subjects:
+  - entities:
+    - role: player
+      name: James Outman
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: '490'
+  uuid: 96b87482-51cf-49a9-9770-448fa471ebdb
+  subjects:
+  - entities:
+    - role: player
+      name: Oswaldo Cabrera
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '491'
+  uuid: 8b742de5-7ad0-44fb-aa44-adc3149f9696
+  subjects:
+  - entities:
+    - role: team
+      name: Minnesota Twins
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: '492'
+  uuid: e799663d-0aef-48b3-b032-155a1d2acee6
+  subjects:
+  - entities:
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '493'
+  uuid: e4c25155-f215-4b7a-a1d3-b3282cf8a4df
+  subjects:
+  - entities:
+    - role: player
+      name: George Kirby
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: '494'
+  uuid: dce0a637-7f79-4821-a258-e97298340ca9
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Jake Palisch
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: '495'
+  uuid: d6ea2625-fbec-4e89-90d6-4f8d262fe876
+  subjects:
+  - entities:
+    - role: player
+      name: Christian Walker
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '496'
+  uuid: 11f8ea6e-03fe-4aed-9d45-f53a9a1533bd
+  subjects:
+  - entities:
+    - role: team
+      name: San Francisco Giants
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '497'
+  uuid: 55707add-fd44-4c73-b40b-cd89078b9902
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Leahy
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: '498'
+  uuid: 9f18740d-e063-4372-9d13-aa7d0f84f45c
+  subjects:
+  - entities:
+    - role: player
+      name: Ryan Helsley
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '499'
+  uuid: 5df0c982-6fc6-4289-8453-42c452cde3aa
+  subjects:
+  - entities:
+    - role: player
+      name: James Wood
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: '500'
+  uuid: 8fc1a6ae-6448-4754-810d-1e781d65d2d2
+  subjects:
+  - entities:
+    - role: player
+      name: Shohei Ohtani
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '501'
+  uuid: c4328fa2-c893-4dea-99d1-6a8ccf887b09
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Connelly Early
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '502'
+  uuid: 64afe4a0-4100-498f-8ae7-0fb0a1a3255b
+  subjects:
+  - entities:
+    - role: player
+      name: Miguel Rojas
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '503'
+  uuid: c5afbc37-98d6-49ff-9c84-e79399bfa749
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Munetaka Murakami
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: '504'
+  uuid: 26e2543a-8c84-4c54-a424-30d14190625c
+  subjects:
+  - entities:
+    - role: player
+      name: Tanner Houck
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '505'
+  uuid: f38eca4f-3b77-45a2-a13f-93ccc2b71ef6
+  subjects:
+  - entities:
+    - role: player
+      name: Ernie Clement
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '506'
+  uuid: 0d85989c-f9fa-49ca-ba8b-678c93299dd4
+  subjects:
+  - entities:
+    - role: player
+      name: Edwin Díaz
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '507'
+  uuid: f5675553-d411-44ec-9110-be5c7478a750
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Castillo
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: '508'
+  uuid: 1891423a-dd54-4397-b807-518ec3d7de1b
+  subjects:
+  - entities:
+    - role: team
+      name: Colorado Rockies
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: '509'
+  uuid: 012f336e-31fa-43e8-9975-787884e9176a
+  subjects:
+  - entities:
+    - role: player
+      name: Pablo López
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: '510'
+  uuid: 01f49ffb-07af-4abe-bb54-6fcbf616ecbd
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Philip Abner
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: '511'
+  uuid: 7b5f298f-1594-4728-a49f-9bd47dcebbfd
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Jayvien Sandridge
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: '512'
+  uuid: 981cb4ec-1726-4a1a-ab51-f5764fc16900
+  subjects:
+  - entities:
+    - role: player
+      name: Simeon Woods Richardson
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: '513'
+  uuid: 6379502c-5b01-4262-9256-fb960974771f
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Tatsuya Imai
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '514'
+  uuid: fe2efaa3-9576-41d5-b0d5-3cc826eaadd1
+  subjects:
+  - entities:
+    - role: player
+      name: Zac Veen
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: '515'
+  uuid: 3805a261-40e3-42d7-a6b8-862515098b50
+  subjects:
+  - entities:
+    - role: player
+      name: Blaze Alexander
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '516'
+  uuid: dfb4b55e-4aac-401c-85af-c8f5ba0ddada
+  subjects:
+  - entities:
+    - role: player
+      name: Korey Lee
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: '517'
+  uuid: 25cfa136-703c-4735-8313-a18353ca6e04
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Trout
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: '518'
+  uuid: 297a8a82-0ed2-4aa1-899c-bd1c328205c5
+  subjects:
+  - entities:
+    - role: player
+      name: Brandon Woodruff
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: '519'
+  uuid: c0690881-71a9-4212-a577-f46504508be8
+  subjects:
+  - entities:
+    - role: player
+      name: Ramón Laureano
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: '520'
+  uuid: 826ffa37-129a-4681-b6c4-9ab320710094
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Andrew Alvarez
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: '521'
+  uuid: ab6966b6-aed5-4e38-9bb3-bf704bd448f7
+  subjects:
+  - entities:
+    - role: player
+      name: Henry Davis
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '522'
+  uuid: acdf400c-24d6-487f-a14c-e4e43f4cc77e
+  subjects:
+  - entities:
+    - role: team
+      name: Miami Marlins
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: '523'
+  uuid: b5d5e408-294f-4142-99fd-681eb2826984
+  subjects:
+  - entities:
+    - role: player
+      name: Heston Kjerstad
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '524'
+  uuid: 9dae6010-9ce6-4161-9dbe-f969144741cf
+  subjects:
+  - entities:
+    - role: player
+      name: Emmet Sheehan
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '525'
+  uuid: 6bedc0be-c196-422e-955f-0659a4368028
+  subjects:
+  - entities:
+    - role: team
+      name: Seattle Mariners
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: '526'
+  uuid: 75a8d0a0-9af4-4ac9-994a-88f5e27a49f1
+  subjects:
+  - entities:
+    - role: player
+      name: Masyn Winn
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: '527'
+  uuid: 7a3c1bc9-5a4d-4114-92ae-897b7b074ee6
+  subjects:
+  - entities:
+    - role: player
+      name: Maikel Garcia
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: '528'
+  uuid: bd6ccd1a-f6fe-4d8a-9a62-58a52b4299bb
+  subjects:
+  - entities:
+    - role: player
+      name: Jared Triolo
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '529'
+  uuid: 25d8ac84-1858-449b-b412-88c861d7500b
+  subjects:
+  - entities:
+    - role: player
+      name: Griffin Conine
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: '530'
+  uuid: 042d684c-c2f7-4048-8f9c-c44f9971608f
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Carter Jensen
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: '531'
+  uuid: d7cb7c4d-65c3-4e44-b509-4d02e66bb6dd
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Alejandro Carrillo
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '532'
+  uuid: 35f40aed-92c8-45e5-a27d-9fd50e34b046
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Jobe
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '533'
+  uuid: 404d7a50-5f94-4389-a489-ac503a7ef54c
+  subjects:
+  - entities:
+    - role: player
+      name: Jasson Domínguez
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '534'
+  uuid: 75672a06-8b37-45d6-81d2-c0e77f6f1147
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Brandon Sproat
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: '535'
+  uuid: 2a12d3f5-a044-45c1-8317-440ef44cdd69
+  subjects:
+  - entities:
+    - role: player
+      name: Javier Assad
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '536'
+  uuid: 110c5aa9-f050-45de-97fc-49c9fcaaeb33
+  subjects:
+  - entities:
+    - role: player
+      name: Trevor Story
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '537'
+  uuid: b08a5fac-5580-40ec-85ce-0941f5fc910d
+  subjects:
+  - entities:
+    - role: player
+      name: Jameson Taillon
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '538'
+  uuid: fbabdc6a-8f96-4caf-bc4b-500da26b8836
+  subjects:
+  - entities:
+    - role: player
+      name: Tommy Nance
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '539'
+  uuid: 7b12da1e-6c17-4448-8192-2a40d22ef3c6
+  subjects:
+  - entities:
+    - role: player
+      name: Lucas Erceg
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: '540'
+  uuid: 65f40ff5-53e1-4aef-a560-4a22dc8cf345
+  subjects:
+  - entities:
+    - role: player
+      name: Ryan Walker
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '541'
+  uuid: 1f7cfd97-45c6-4bd9-bdbd-81b6b11ef3da
+  subjects:
+  - entities:
+    - role: player
+      name: Jung Hoo Lee
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '542'
+  uuid: 7a5a79f0-e4b5-461f-8738-f7669505f23d
+  subjects:
+  - entities:
+    - role: player
+      name: Joey Ortiz
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: '543'
+  uuid: 31e444be-8de8-4f12-9b5c-51d5355e08e0
+  subjects:
+  - entities:
+    - role: player
+      name: Jonny DeLuca
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: '544'
+  uuid: 69f5014e-d06e-476b-98f3-b997e8c63b57
+  subjects:
+  - entities:
+    - role: player
+      name: Kutter Crawford
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '545'
+  uuid: 03fb7b54-1e4f-49d2-a833-d624f3c564a0
+  subjects:
+  - entities:
+    - role: player
+      name: Austin Hedges
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '546'
+  uuid: 1f0f3f0a-689c-4ae8-9ba4-ef3baaf95ca6
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Fortes
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: '547'
+  uuid: 42a624d3-eba4-44e5-8a64-a8cc290b16ca
+  subjects:
+  - entities:
+    - role: player
+      name: Dylan Cease
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '548'
+  uuid: 23d69791-5f5a-4e57-b3e0-55af3ec7bc5f
+  subjects:
+  - entities:
+    - role: player
+      name: Steven Kwan
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '549'
+  uuid: fef01c1a-7b0f-41b2-8541-313ff053f7b0
+  subjects:
+  - entities:
+    - role: player
+      name: Daylen Lile
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: '550'
+  uuid: 7be982c0-180f-4dbb-9279-648f7e2829b3
+  subjects:
+  - entities:
+    - role: player
+      name: Dansby Swanson
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '551'
+  uuid: 2b6a93e7-7a21-4028-92e1-180c96014e04
+  subjects:
+  - entities:
+    - role: player
+      name: Taylor Ward
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '552'
+  uuid: 9fce3aeb-55ee-4261-a102-fd1010d2eae9
+  subjects:
+  - entities:
+    - role: player
+      name: Merrill Kelly
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: '553'
+  uuid: fe5068b1-8477-4d60-aaca-6ac98fd2346e
+  subjects:
+  - entities:
+    - role: player
+      name: Elly De La Cruz
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '554'
+  uuid: 0ffcd043-ce4d-47c2-aa50-c157f483ff02
+  subjects:
+  - entities:
+    - role: player
+      name: Ezequiel Duran
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: '555'
+  uuid: 75f74051-e27f-4be1-9ac9-95f8bc7df76f
+  subjects:
+  - entities:
+    - role: player
+      name: Cade Povich
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '556'
+  uuid: 20e469b3-ebeb-4348-b11c-07191dd2a6ea
+  subjects:
+  - entities:
+    - role: player
+      name: Lance McCullers Jr.
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '557'
+  uuid: 550dbe78-cc72-4ae4-9b93-cb4a92e4faff
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Higashioka
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: '558'
+  uuid: 542a1cc0-3328-4acb-833a-57e4506a2e4a
+  subjects:
+  - entities:
+    - role: player
+      name: Michael King
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: '559'
+  uuid: c059f351-8bd1-42c2-a543-f6d56278b28d
+  subjects:
+  - entities:
+    - role: player
+      name: JP Sears
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: '560'
+  uuid: b93995a7-003a-4692-9e46-4d2bc2ed10c2
+  subjects:
+  - entities:
+    - role: player
+      name: Jarren Duran
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '561'
+  uuid: 259e9250-a2b7-4957-8227-48aa3088a896
+  subjects:
+  - entities:
+    - role: player
+      name: Matt Chapman
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '562'
+  uuid: e59c1372-3dbb-49e2-87a1-32dbf24c9da0
+  subjects:
+  - entities:
+    - role: player
+      name: Bryson Stott
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: '563'
+  uuid: 893256f3-a23d-472d-962e-379f075fa2e0
+  subjects:
+  - entities:
+    - role: player
+      name: Ji Hwan Bae
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '564'
+  uuid: 50df6205-7720-4c87-8df5-258fedc90d64
+  subjects:
+  - entities:
+    - role: player
+      name: Tyler Soderstrom
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: '565'
+  uuid: 92f7a8fa-248a-4f94-bc0c-851f38799ae6
+  subjects:
+  - entities:
+    - role: player
+      name: Jordan Walker
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: '566'
+  uuid: 95fa15f2-9231-43ad-9b4c-c729efb11b70
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Jack Little
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '567'
+  uuid: 68ceadf0-370b-4811-8dd1-b718ff224320
+  subjects:
+  - entities:
+    - role: player
+      name: Thomas Saggese
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: '568'
+  uuid: 972eb640-99c7-4187-ba8a-e1e3bc36db45
+  subjects:
+  - entities:
+    - role: player
+      name: Ozzie Albies
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: '569'
+  uuid: 6292fead-6790-440e-996b-33cbe82ac2c2
+  subjects:
+  - entities:
+    - role: player
+      name: Max Scherzer
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '570'
+  uuid: 96d25b4a-1c29-4655-ae6f-1e9601241b22
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Rolddy Muñoz
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: '571'
+  uuid: f6961fab-27fd-43d9-bfff-16f13cbf4108
+  subjects:
+  - entities:
+    - role: player
+      name: Kiké Hernández
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '572'
+  uuid: ecf9c4a4-7d24-4df3-af3e-e04d9accdeb3
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Alan Rangel
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: '573'
+  uuid: dd2a4e84-8f9d-4811-a7a3-f3a18dc5c5cf
+  subjects:
+  - entities:
+    - role: player
+      name: Alec Burleson
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: '574'
+  uuid: b9d6146b-baf4-4d87-8ade-a4ebcb0a0bb8
+  subjects:
+  - entities:
+    - role: player
+      name: Andrés Muñoz
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: '575'
+  uuid: f1cecb56-84a4-45f3-87b3-fc3a912fb883
+  subjects:
+  - entities:
+    - role: player
+      name: Jake Meyers
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '576'
+  uuid: 8813b10f-0e52-4888-8e85-577f389342bb
+  subjects:
+  - entities:
+    - role: player
+      name: Jarren Duran
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '577'
+  uuid: '0539caca-e52e-48c2-9540-c45ac3a13af5'
+  subjects:
+  - entities:
+    - role: player
+      name: Grayson Rodriguez
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: '578'
+  uuid: '029cb3e5-037d-4b96-a537-3e9053f3f478'
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Heriberto Hernández
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: '579'
+  uuid: 77d16baf-030d-46d2-a145-8f36f86883d4
+  subjects:
+  - entities:
+    - role: player
+      name: Brandon Lowe
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '580'
+  uuid: 4f2dedb1-b021-434c-bf52-f7a837f97253
+  subjects:
+  - entities:
+    - role: player
+      name: Marcell Ozuna
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '581'
+  uuid: ea994283-4937-47ca-a4d8-6206b6806c84
+  subjects:
+  - entities:
+    - role: player
+      name: Chase Meidroth
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: '582'
+  uuid: 7712859e-5ef5-4f7c-9bc6-41ab8db6724c
+  subjects:
+  - entities:
+    - role: player
+      name: Robert Hassell III
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: '583'
+  uuid: f3e11563-2c79-4d42-86c5-741fa072140f
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Josh Simpson
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: '584'
+  uuid: 0ae35af6-ed14-4b28-8b5e-0bb3012fa505
+  subjects:
+  - entities:
+    - role: player
+      name: Moisés Ballesteros
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '585'
+  uuid: a3bde543-d5ca-4776-8910-847e4443654c
+  subjects:
+  - entities:
+    - role: player
+      name: Ian Happ
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '586'
+  uuid: 8e3167d4-d4ad-46ce-b674-002b2e99bb6b
+  subjects:
+  - entities:
+    - role: player
+      name: Marcus Semien
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '587'
+  uuid: 9ade33dc-ed6b-4f9e-9c2e-42ea33ee810b
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan Gorman
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: '588'
+  uuid: d376e111-4b35-4da9-a016-cd17921ea25e
+  subjects:
+  - entities:
+    - role: player
+      name: Andrés Giménez
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '589'
+  uuid: 9cef4e65-289d-47e9-b0a8-cd652c35b094
+  subjects:
+  - entities:
+    - role: player
+      name: Braxton Ashcraft
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '590'
+  uuid: 3aa604f2-309b-478c-a15d-bcf1d90aad96
+  subjects:
+  - entities:
+    - role: player
+      name: Austin Wynns
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: '591'
+  uuid: 0d110611-8b06-4e51-b776-5a460f7b7783
+  subjects:
+  - entities:
+    - role: player
+      name: Jahmai Jones
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '592'
+  uuid: e75baf84-58ae-4344-b9ee-34b4184ddcca
+  subjects:
+  - entities:
+    - role: player
+      name: Joc Pederson
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: '593'
+  uuid: ff965ab3-f058-42bb-9ffc-c262d5ee7ad5
+  subjects:
+  - entities:
+    - role: player
+      name: Sal Frelick
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: '594'
+  uuid: d30fd0f1-a829-40a7-b99b-0474039d71fe
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Gil
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '595'
+  uuid: 63b5ee7d-7a7f-4fda-ba01-36242080961e
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: McCade Brown
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: '596'
+  uuid: 4e445656-069a-47eb-8c9d-8fadd9ee5f18
+  subjects:
+  - entities:
+    - role: player
+      name: Liam Hicks
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: '597'
+  uuid: bcfbe543-f3fd-4503-b2a4-874fd22370a1
+  subjects:
+  - entities:
+    - role: player
+      name: Paul Goldschmidt
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '598'
+  uuid: 4c4a366d-2858-4ecb-827e-ac0e04855437
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Jack Winkler
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '599'
+  uuid: 4a551c0d-fc4b-49c0-b35c-e4e8cf2411b2
+  subjects:
+  - entities:
+    - role: player
+      name: Cristian Javier
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '600'
+  uuid: 6182d8b7-4f43-4ff3-9a51-6445ce8c16ec
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '601'
+  uuid: 26484724-19d0-4386-8755-7304f0953b91
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Zach Cole
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '602'
+  uuid: b33484fe-3c09-4ef5-b5de-0331b4b25599
+  subjects:
+  - entities:
+    - role: player
+      name: Shane McClanahan
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: '603'
+  uuid: ffff3c48-3904-4c0f-8429-5a03c8d8c132
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: George Valera
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '604'
+  uuid: 8e412f9e-dac8-47a0-9254-a6db514f9254
+  subjects:
+  - entities:
+    - role: player
+      name: Jake Bauers
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: '605'
+  uuid: 5fce0147-e7df-4a88-9c4f-00a7c75021d1
+  subjects:
+  - entities:
+    - role: player
+      name: Xander Bogaerts
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: '606'
+  uuid: 8408c594-489e-4e0c-a318-6d8112a331e0
+  subjects:
+  - entities:
+    - role: player
+      name: Zebby Matthews
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: '607'
+  uuid: 667525ea-45e1-4883-8942-517c06aecaf9
+  subjects:
+  - entities:
+    - role: player
+      name: Cody Bellinger
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '608'
+  uuid: 31b4578f-5b48-41b8-8c6d-be26fa489a4d
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Cody Laweryson
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: '609'
+  uuid: d3758fae-cd26-4de7-9933-63065837f873
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Mitch Farris
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: '610'
+  uuid: dbf6d339-e0d8-4414-9e5d-f9acee580542
+  subjects:
+  - entities:
+    - role: player
+      name: Brooks Lee
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: '611'
+  uuid: c94ec232-f195-4443-9bd5-a318fd09f007
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Paul Gervase
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '612'
+  uuid: 5f183e45-0f41-436e-ba40-54a35fdf2d0b
+  subjects:
+  - entities:
+    - role: player
+      name: José Fermín
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: '613'
+  uuid: 6b8c421d-3736-49f9-bd8e-ced12db07cc7
+  subjects:
+  - entities:
+    - role: player
+      name: Jordan Westburg
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '614'
+  uuid: 93eb0e71-8426-432c-a5be-1573155e9b60
+  subjects:
+  - entities:
+    - role: player
+      name: Manny Machado
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: '615'
+  uuid: 51030538-7521-4406-b872-bfe7db495bf5
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Taylor Rashi
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: '616'
+  uuid: 20509841-dc7a-42a4-b23c-47f079b92932
+  subjects:
+  - entities:
+    - role: player
+      name: Hoby Milner
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '617'
+  uuid: dd278d3a-6449-4c1a-b1d1-3dab536b9191
+  subjects:
+  - entities:
+    - role: player
+      name: Caden Dana
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: '618'
+  uuid: 67e344c4-9e0b-41a3-b99a-cd31696d9af7
+  subjects:
+  - entities:
+    - role: player
+      name: Tanner Bibee
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '619'
+  uuid: b8dd61d5-e6d0-4724-8519-46e66948d70c
+  subjects:
+  - entities:
+    - role: player
+      name: Brooks Baldwin
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: '620'
+  uuid: b22f8b98-29c5-42a2-8972-54f7a7208566
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Trey Yesavage
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '621'
+  uuid: 4c87e1fe-0b22-4fb6-bc33-a4b155a8bcd4
+  subjects:
+  - entities:
+    - role: player
+      name: Matthew Liberatore
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: '622'
+  uuid: 7e64ba3c-5247-4bd1-a58c-dbbd9228de9b
+  subjects:
+  - entities:
+    - role: player
+      name: Cade Smith
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '623'
+  uuid: 3b1f6c4a-c7e2-430d-af14-f38850b84aff
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Rafael Flores
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '624'
+  uuid: dc72f880-84c6-40f2-8843-2679aeb03224
+  subjects:
+  - entities:
+    - role: player
+      name: Harrison Bader
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '625'
+  uuid: e3f5570d-ee43-45b8-b0ff-0a248ce17742
+  subjects:
+  - entities:
+    - role: player
+      name: Yoán Moncada
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: '626'
+  uuid: 54b66190-14c3-4171-9917-e24520d1824a
+  subjects:
+  - entities:
+    - role: player
+      name: Max Muncy
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: '627'
+  uuid: 30aa9657-c9b0-4c7e-88ed-173fb6bced82
+  subjects:
+  - entities:
+    - role: player
+      name: Gustavo Campero
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: '628'
+  uuid: f5c594c2-3fa5-4235-a257-ab1cb02a7c6b
+  subjects:
+  - entities:
+    - role: team
+      name: New York Yankees
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '629'
+  uuid: 5c8e317c-b2c3-4b24-9000-160cabc69b74
+  subjects:
+  - entities:
+    - role: player
+      name: Tyler Glasnow
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '630'
+  uuid: ef4a9afc-8521-49c4-b80c-c044d604ab81
+  subjects:
+  - entities:
+    - role: player
+      name: Corbin Burnes
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: '631'
+  uuid: bf5106e6-f225-4bb9-ba4d-51971e21290c
+  subjects:
+  - entities:
+    - role: player
+      name: Will Smith
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '632'
+  uuid: dd15c808-e20e-4dd8-9f41-962913513299
+  subjects:
+  - entities:
+    - role: player
+      name: Cade Horton
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '633'
+  uuid: 861bd13c-1cb1-425c-b4f9-baaab56a7b51
+  subjects:
+  - entities:
+    - role: player
+      name: Salvador Perez
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: '634'
+  uuid: 632537f1-0daf-4320-9bd7-ab80f25f3a8e
+  subjects:
+  - entities:
+    - role: player
+      name: Ryan Weathers
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '635'
+  uuid: 8b87188d-ea7b-4e81-9333-9f79a9f03df5
+  subjects:
+  - entities:
+    - role: player
+      name: Edgar Quero
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: '636'
+  uuid: 1281e6de-5f1b-4101-9927-5a3092a8a2cd
+  subjects:
+  - entities:
+    - role: player
+      name: Joe Musgrove
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: '637'
+  uuid: 06ced754-3909-4817-b2ae-221e28c1073c
+  subjects:
+  - entities:
+    - role: player
+      name: Johan Rojas
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: '638'
+  uuid: c2c684ff-459a-4fd4-8acd-26bab94a4c65
+  subjects:
+  - entities:
+    - role: player
+      name: Seth Lugo
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: '639'
+  uuid: 24070a00-debf-40ee-baae-61c5a98ba75a
+  subjects:
+  - entities:
+    - role: player
+      name: Reese Olson
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '640'
+  uuid: 70e46910-f330-4319-8c76-595b0fbb0957
+  subjects:
+  - entities:
+    - role: team
+      name: Atlanta Braves
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: '641'
+  uuid: c117e854-2e36-4b2d-b6f8-09394f1906ae
+  subjects:
+  - entities:
+    - role: player
+      name: Slade Cecconi
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '642'
+  uuid: 703ba766-eab9-442e-89f1-3a2483963b65
+  subjects:
+  - entities:
+    - role: player
+      name: Yoshinobu Yamamoto
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '643'
+  uuid: 2ddd7b5d-cfd9-4f31-afb5-5a8cf9cdc7ae
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Lodolo
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '644'
+  uuid: 17567852-2cf6-4134-a178-0392c8c7d228
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Christian Montes De Oca
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: '645'
+  uuid: 99014283-ec19-49d3-8e51-25d8ee579d88
+  subjects:
+  - entities:
+    - role: player
+      name: Nasim Nuñez
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: '646'
+  uuid: 991fe928-cfb6-402c-9a39-328153c71c96
+  subjects:
+  - entities:
+    - role: player
+      name: Mark Vientos
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '647'
+  uuid: 33b47dd8-9ac5-4160-bda0-ab4306e5edfc
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Bradish
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '648'
+  uuid: 326d2da7-c0a6-4d8b-b2b4-34620ef1d1f3
+  subjects:
+  - entities:
+    - role: player
+      name: Jonathan Cannon
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: '649'
+  uuid: 7928c73c-55a8-4c7e-98cd-27b7cb6988d3
+  subjects:
+  - entities:
+    - role: player
+      name: Leo Rivas
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: '650'
+  uuid: 2dc2ee55-554a-457a-992e-8e598c126be6
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Schwarber
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: '651'
+  uuid: b349f783-7d29-4e5d-bd95-db992e04b8a7
+  subjects:
+  - entities:
+    - role: player
+      name: Abner Uribe
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: '652'
+  uuid: '0208381d-eb5a-4382-842c-84c4e3d5e02b'
+  subjects:
+  - entities:
+    - role: player
+      name: Ryan Mountcastle
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '653'
+  uuid: c7f92d47-61fc-4d82-9551-f95646da71f0
+  subjects:
+  - entities:
+    - role: player
+      name: Andruw Monasterio
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '654'
+  uuid: 14e89954-95ea-4a74-b488-5cd4966fe297
+  subjects:
+  - entities:
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '655'
+  uuid: 6ca860fd-34b7-4ac3-a59c-964755860de0
+  subjects:
+  - entities:
+    - role: player
+      name: Jack Suwinski
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '656'
+  uuid: ff4a9bce-3bcc-4aae-b7a8-13df4aa4c172
+  subjects:
+  - entities:
+    - role: player
+      name: Aroldis Chapman
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '657'
+  uuid: cd4e5943-40a9-4d59-a2f8-60c656c778ad
+  subjects:
+  - entities:
+    - role: player
+      name: Freddy Peralta
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '658'
+  uuid: 26616809-8902-4455-bef9-a90200d7ede2
+  subjects:
+  - entities:
+    - role: player
+      name: Jack Flaherty
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '659'
+  uuid: 155f4ca6-e89b-4ad9-ada0-b803677f6c4d
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Harry Ford
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: '660'
+  uuid: b5df2407-6af4-44c6-bda7-7d0a9a88d88e
+  subjects:
+  - entities:
+    - role: player
+      name: Edouard Julien
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: '661'
+  uuid: 7b5226c5-efda-4891-8785-ab1a0e95b238
+  subjects:
+  - entities:
+    - role: team
+      name: Chicago White Sox
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: '662'
+  uuid: d669cfe2-22b9-467b-97ed-ff550b243212
+  subjects:
+  - entities:
+    - role: player
+      name: Jeff McNeil
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: '663'
+  uuid: 5a7c3bc2-9aa4-40df-883c-f20a2b3fd193
+  subjects:
+  - entities:
+    - role: player
+      name: Hyeseong Kim
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '664'
+  uuid: d84a5754-f109-4612-a167-f7cb20b26557
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Jayden Murray
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '665'
+  uuid: 831f43b0-15d2-4b74-ac12-eec9c603ada1
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Jose Corniell
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: '666'
+  uuid: eb390a01-a0c5-4fbc-a748-085bf5e85a74
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan Hoffman
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: '667'
+  uuid: f92ff11e-31e2-4f48-b8be-8369b14067dc
+  subjects:
+  - entities:
+    - role: player
+      name: Kodai Senga
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '668'
+  uuid: b5503087-0242-452b-8189-17a658d7e759
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Petey Halpin
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '669'
+  uuid: 6837ec21-1043-4a9f-990b-4a6f10282614
+  subjects:
+  - entities:
+    - role: player
+      name: Randy Vásquez
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: '670'
+  uuid: ca08d93f-0844-45dc-9745-3faa57993ea6
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Harrison
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: '671'
+  uuid: 81fc8400-0010-4284-a67f-db8aefff04a6
+  subjects:
+  - entities:
+    - role: player
+      name: JJ Bleday
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '672'
+  uuid: e016d7a7-47fd-4f11-b7bc-3235a1add030
+  subjects:
+  - entities:
+    - role: player
+      name: Yainer Diaz
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '673'
+  uuid: 0bec73b9-ab75-4797-83ec-a15ece5b8b37
+  subjects:
+  - entities:
+    - role: player
+      name: Reynaldo López
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: '674'
+  uuid: 3e2a917e-faa3-4b06-b3cf-2103db6c5544
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Andre Granillo
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: '675'
+  uuid: af822e9b-fad4-49e2-8f55-d338c63fccb3
+  subjects:
+  - entities:
+    - role: player
+      name: Steven Kwan
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '676'
+  uuid: 8d371613-9448-47d5-89eb-c81e1919d7cd
+  subjects:
+  - entities:
+    - role: player
+      name: Jorge Polanco
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '677'
+  uuid: 6cdb9f76-d22b-47c2-858f-0a7e484f9268
+  subjects:
+  - entities:
+    - role: player
+      name: Wilyer Abreu
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '678'
+  uuid: 40b10cb4-e79a-4c32-8405-0608d0cfb86b
+  subjects:
+  - entities:
+    - role: player
+      name: Darell Hernaiz
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: '679'
+  uuid: 33d79104-806e-46d7-aa91-894ee96e813e
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Cam Sanders
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '680'
+  uuid: 07c39109-312e-48a3-a1c0-394b2e8ca35b
+  subjects:
+  - entities:
+    - role: player
+      name: Carlos Correa
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '681'
+  uuid: 1a6f8a5a-5562-4e65-a238-0b1a41cb73af
+  subjects:
+  - entities:
+    - role: player
+      name: Nathan Lukes
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '682'
+  uuid: 0e55c937-1388-4448-9ed7-51a6c4a0199c
+  subjects:
+  - entities:
+    - role: player
+      name: Wenceel Pérez
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '683'
+  uuid: 1c5c0fd4-811b-4d8d-a37f-671129890ff0
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Dugan Darnell
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '684'
+  uuid: c020e16e-6caf-4b23-b256-bec31ed80302
+  subjects:
+  - entities:
+    - role: player
+      name: Quinn Priester
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: '685'
+  uuid: af9974bd-241f-49f9-9447-5601e2973e26
+  subjects:
+  - entities:
+    - role: player
+      name: Seiya Suzuki
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '686'
+  uuid: 3927ca49-6d11-41d9-8882-3dac100136c7
+  subjects:
+  - entities:
+    - role: player
+      name: Carson Kelly
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '687'
+  uuid: 8f4a5795-addf-49f3-a737-c437098a8252
+  subjects:
+  - entities:
+    - role: player
+      name: Noelvi Marte
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '688'
+  uuid: 5d6ce468-051f-4e91-8dd5-f56cbe312f49
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Blas Castaño
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: '689'
+  uuid: 640b95dd-40b7-45ef-9be8-0b4640372188
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Isbel
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: '690'
+  uuid: 5de87508-dcb2-43fd-ba71-be29284d903e
+  subjects:
+  - entities:
+    - role: player
+      name: Cedric Mullins
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: '691'
+  uuid: '08b9b126-166c-4b75-af04-de6a26723231'
+  subjects:
+  - entities:
+    - role: player
+      name: Joey Cantillo
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '692'
+  uuid: 2b717926-7db3-49dd-bfbb-abf43ee424e9
+  subjects:
+  - entities:
+    - role: player
+      name: Drake Baldwin
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: '693'
+  uuid: aa0cfc86-1d84-430a-8c85-a7a037650580
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Matos
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '694'
+  uuid: 890ccbf8-1aaa-4431-816d-ec6d77c15ad1
+  subjects:
+  - entities:
+    - role: player
+      name: Tyler Anderson
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: '695'
+  uuid: e61170df-c938-4651-938f-4278e58b02dd
+  subjects:
+  - entities:
+    - role: player
+      name: Connor Norby
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: '696'
+  uuid: 97e310c9-6918-4b88-8875-d6758071f3f9
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Andrew Hoffmann
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: '697'
+  uuid: ab58dd39-84bb-437c-88fd-8b5edc614f7c
+  subjects:
+  - entities:
+    - role: player
+      name: Bryan Reynolds
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '698'
+  uuid: ed67de31-ab92-4886-9cb3-fb1553ea1197
+  subjects:
+  - entities:
+    - role: player
+      name: Andre Pallante
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: '699'
+  uuid: bbad1128-7c46-45d1-bd56-e837453ee52a
+  subjects:
+  - entities:
+    - role: player
+      name: Jared Young
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '700'
+  uuid: 66b992aa-2541-4c23-9e80-ce23d602e4e4
+  subjects:
+  - entities:
+    - role: player
+      name: Freddie Freeman
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 

--- a/data/baseball/2026-topps-series-2/checklists/baseball-stars-autographs.yaml
+++ b/data/baseball/2026-topps-series-2/checklists/baseball-stars-autographs.yaml
@@ -1,0 +1,920 @@
+- number: BSA-BB
+  uuid: 9d93b44e-20c0-44f6-b752-0a786c86f19e
+  subjects:
+  - entities:
+    - role: player
+      name: Barry Bonds
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: BSA2-AB
+  uuid: 3a104ebd-c63a-428a-b563-8cc17f8c64c2
+  subjects:
+  - entities:
+    - role: player
+      name: Addison Barger
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: BSA2-ABO
+  uuid: d0bfd331-7e04-4632-90d2-1c8d7c5d8a71
+  subjects:
+  - entities:
+    - role: player
+      name: Alec Bohm
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: BSA2-ABR
+  uuid: 4a783f1b-231e-4afe-b5ba-a7bbfed1041f
+  subjects:
+  - entities:
+    - role: player
+      name: Alex Bregman
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: BSA2-AF
+  uuid: '02112459-d66e-4e8c-9f54-3b9b49918920'
+  subjects:
+  - entities:
+    - role: player
+      name: Alex Freeland
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: BSA2-AG
+  uuid: c1f42856-f2dd-4b1d-babb-52638ab4c0b8
+  subjects:
+  - entities:
+    - role: player
+      name: Andres Galarraga
+      ref: 
+    - role: team
+      name: Montréal Expos
+      ref: 
+- number: BSA2-AGA
+  uuid: 5d7b06ad-9648-4a5e-af12-c304a7f9ef68
+  subjects:
+  - entities:
+    - role: player
+      name: Adolis García
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: BSA2-AGI
+  uuid: ef4c338c-5f6f-4736-9945-56abb4c96039
+  subjects:
+  - entities:
+    - role: player
+      name: Andrés Giménez
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: BSA2-AGR
+  uuid: 3edea86b-cde8-4d34-91fe-d80dc88cc667
+  subjects:
+  - entities:
+    - role: player
+      name: Andre Granillo
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: BSA2-AP
+  uuid: 114679cb-cb9b-43ed-a03a-0498670d8d4e
+  subjects:
+  - entities:
+    - role: player
+      name: Andy Pages
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: BSA2-APA
+  uuid: a689e942-78d1-494e-9b22-3dd0172a81de
+  subjects:
+  - entities:
+    - role: player
+      name: Andrew Painter
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: BSA2-AS
+  uuid: 52a585ed-572c-4032-91a2-2e93a43e31a9
+  subjects:
+  - entities:
+    - role: player
+      name: Alfonso Soriano
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: BSA2-BG
+  uuid: 22682b34-dadc-429a-98cd-08c63de61765
+  subjects:
+  - entities:
+    - role: player
+      name: Brett Gardner
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: BSA2-BM
+  uuid: 2783d816-7cb5-4457-8554-317e4cbd86b3
+  subjects:
+  - entities:
+    - role: player
+      name: Brice Matthews
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: BSA2-BR
+  uuid: d0a70e56-d895-4242-a86d-f045405431f1
+  subjects:
+  - entities:
+    - role: player
+      name: Billy Ripken
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: BSA2-BS
+  uuid: 5a534782-40c7-45f2-ac31-9bf4fba9ddbf
+  subjects:
+  - entities:
+    - role: player
+      name: Blake Snell
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: BSA2-BSP
+  uuid: 9168be23-9c48-4392-850c-9068865edcf4
+  subjects:
+  - entities:
+    - role: player
+      name: Brandon Sproat
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: BSA2-BW
+  uuid: 2d4d7a88-e2db-4680-8253-04ae9b69f9f6
+  subjects:
+  - entities:
+    - role: player
+      name: Bryan Woo
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: BSA2-CC
+  uuid: d67f9c4a-6bf1-47a8-93a4-88b508246b7b
+  subjects:
+  - entities:
+    - role: player
+      name: Cade Cavalli
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: BSA2-CD
+  uuid: 19b115cf-14c9-468a-9b45-65339e11a1e2
+  subjects:
+  - entities:
+    - role: player
+      name: Chase DeLauter
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: BSA2-CJ
+  uuid: af3887f7-a249-4d17-ae4c-4c5f7416c4f8
+  subjects:
+  - entities:
+    - role: player
+      name: Carter Jensen
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: BSA2-CM
+  uuid: d2c50602-e472-4e5c-80f0-8ed286177fb5
+  subjects:
+  - entities:
+    - role: player
+      name: Christian Moore
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: BSA2-CP
+  uuid: 8dd93ef1-d94b-4db9-bccf-ea6081a3abb6
+  subjects:
+  - entities:
+    - role: player
+      name: César Prieto
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: BSA2-CS
+  uuid: bae86e0e-6d60-4b93-969c-8842f9ed1cec
+  subjects:
+  - entities:
+    - role: player
+      name: Chandler Simpson
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: BSA2-DB
+  uuid: 9dae6a8c-443f-4561-89e5-d11eab25d492
+  subjects:
+  - entities:
+    - role: player
+      name: Dusty Baker
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: BSA2-DBE
+  uuid: c3f007e0-760d-474d-8f4b-cf1c370a5209
+  subjects:
+  - entities:
+    - role: player
+      name: Dylan Beavers
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: BSA2-DBR
+  uuid: da8eca64-02a3-42c2-b49f-8547b6f0e9b1
+  subjects:
+  - entities:
+    - role: player
+      name: David Bednar
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: BSA2-DC
+  uuid: 3b7e2b56-d21a-4c87-9923-47eb5d58893f
+  subjects:
+  - entities:
+    - role: player
+      name: Denzel Clarke
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: BSA2-DE
+  uuid: a33db2eb-f776-4ab3-81a5-f2b2bea89d54
+  subjects:
+  - entities:
+    - role: player
+      name: Dennis Eckersley
+      ref: 
+    - role: team
+      name: Oakland Athletics
+      ref: 
+- number: BSA2-DGU
+  uuid: 56d10ebb-727b-49a7-b50c-2c779ea69ec4
+  subjects:
+  - entities:
+    - role: player
+      name: Denzer Guzman
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: BSA2-DM
+  uuid: 31003d6f-f85a-40f2-b5e3-e8a332cd3729
+  subjects:
+  - entities:
+    - role: player
+      name: Dale Murphy
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: BSA2-DV
+  uuid: 3c969549-00fb-4507-ac7d-34a92d632713
+  subjects:
+  - entities:
+    - role: player
+      name: Daulton Varsho
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: BSA2-EG
+  uuid: f9202e9e-4e05-4819-a296-f120ab887601
+  subjects:
+  - entities:
+    - role: player
+      name: Eric Gagne
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: BSA2-FL
+  uuid: 3f691dd5-8f75-47a2-960b-460ad9540b66
+  subjects:
+  - entities:
+    - role: player
+      name: Fred Lynn
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: BSA2-GC
+  uuid: d4ad2b95-669b-457a-8397-cb79fc779b5c
+  subjects:
+  - entities:
+    - role: player
+      name: Garrett Crochet
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: BSA2-GK
+  uuid: 9df1dc52-c5a6-4881-baec-73c180642482
+  subjects:
+  - entities:
+    - role: player
+      name: George Kirby
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: BSA2-GV
+  uuid: 365798e1-3822-41d2-9834-69f9da5f818d
+  subjects:
+  - entities:
+    - role: player
+      name: George Valera
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: BSA2-HB
+  uuid: a0cc9735-f8e9-4797-80bd-b22ec512e09a
+  subjects:
+  - entities:
+    - role: player
+      name: Harrison Bader
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: BSA2-HBA
+  uuid: 5a9dd1c7-e795-4d6e-b71a-0619a32e32f0
+  subjects:
+  - entities:
+    - role: player
+      name: Hunter Barco
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: BSA2-HF
+  uuid: d1378900-4ce5-48d8-9817-68e0d6e3465c
+  subjects:
+  - entities:
+    - role: player
+      name: Harry Ford
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: BSA2-HHA
+  uuid: ac1cb6a2-fba4-4eb2-b757-2e840a640ef2
+  subjects:
+  - entities:
+    - role: player
+      name: Hayden Harris
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: BSA2-JB
+  uuid: 744c10e5-e71c-4ec0-a04d-98a386cd231d
+  subjects:
+  - entities:
+    - role: player
+      name: Jay Buhner
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: BSA2-JC
+  uuid: 44f86d47-963c-41a3-95fb-9026706302d7
+  subjects:
+  - entities:
+    - role: player
+      name: Junior Caminero
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: BSA2-JD
+  uuid: 2ce428d2-8f87-48d5-a27a-5408e9b2a943
+  subjects:
+  - entities:
+    - role: player
+      name: Jhoan Duran
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: BSA2-JG
+  uuid: bed6823b-fa9e-480a-a001-83dad693e054
+  subjects:
+  - entities:
+    - role: player
+      name: Jhostynxon Garcia
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: BSA2-JJ
+  uuid: bb67252d-ea2c-499e-a58e-1a2efa22cb8f
+  subjects:
+  - entities:
+    - role: player
+      name: Jared Jones
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: BSA2-JJU
+  uuid: 88075dda-27f7-4d04-a35e-4ba4302ec65c
+  subjects:
+  - entities:
+    - role: player
+      name: Josh Jung
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: BSA2-JL
+  uuid: 11c8cf36-4ef7-4bc2-bf00-7794ab2c229e
+  subjects:
+  - entities:
+    - role: player
+      name: Jesús Luzardo
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: BSA2-JM
+  uuid: 2aaba86f-733c-482c-bc1d-5abad35f0db8
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Melton
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: BSA2-JO
+  uuid: dac308f5-fd50-4d1e-a0fb-864758c12c12
+  subjects:
+  - entities:
+    - role: player
+      name: James Outman
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: BSA2-JR
+  uuid: 42e783e2-1bec-4904-b3f3-7eb0db508c34
+  subjects:
+  - entities:
+    - role: player
+      name: Jim Rice
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: BSA2-JS
+  uuid: 3141ee35-631e-49f0-9642-949b2f045754
+  subjects:
+  - entities:
+    - role: player
+      name: Justin Steele
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: BSA2-JW
+  uuid: 8674f739-68dd-4d01-b120-08aa12ef49ee
+  subjects:
+  - entities:
+    - role: player
+      name: Jack Winkler
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: BSA2-LC
+  uuid: a14079a3-9d02-4ce6-b9a1-65d8e34e3def
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Castillo
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: BSA2-MB
+  uuid: 369f1cbd-96b4-4625-b61e-5bb99af1d179
+  subjects:
+  - entities:
+    - role: player
+      name: Michael Busch
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: BSA2-MC
+  uuid: 38c27431-60b4-4518-9c9e-e0ddb4463ac8
+  subjects:
+  - entities:
+    - role: player
+      name: Matt Chapman
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: BSA2-MF
+  uuid: 9f8ecc25-d711-482f-af33-7ace86342789
+  subjects:
+  - entities:
+    - role: player
+      name: Mitch Farris
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: BSA2-MG
+  uuid: 8365ba4a-0946-446c-b6b7-83ff9e306fc9
+  subjects:
+  - entities:
+    - role: player
+      name: Mark Grace
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: BSA2-MM
+  uuid: 941737b8-64db-464a-a565-f1a54e145327
+  subjects:
+  - entities:
+    - role: player
+      name: Max Muncy
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: BSA2-MMI
+  uuid: b6845e08-9aa0-4fc6-afe3-75e1547e42a4
+  subjects:
+  - entities:
+    - role: player
+      name: Munetaka Murakami
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: BSA2-MMU
+  uuid: 7b619a58-679b-4095-a763-5f37b9256a08
+  subjects:
+  - entities:
+    - role: player
+      name: Mark Mulder
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: BSA2-MV
+  uuid: d150d7df-bb57-4682-aba5-8fc2b8cb02dc
+  subjects:
+  - entities:
+    - role: player
+      name: Mark Vientos
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: BSA2-MY
+  uuid: eba16072-be0a-43ea-8918-e4a5c334141d
+  subjects:
+  - entities:
+    - role: player
+      name: Michael Young
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: BSA2-NL
+  uuid: edc2b886-5cf3-4de3-bab4-17cf23c4154f
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Lodolo
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: BSA2-NM
+  uuid: 2aa97a1b-034c-4465-948f-d04577acf7c9
+  subjects:
+  - entities:
+    - role: player
+      name: Noelvi Marte
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: BSA2-NMC
+  uuid: 43d56042-9c28-47e5-b58c-4916d9315b1a
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan McLean
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: BSA2-NS
+  uuid: 5585b8c8-80ab-48dd-b7fb-845425c77c0d
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan Schanuel
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: BSA2-OC
+  uuid: 355ec9e1-159d-459b-966f-c9f108e65ddf
+  subjects:
+  - entities:
+    - role: player
+      name: Owen Caissie
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: BSA2-PB
+  uuid: 8a12f032-e249-4348-abe6-5afafac29bf1
+  subjects:
+  - entities:
+    - role: player
+      name: Patrick Bailey
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: BSA2-PH
+  uuid: 81af10f0-a98d-4ade-833f-6fe08d12d1ee
+  subjects:
+  - entities:
+    - role: player
+      name: Petey Halpin
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: BSA2-PK
+  uuid: 955ffdb0-41cb-44bb-be7b-2fbb5424b0cd
+  subjects:
+  - entities:
+    - role: player
+      name: Paul Konerko
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: BSA2-PM
+  uuid: 33eadcff-9c6b-4c1f-92ac-45685e2a1f5c
+  subjects:
+  - entities:
+    - role: player
+      name: Paul Molitor
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: BSA2-PME
+  uuid: 3004c6a2-ebe2-4e84-9f58-53c4037c0e18
+  subjects:
+  - entities:
+    - role: player
+      name: Parker Messick
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: BSA2-PO
+  uuid: 526ef89b-5de0-43b2-abd1-c2e05783bb90
+  subjects:
+  - entities:
+    - role: player
+      name: Paul O'Neill
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: BSA2-PT
+  uuid: dce4c23d-3718-4cca-af40-7b1c2b235326
+  subjects:
+  - entities:
+    - role: player
+      name: Payton Tolle
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: BSA2-QP
+  uuid: ba32dbe9-2192-45b3-9e9d-f24fa44d534b
+  subjects:
+  - entities:
+    - role: player
+      name: Quinn Priester
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: BSA2-RF
+  uuid: 19a4645e-adb7-4d53-a660-97184d80197a
+  subjects:
+  - entities:
+    - role: player
+      name: Richard Fitts
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: BSA2-RFL
+  uuid: 1c634e96-2d05-4b08-8344-e5871b2dedd1
+  subjects:
+  - entities:
+    - role: player
+      name: Rafael Flores
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: BSA2-RM
+  uuid: 3608f2b5-5ca5-4b06-937d-2f2925d45d87
+  subjects:
+  - entities:
+    - role: player
+      name: Rolddy Muñoz
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: BSA2-SB
+  uuid: bea212d3-3c95-4fc4-8545-fab1bca90187
+  subjects:
+  - entities:
+    - role: player
+      name: Shane Bieber
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: BSA2-SC
+  uuid: 95e66ddf-9f24-4e56-8698-3e99e8645928
+  subjects:
+  - entities:
+    - role: player
+      name: Steve Carlton
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: BSA2-SG
+  uuid: 490b115d-ef56-40db-8227-57b81d2c6a16
+  subjects:
+  - entities:
+    - role: player
+      name: Sonny Gray
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: BSA2-SL
+  uuid: 48d0905f-54d7-404d-a480-152887f69ddb
+  subjects:
+  - entities:
+    - role: player
+      name: Shea Langeliers
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: BSA2-SR
+  uuid: 28873017-6cd7-4d6c-b475-78f214026f6a
+  subjects:
+  - entities:
+    - role: player
+      name: Scott Rolen
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: BSA2-SS
+  uuid: a77dbf3e-0eb9-4303-9e5f-73190971920e
+  subjects:
+  - entities:
+    - role: player
+      name: Sal Stewart
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: BSA2-TB
+  uuid: 2f9f8960-8176-4ca8-8a18-c9d402a43e2e
+  subjects:
+  - entities:
+    - role: player
+      name: Tanner Bibee
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: BSA2-TH
+  uuid: '029b6f9e-e9d5-4387-8808-d18bb903b186'
+  subjects:
+  - entities:
+    - role: player
+      name: Tim Hudson
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: BSA2-TI
+  uuid: ea2e6581-1a54-4395-a580-40d73aab1a7a
+  subjects:
+  - entities:
+    - role: player
+      name: Tatsuya Imai
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: BSA2-WB
+  uuid: 57790e45-ebbe-4aa8-87f3-733f7fb2afce
+  subjects:
+  - entities:
+    - role: player
+      name: Warming Bernabel
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: BSA2-WL
+  uuid: 2ada3a96-1cc5-4296-9c6a-e46b10480bf3
+  subjects:
+  - entities:
+    - role: player
+      name: Wyatt Langford
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: BSA2-YF
+  uuid: abf032b4-7bc7-4387-9d90-016bf9d60306
+  subjects:
+  - entities:
+    - role: player
+      name: Yanquiel Fernández
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: BSA2-ZC
+  uuid: 3e83f3a6-4a56-4111-b410-d09bd3e7d997
+  subjects:
+  - entities:
+    - role: player
+      name: Zach Cole
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 

--- a/data/baseball/2026-topps-series-2/checklists/bulk-order.yaml
+++ b/data/baseball/2026-topps-series-2/checklists/bulk-order.yaml
@@ -1,0 +1,100 @@
+- number: BO-1
+  uuid: 36acc35c-2209-4b91-aa21-f9bacabb42b3
+  subjects:
+  - entities:
+    - role: player
+      name: Seiya Suzuki
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: BO-2
+  uuid: 1459ab7c-e9e3-4d80-ac01-62d768b7aff6
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: BO-3
+  uuid: c3baaa0a-bbc5-4ab8-846a-fe538d5a4ea7
+  subjects:
+  - entities:
+    - role: player
+      name: George Springer
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: BO-4
+  uuid: 621f0f48-6b16-46e4-80e2-057581b59cd9
+  subjects:
+  - entities:
+    - role: player
+      name: Byron Buxton
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: BO-5
+  uuid: f325f45b-9b83-4856-b2d1-0857dc5391e6
+  subjects:
+  - entities:
+    - role: player
+      name: José Ramírez
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: BO-6
+  uuid: 867b03fe-290a-4516-a9e5-aad19ee1a00f
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Kurtz
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: BO-7
+  uuid: 81649f19-6cc1-4873-87f8-8d36b9ec55b8
+  subjects:
+  - entities:
+    - role: player
+      name: Giancarlo Stanton
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: BO-8
+  uuid: afc4c913-7ec9-4ede-af84-c9ea593a116d
+  subjects:
+  - entities:
+    - role: player
+      name: Mookie Betts
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: BO-9
+  uuid: 31532d34-dce0-4bc7-9b94-57a6a1c43ee7
+  subjects:
+  - entities:
+    - role: player
+      name: James Wood
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: BO-10
+  uuid: 97bdff94-8da1-491d-91ad-4d8e11701505
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Trout
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 

--- a/data/baseball/2026-topps-series-2/checklists/city-connect-swatch-collection.yaml
+++ b/data/baseball/2026-topps-series-2/checklists/city-connect-swatch-collection.yaml
@@ -1,0 +1,500 @@
+- number: CC2-ABO
+  uuid: c43485f2-d5f6-44a9-8481-dc2d2e11dadb
+  subjects:
+  - entities:
+    - role: player
+      name: Alec Bohm
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: CC2-AR
+  uuid: c51c7276-36cc-4203-beab-69b083d8b4dc
+  subjects:
+  - entities:
+    - role: player
+      name: Adley Rutschman
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: CC2-BB
+  uuid: 4e9e51e0-8b99-4e66-bf49-e3846bad9199
+  subjects:
+  - entities:
+    - role: player
+      name: Byron Buxton
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: CC2-BS
+  uuid: afe4c011-1115-4e7f-90f3-83176292acd1
+  subjects:
+  - entities:
+    - role: player
+      name: Bryson Stott
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: CC2-BW
+  uuid: e5ef613f-580b-46e1-af04-8c02080c1850
+  subjects:
+  - entities:
+    - role: player
+      name: Bryan Woo
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: CC2-CA
+  uuid: 212f4452-8a84-450b-8f63-5049d5f4e26c
+  subjects:
+  - entities:
+    - role: player
+      name: CJ Abrams
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: CC2-CC
+  uuid: 3f6c44a8-2156-44ef-ac62-ad2ed9e73127
+  subjects:
+  - entities:
+    - role: player
+      name: Colton Cowser
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: CC2-CR
+  uuid: 39eac767-10ae-4fe7-9397-610e3df95329
+  subjects:
+  - entities:
+    - role: player
+      name: Ceddanne Rafaela
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: CC2-CS
+  uuid: 855e3ad0-78ab-4d83-930e-8c2d4c75a268
+  subjects:
+  - entities:
+    - role: player
+      name: Cristopher Sánchez
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: CC2-CSM
+  uuid: 82baef9d-9869-4c9e-bec0-2a89f024e0f0
+  subjects:
+  - entities:
+    - role: player
+      name: Cam Smith
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: CC2-DG
+  uuid: ea3d8153-5384-47bd-95b6-3fcc9ede4e8e
+  subjects:
+  - entities:
+    - role: player
+      name: Drew Gilbert
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: CC2-ET
+  uuid: c9be5529-649b-432b-b1a6-18bc3971bff9
+  subjects:
+  - entities:
+    - role: player
+      name: Ezequiel Tovar
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: CC2-FF
+  uuid: 6afefcb4-ca73-481e-87dd-0848a7b3c18c
+  subjects:
+  - entities:
+    - role: player
+      name: Freddie Freeman
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: CC2-FL
+  uuid: 49ec08bb-fdc0-4d24-861d-f04ee13e99ba
+  subjects:
+  - entities:
+    - role: player
+      name: Francisco Lindor
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: CC2-FT
+  uuid: f9912a27-d905-4ddf-84de-7bf79f310963
+  subjects:
+  - entities:
+    - role: player
+      name: Fernando Tatis Jr.
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: CC2-JC
+  uuid: ead7b645-527c-4844-a160-44b850fd5313
+  subjects:
+  - entities:
+    - role: player
+      name: Junior Caminero
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: CC2-JD
+  uuid: a2aab4df-d4e6-4cf3-822d-154dbde2a89a
+  subjects:
+  - entities:
+    - role: player
+      name: Jarren Duran
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: CC2-JH
+  uuid: 7f79214a-1475-46f3-81eb-afb2a05912a1
+  subjects:
+  - entities:
+    - role: player
+      name: Jung Hoo Lee
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: CC2-JHO
+  uuid: 92d6f8cd-390c-4e2d-9d25-8770a2c34ef7
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Holliday
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: CC2-JJ
+  uuid: 317d0d49-2533-4c9b-b7c1-f399dc3264eb
+  subjects:
+  - entities:
+    - role: player
+      name: Josh Jung
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: CC2-JL
+  uuid: 2bf767f4-d834-46b4-ad84-514ca6431e78
+  subjects:
+  - entities:
+    - role: player
+      name: Jordan Lawlar
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: CC2-JP
+  uuid: edd3e87d-5184-4c53-b92d-4b4e72c2168c
+  subjects:
+  - entities:
+    - role: player
+      name: Jeremy Peña
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: CC2-JR
+  uuid: b51eeef7-cdc4-4b17-ae63-4d1c1ed4b4bd
+  subjects:
+  - entities:
+    - role: player
+      name: J.T. Realmuto
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: CC2-JRA
+  uuid: bea611e5-7cff-47e5-b768-318b335c849a
+  subjects:
+  - entities:
+    - role: player
+      name: José Ramírez
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: CC2-JS
+  uuid: 678ef447-461c-42ad-85d2-73480e88c8bd
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: CC2-JW
+  uuid: 35e48036-7b12-44cd-9fd6-8a62e831ec8b
+  subjects:
+  - entities:
+    - role: player
+      name: James Wood
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: CC2-JWE
+  uuid: 7f4d039a-743f-4600-b36a-18134b2a0cd7
+  subjects:
+  - entities:
+    - role: player
+      name: Jordan Westburg
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: CC2-KK
+  uuid: 19d3b5b5-d37f-4548-b189-fd6957a22a1d
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Karros
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: CC2-LN
+  uuid: 0aaf552f-06cc-4778-a630-7e51a560e87c
+  subjects:
+  - entities:
+    - role: player
+      name: Lars Nootbaar
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: CC2-LO
+  uuid: 82d91ef1-0886-4d09-bc8b-0cf1ddab1e9d
+  subjects:
+  - entities:
+    - role: player
+      name: Logan O'Hoppe
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: CC2-MC
+  uuid: c270e7a3-e1e8-4b26-b399-1759a4e0af60
+  subjects:
+  - entities:
+    - role: player
+      name: Matt Chapman
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: CC2-MMA
+  uuid: e2aceba8-6a12-4ac9-a8b6-dd05bd035619
+  subjects:
+  - entities:
+    - role: player
+      name: Manny Machado
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: CC2-MT
+  uuid: 105229cf-2914-49f8-8529-02c217d05f83
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Trout
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: CC2-MV
+  uuid: a77cbbe2-e2d3-46f7-8462-ad5c432dccfc
+  subjects:
+  - entities:
+    - role: player
+      name: Mark Vientos
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: CC2-MW
+  uuid: 92bae80b-fc7b-4785-830f-b3b3aba546fb
+  subjects:
+  - entities:
+    - role: player
+      name: Masyn Winn
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: CC2-NA
+  uuid: e7021db4-14a9-4cee-8997-4238cd00a447
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan Arenado
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: CC2-NS
+  uuid: 857011d7-a9ae-42f5-abe7-7215c7b5adc5
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan Schanuel
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: CC2-PA
+  uuid: '087cb373-65d1-4901-a418-801566aeafdc'
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Alonso
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: CC2-RA
+  uuid: 98fe8bb5-e29d-4293-9398-ae50d822aa86
+  subjects:
+  - entities:
+    - role: player
+      name: Ronald Acuña Jr.
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: CC2-RM
+  uuid: 6f33e88c-137e-4d10-8a55-f96776c313ff
+  subjects:
+  - entities:
+    - role: player
+      name: Ryan Mountcastle
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: CC2-SF
+  uuid: 19467972-5804-4db6-9cd3-585b6f1ca1b7
+  subjects:
+  - entities:
+    - role: player
+      name: Sal Frelick
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: CC2-SP
+  uuid: e0e89525-a0dc-46d8-b9f4-aba7942f8bbf
+  subjects:
+  - entities:
+    - role: player
+      name: Salvador Perez
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: CC2-TG
+  uuid: 91b3d0e5-b953-4d18-ad3b-cb6e46d984fb
+  subjects:
+  - entities:
+    - role: player
+      name: Tyler Glasnow
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: CC2-TH
+  uuid: f5386cf9-ff75-445a-845d-5e550625eaff
+  subjects:
+  - entities:
+    - role: player
+      name: Teoscar Hernández
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: CC2-TS
+  uuid: '05971c3f-5e5f-403c-b0c1-1b905719577f'
+  subjects:
+  - entities:
+    - role: player
+      name: Tarik Skubal
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: CC2-TT
+  uuid: 6048ad6b-9b07-4e75-9635-503b11cd5eaf
+  subjects:
+  - entities:
+    - role: player
+      name: Trea Turner
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: CC2-VG
+  uuid: a5112430-159f-4cd6-9521-687367d4abd5
+  subjects:
+  - entities:
+    - role: player
+      name: Vladimir Guerrero Jr.
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: CC2-WA
+  uuid: b80a572e-00c8-4b71-bb04-753fc8d73fcb
+  subjects:
+  - entities:
+    - role: player
+      name: Willy Adames
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: CC2-WS
+  uuid: 7db014f9-0de4-4c75-b6f6-323e9ddafe04
+  subjects:
+  - entities:
+    - role: player
+      name: Will Smith
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: CC2-ZN
+  uuid: d7b48250-f8cf-4939-8de5-998e394d5ac4
+  subjects:
+  - entities:
+    - role: player
+      name: Zach Neto
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 

--- a/data/baseball/2026-topps-series-2/checklists/city-connect-swatches-autographs.yaml
+++ b/data/baseball/2026-topps-series-2/checklists/city-connect-swatches-autographs.yaml
@@ -1,0 +1,560 @@
+- number: CC2-ABO
+  uuid: b1fd567c-7dae-4506-a398-4d7fc85c399c
+  subjects:
+  - entities:
+    - role: player
+      name: Alec Bohm
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: CC2-AR
+  uuid: 3de58f53-ca17-4f9b-bf0a-f00af0975702
+  subjects:
+  - entities:
+    - role: player
+      name: Adley Rutschman
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: CC2-BB
+  uuid: 6a823f77-e585-45e5-ba61-323fbc368591
+  subjects:
+  - entities:
+    - role: player
+      name: Byron Buxton
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: CC2-BS
+  uuid: 197801ea-07cd-44c5-91c8-fc21f3ec7b15
+  subjects:
+  - entities:
+    - role: player
+      name: Bryson Stott
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: CC2-BW
+  uuid: ff4cb922-6c27-474c-a868-a9d8b26acdfd
+  subjects:
+  - entities:
+    - role: player
+      name: Bryan Woo
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: CC2-CA
+  uuid: 5ff19660-f97e-425f-ba81-1350a2ff909e
+  subjects:
+  - entities:
+    - role: player
+      name: CJ Abrams
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: CC2-CC
+  uuid: f714f3b5-28fa-4309-a7da-ac2f765af35f
+  subjects:
+  - entities:
+    - role: player
+      name: Colton Cowser
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: CC2-CR
+  uuid: e9f9ac72-dd83-4fe7-9e69-e64439d3dc76
+  subjects:
+  - entities:
+    - role: player
+      name: Ceddanne Rafaela
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: CC2-DG
+  uuid: 6c22d798-68fc-4807-946c-3382c88b9d5d
+  subjects:
+  - entities:
+    - role: player
+      name: Drew Gilbert
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: CC2-ET
+  uuid: 957328b8-d0fc-4ab1-a97b-9cbd2562019a
+  subjects:
+  - entities:
+    - role: player
+      name: Ezequiel Tovar
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: CC2-FF
+  uuid: 05e5a857-d991-4ca4-b1b6-494afdd46c68
+  subjects:
+  - entities:
+    - role: player
+      name: Freddie Freeman
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: CC2-FL
+  uuid: 3d92714e-3283-47c6-8054-37383bbfe0de
+  subjects:
+  - entities:
+    - role: player
+      name: Francisco Lindor
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: CC2-FT
+  uuid: f2436aa2-b3b8-4741-8709-404383b9973b
+  subjects:
+  - entities:
+    - role: player
+      name: Fernando Tatis Jr.
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: CC2-JC
+  uuid: b451f9f5-66a9-40ac-8fbd-9319faa5cc3f
+  subjects:
+  - entities:
+    - role: player
+      name: Junior Caminero
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: CC2-JD
+  uuid: fd0e88b5-12b9-4413-938e-8ff293dc1f5a
+  subjects:
+  - entities:
+    - role: player
+      name: Jarren Duran
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: CC2-JH
+  uuid: c014c29c-d94e-46c5-8b21-7fc98704d53f
+  subjects:
+  - entities:
+    - role: player
+      name: Jung Hoo Lee
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: CC2-JHO
+  uuid: 39ab3867-59cb-4d87-b299-48cc448fdbd2
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Holliday
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: CC2-JJ
+  uuid: a06fd82f-d016-4869-a127-ba6ae1e8f5bd
+  subjects:
+  - entities:
+    - role: player
+      name: Josh Jung
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: CC2-JL
+  uuid: ec2b0d83-0b53-4abb-9d1d-88adf7f62fd7
+  subjects:
+  - entities:
+    - role: player
+      name: Jordan Lawlar
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: CC2-JR
+  uuid: b6a8e99c-f522-4aa8-9ba4-f4abd977f4a6
+  subjects:
+  - entities:
+    - role: player
+      name: J.T. Realmuto
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: CC2-JRA
+  uuid: d7501df1-8420-41bf-9245-586f33359832
+  subjects:
+  - entities:
+    - role: player
+      name: José Ramírez
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: CC2-JS
+  uuid: abd4395b-65e7-465c-92e8-8408f06613f8
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: CC2-JW
+  uuid: f70a044d-aebd-410d-8ccf-3282b87141ed
+  subjects:
+  - entities:
+    - role: player
+      name: James Wood
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: CC2-JWE
+  uuid: ee0e1588-6198-4363-8a8b-e396220fb8d9
+  subjects:
+  - entities:
+    - role: player
+      name: Jordan Westburg
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: CC2-KK
+  uuid: f581c4cf-ed5c-4c72-939d-1a2f107f5b79
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Karros
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: CC2-LO
+  uuid: 50e75831-1ce5-4392-9dab-b0a7422dc868
+  subjects:
+  - entities:
+    - role: player
+      name: Logan O'Hoppe
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: CC2-MC
+  uuid: 65805804-ea1e-44ed-9c65-013cc647cf38
+  subjects:
+  - entities:
+    - role: player
+      name: Matt Chapman
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: CC2-MMA
+  uuid: bc932265-43eb-4334-8ba1-74d0441ae96b
+  subjects:
+  - entities:
+    - role: player
+      name: Manny Machado
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: CC2-MT
+  uuid: bc13a90e-0064-444d-aa96-c56ccbb1f409
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Trout
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: CC2-MV
+  uuid: fadddd80-b181-4777-a5bb-4328e7c0c6ea
+  subjects:
+  - entities:
+    - role: player
+      name: Mark Vientos
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: CC2-MW
+  uuid: 94dd4f96-2b56-4460-9fc1-092d9f2a69db
+  subjects:
+  - entities:
+    - role: player
+      name: Masyn Winn
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: CC2-NA
+  uuid: 174d85f5-5378-490b-bddc-21d2a1fa612f
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan Arenado
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: CC2-NS
+  uuid: e1929354-0f77-4622-aa20-91224604ca3d
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan Schanuel
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: CC2-PA
+  uuid: 2ebb378b-0dcd-405f-bd8d-b5b415fc1e55
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Alonso
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: CC2-RA
+  uuid: e18017f0-3ca2-4a0b-a9cf-7b67dbcfdf44
+  subjects:
+  - entities:
+    - role: player
+      name: Ronald Acuña Jr.
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: CC2-RM
+  uuid: 7ca613f4-e558-4db7-aebe-1179b719add7
+  subjects:
+  - entities:
+    - role: player
+      name: Ryan Mountcastle
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: CC2-SF
+  uuid: bf560b11-2572-40d3-8c7c-b52745f3cb9b
+  subjects:
+  - entities:
+    - role: player
+      name: Sal Frelick
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: CC2-TH
+  uuid: b974e804-15a8-409a-b3bf-924a2209b294
+  subjects:
+  - entities:
+    - role: player
+      name: Teoscar Hernández
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: CC2-TS
+  uuid: 3c69e5f7-8da4-413e-a40a-60f0ff5efbb8
+  subjects:
+  - entities:
+    - role: player
+      name: Tarik Skubal
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: CC2-TT
+  uuid: b8a0f4be-480a-465e-a5e2-df67396b5627
+  subjects:
+  - entities:
+    - role: player
+      name: Trea Turner
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: CC2-WS
+  uuid: 73f6b3d6-a801-49f0-b99c-db916f20564e
+  subjects:
+  - entities:
+    - role: player
+      name: Will Smith
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: CC2-ZN
+  uuid: ebd91575-c7fd-48e1-95b8-2e987ae1db70
+  subjects:
+  - entities:
+    - role: player
+      name: Zach Neto
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: CCAR-AR
+  uuid: bd02f45f-e672-44fb-a481-489dcd7991da
+  subjects:
+  - entities:
+    - role: player
+      name: Austin Riley
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: CCAR-CM
+  uuid: 43ffb611-da3b-4921-ac6f-3f6b71231a00
+  subjects:
+  - entities:
+    - role: player
+      name: Christopher Morel
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: CCAR-CR
+  uuid: 6a2dda40-12c3-4442-bb11-9abda4cf51e7
+  subjects:
+  - entities:
+    - role: player
+      name: Cal Raleigh
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: CCAR-CS
+  uuid: b7f9fc02-54ca-4e3d-a618-db113171758a
+  subjects:
+  - entities:
+    - role: player
+      name: Corey Seager
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: CCAR-FT
+  uuid: fc64e96c-1c7e-41d9-a5ea-179709eb9f3c
+  subjects:
+  - entities:
+    - role: player
+      name: Fernando Tatis Jr.
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: CCAR-JP
+  uuid: 28129846-564b-454d-b530-1a1885a4349f
+  subjects:
+  - entities:
+    - role: player
+      name: Jeremy Peña
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: CCAR-JRA
+  uuid: cd86a6fd-6449-410c-9704-a0e7129e6774
+  subjects:
+  - entities:
+    - role: player
+      name: José Ramírez
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: CCAR-JV
+  uuid: 961ee0aa-b86e-4d0d-a5c6-c9cb5c4681e6
+  subjects:
+  - entities:
+    - role: player
+      name: Joey Votto
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: CCAR-LA
+  uuid: 28805c6f-8aea-46c4-a6e6-3ffe32c275c9
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Arraez
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: CCAR-MH
+  uuid: 0f9d3b5c-2da9-43f7-866d-b5298a657bdb
+  subjects:
+  - entities:
+    - role: player
+      name: Michael Harris II
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: CCAR-RA
+  uuid: 5b2da44b-0e76-4b37-9027-6aad251acca9
+  subjects:
+  - entities:
+    - role: player
+      name: Ronald Acuña Jr.
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: CCAR-SO
+  uuid: 6a1735b8-a1e8-4c07-be81-f344b79b1c7d
+  subjects:
+  - entities:
+    - role: player
+      name: Shohei Ohtani
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: CCAR-TC
+  uuid: 866f1b09-ccd7-48c4-bfbb-9ad73d346bd1
+  subjects:
+  - entities:
+    - role: player
+      name: Triston Casas
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: CCAR-TSW
+  uuid: d4ea47a6-ca68-40dc-9b2e-c1a416a34d92
+  subjects:
+  - entities:
+    - role: player
+      name: Trey Sweeney
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 

--- a/data/baseball/2026-topps-series-2/checklists/clear-variation.yaml
+++ b/data/baseball/2026-topps-series-2/checklists/clear-variation.yaml
@@ -1,0 +1,1000 @@
+- number: '352'
+  uuid: c4e87670-6307-4f25-9967-f7b95d8fa2a6
+  subjects:
+  - entities:
+    - role: player
+      name: Spencer Torkelson
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '355'
+  uuid: bbe8b3e2-d79c-4dea-ae6d-878a5c833f96
+  subjects:
+  - entities:
+    - role: player
+      name: Nathan Eovaldi
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: '358'
+  uuid: 2d20164b-2a44-41f3-8e9d-f734bf99299c
+  subjects:
+  - entities:
+    - role: player
+      name: Adley Rutschman
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '363'
+  uuid: 9f616212-bd60-43da-8072-26a1189b417e
+  subjects:
+  - entities:
+    - role: player
+      name: J.T. Realmuto
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: '365'
+  uuid: a62d6f82-0e03-4078-96b9-b39dd52da9e3
+  subjects:
+  - entities:
+    - role: player
+      name: Spencer Steer
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '367'
+  uuid: bc459b6f-fcdc-4c83-962a-1dc626098d6f
+  subjects:
+  - entities:
+    - role: player
+      name: Robbie Ray
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '368'
+  uuid: 80e22b73-f252-45e1-b4bb-105654cc88b8
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Tucker
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '371'
+  uuid: 0edf7df7-6f02-4dd2-a5e6-4a54f2449dc0
+  subjects:
+  - entities:
+    - role: player
+      name: Brent Rooker
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: '372'
+  uuid: fd9a07ed-8a58-4c50-b054-4549eb2f8727
+  subjects:
+  - entities:
+    - role: player
+      name: Sal Stewart
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '382'
+  uuid: dc606e20-cbd1-43a9-ae3a-b0936115c355
+  subjects:
+  - entities:
+    - role: player
+      name: Hunter Greene
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '383'
+  uuid: 80717942-ed2d-4da2-9937-c231c3bd8ed6
+  subjects:
+  - entities:
+    - role: player
+      name: Wyatt Langford
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: '386'
+  uuid: 97bbba6e-1af5-403e-afef-43c9e36aaa36
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Curvelo
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: '387'
+  uuid: 1cc13ea3-1e3c-445a-9a7b-559dfa78fa92
+  subjects:
+  - entities:
+    - role: player
+      name: Drew Sommers
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '393'
+  uuid: 37bd33ce-a803-4f0b-8c22-5a3170a1a0b3
+  subjects:
+  - entities:
+    - role: player
+      name: Jazz Chisholm Jr.
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '395'
+  uuid: 3811ff71-3fbc-4938-8fab-8964efb43ee2
+  subjects:
+  - entities:
+    - role: player
+      name: Josh Naylor
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: '398'
+  uuid: 7592db05-fccb-40f4-939e-41b569012fc0
+  subjects:
+  - entities:
+    - role: player
+      name: Hunter Barco
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '400'
+  uuid: 0bf941e5-e97d-4268-aa94-3b8417369ebc
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Alonso
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '406'
+  uuid: bcc38e26-3ce1-41a9-a439-31fc0c85ba5a
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Eldridge
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '410'
+  uuid: 68903917-ea09-4440-bfaa-0290c8834070
+  subjects:
+  - entities:
+    - role: player
+      name: Hayden Harris
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: '415'
+  uuid: 033d4232-df12-425b-b9fc-386c478ceaaa
+  subjects:
+  - entities:
+    - role: player
+      name: Justin Verlander
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '422'
+  uuid: 530b5150-83e6-45e2-b1e9-8e439006686a
+  subjects:
+  - entities:
+    - role: player
+      name: Shane Bieber
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '423'
+  uuid: e46a5e45-72eb-4e42-b000-bb4c41581ebc
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Robert Jr.
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '425'
+  uuid: c7d56384-b4c1-4b41-b853-25da582f1e8e
+  subjects:
+  - entities:
+    - role: player
+      name: Trent Grisham
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '427'
+  uuid: bfbff299-1824-4b17-a433-1fb1da4c49f3
+  subjects:
+  - entities:
+    - role: player
+      name: Chris Sale
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: '431'
+  uuid: adbc0903-d5b4-4393-9653-551c3f212d29
+  subjects:
+  - entities:
+    - role: player
+      name: Randy Arozarena
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: '435'
+  uuid: 6c127172-a904-4548-96a1-16af6e5ad25e
+  subjects:
+  - entities:
+    - role: player
+      name: Denzer Guzman
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: '439'
+  uuid: 71f67b3a-439c-44c0-a48b-de48d896a0cc
+  subjects:
+  - entities:
+    - role: player
+      name: Gleyber Torres
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '441'
+  uuid: 4af2b881-1861-4491-8852-09982d8595a9
+  subjects:
+  - entities:
+    - role: player
+      name: Lars Nootbaar
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: '446'
+  uuid: a4c9c009-e400-4375-8688-6fa23d8f7e7a
+  subjects:
+  - entities:
+    - role: player
+      name: Eugenio Suárez
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '448'
+  uuid: 21d7300d-1e70-457c-be4a-bc22a8ce6ba7
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Chourio
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: '450'
+  uuid: dec840e4-ba30-4261-af22-25cbff2644e4
+  subjects:
+  - entities:
+    - role: player
+      name: Gerrit Cole
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '455'
+  uuid: c55f46fe-0bf4-4258-b4e7-95c965b4d857
+  subjects:
+  - entities:
+    - role: player
+      name: George Springer
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '458'
+  uuid: e9e03739-2d3b-49a7-8d45-63f09a47b0ef
+  subjects:
+  - entities:
+    - role: player
+      name: Chase DeLauter
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '459'
+  uuid: d845e2e7-a04c-4cd0-9b8d-178db820c649
+  subjects:
+  - entities:
+    - role: player
+      name: Ketel Marte
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: '463'
+  uuid: 0b246bb7-a48d-423d-a44d-9c50a9665d58
+  subjects:
+  - entities:
+    - role: player
+      name: Aaron Nola
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: '468'
+  uuid: 6a9558ad-4d1e-43bb-af67-8a2f10c2ed2d
+  subjects:
+  - entities:
+    - role: player
+      name: Yordan Alvarez
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '470'
+  uuid: eff502cb-3bde-4454-ad26-2838c4395daa
+  subjects:
+  - entities:
+    - role: player
+      name: Brandon Nimmo
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: '471'
+  uuid: 3ad53d74-00d5-4a48-bfb2-dff6cfca2db7
+  subjects:
+  - entities:
+    - role: player
+      name: J.P. Crawford
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: '473'
+  uuid: 988da113-358d-4521-b9c0-c7d4d100d232
+  subjects:
+  - entities:
+    - role: player
+      name: Bo Bichette
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '483'
+  uuid: d81f0627-da8c-4448-9962-d95a664cc81e
+  subjects:
+  - entities:
+    - role: player
+      name: Logan O'Hoppe
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: '493'
+  uuid: d4e468f8-458c-4867-bcd4-cee6bdd6958c
+  subjects:
+  - entities:
+    - role: player
+      name: George Kirby
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: '500'
+  uuid: 95583527-8ef4-436a-a2d3-0048a808fa41
+  subjects:
+  - entities:
+    - role: player
+      name: Shohei Ohtani
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '501'
+  uuid: 6aec04fa-b525-44f1-941d-93362d09ee77
+  subjects:
+  - entities:
+    - role: player
+      name: Connelly Early
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '503'
+  uuid: 529383f9-5764-4349-b7ff-966b3dbf8426
+  subjects:
+  - entities:
+    - role: player
+      name: Munetaka Murakami
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: '507'
+  uuid: 8c83c366-b360-4a18-ac51-107d98aa3b23
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Castillo
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: '510'
+  uuid: 17105c40-5a59-491d-913a-124316433760
+  subjects:
+  - entities:
+    - role: player
+      name: Philip Abner
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: '520'
+  uuid: 63d00423-5620-441a-bc7f-3411e2f41b14
+  subjects:
+  - entities:
+    - role: player
+      name: Andrew Alvarez
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: '526'
+  uuid: ab7a0721-0269-434a-926c-37305818878e
+  subjects:
+  - entities:
+    - role: player
+      name: Masyn Winn
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: '530'
+  uuid: dcf0530c-2d28-4fc2-a0ea-4d3ae0508201
+  subjects:
+  - entities:
+    - role: player
+      name: Carter Jensen
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: '533'
+  uuid: 21254486-f1ba-48a5-8d07-b73a8125d5e1
+  subjects:
+  - entities:
+    - role: player
+      name: Jasson Domínguez
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '534'
+  uuid: 771d7f7c-f8f7-4f28-ac07-9c63383b62d7
+  subjects:
+  - entities:
+    - role: player
+      name: Brandon Sproat
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: '536'
+  uuid: cf1e09c7-727e-4c07-a909-5f494d18f8ff
+  subjects:
+  - entities:
+    - role: player
+      name: Trevor Story
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '541'
+  uuid: 8c139984-901b-4b6b-8edf-3a482993169b
+  subjects:
+  - entities:
+    - role: player
+      name: Jung Hoo Lee
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '547'
+  uuid: e087d28c-038c-4cd7-8b65-43925aa8f185
+  subjects:
+  - entities:
+    - role: player
+      name: Dylan Cease
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '550'
+  uuid: 0aded744-f8a1-41f4-a74e-d75b7cddb930
+  subjects:
+  - entities:
+    - role: player
+      name: Dansby Swanson
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '551'
+  uuid: 4c9b2283-c8b7-4b4b-bd15-3e1ee15805e8
+  subjects:
+  - entities:
+    - role: player
+      name: Taylor Ward
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '560'
+  uuid: e56fb082-3d50-445c-8fc5-9318294fd5c9
+  subjects:
+  - entities:
+    - role: player
+      name: Jarren Duran
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '561'
+  uuid: 55062310-0006-425f-9d5f-e8558e1f5092
+  subjects:
+  - entities:
+    - role: player
+      name: Matt Chapman
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '562'
+  uuid: c8d19f81-a525-461b-b5da-10cbbbbce88a
+  subjects:
+  - entities:
+    - role: player
+      name: Bryson Stott
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: '564'
+  uuid: b9edb8c9-d202-4943-8a06-74f4b343adbf
+  subjects:
+  - entities:
+    - role: player
+      name: Tyler Soderstrom
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: '568'
+  uuid: 6ee5d763-462e-4244-9b9b-0782be742faf
+  subjects:
+  - entities:
+    - role: player
+      name: Ozzie Albies
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: '569'
+  uuid: dc57404b-6c6e-4401-a9a5-f7635ce2db0c
+  subjects:
+  - entities:
+    - role: player
+      name: Max Scherzer
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '570'
+  uuid: 6633671e-06d9-46bd-8e4f-88ff611e0621
+  subjects:
+  - entities:
+    - role: player
+      name: Rolddy Muñoz
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: '578'
+  uuid: fe252417-12fe-4c07-8736-038ea8f3b378
+  subjects:
+  - entities:
+    - role: player
+      name: Heriberto Hernández
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: '585'
+  uuid: 2179ae27-1dc1-4638-bfc4-57f187049aea
+  subjects:
+  - entities:
+    - role: player
+      name: Ian Happ
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '586'
+  uuid: 3df8112c-48fb-497d-acf0-d8cc5a4aadb6
+  subjects:
+  - entities:
+    - role: player
+      name: Marcus Semien
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '594'
+  uuid: 362244c0-5f2d-4a5c-9bae-a3d7912f953b
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Gil
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '597'
+  uuid: d6e9acaf-1fff-4e96-b28c-c7f4e8738681
+  subjects:
+  - entities:
+    - role: player
+      name: Paul Goldschmidt
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '598'
+  uuid: 8730f967-c179-4da8-8856-a7c827c83431
+  subjects:
+  - entities:
+    - role: player
+      name: Jack Winkler
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '600'
+  uuid: e43035e7-60c9-46c3-8340-9b3dd987068c
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '601'
+  uuid: 93b59c78-daf6-4900-bbc0-b353d5dfdd63
+  subjects:
+  - entities:
+    - role: player
+      name: Zach Cole
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '603'
+  uuid: c31353f8-42ca-4645-bafd-e22f60c1d5e5
+  subjects:
+  - entities:
+    - role: player
+      name: George Valera
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '607'
+  uuid: f93c0e36-4321-404c-8f4a-7e9445703c0b
+  subjects:
+  - entities:
+    - role: player
+      name: Cody Bellinger
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '611'
+  uuid: f1c8dcdd-37db-4e2c-86a1-f0f0afba7e2f
+  subjects:
+  - entities:
+    - role: player
+      name: Paul Gervase
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '613'
+  uuid: 5d8d2c75-d270-4a0f-bd68-ce3dddae9375
+  subjects:
+  - entities:
+    - role: player
+      name: Jordan Westburg
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '614'
+  uuid: 06af70a9-07c0-4e74-adf9-b4b1751cd40d
+  subjects:
+  - entities:
+    - role: player
+      name: Manny Machado
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: '618'
+  uuid: 28dbac56-7f4f-49af-ad13-035759b6d091
+  subjects:
+  - entities:
+    - role: player
+      name: Tanner Bibee
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '620'
+  uuid: 5e6b3956-992f-4074-b56b-143e5879b18a
+  subjects:
+  - entities:
+    - role: player
+      name: Trey Yesavage
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '623'
+  uuid: '02486a26-57d3-44a8-94ac-2974d9e66775'
+  subjects:
+  - entities:
+    - role: player
+      name: Rafael Flores
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '629'
+  uuid: 6a2c035d-9d45-41c6-abd8-b33325d447ed
+  subjects:
+  - entities:
+    - role: player
+      name: Tyler Glasnow
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '631'
+  uuid: bb057b35-ae63-4967-b08a-0e2c568d47a1
+  subjects:
+  - entities:
+    - role: player
+      name: Will Smith
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '632'
+  uuid: d7fb1139-1789-4414-a9c1-6a77ee38145f
+  subjects:
+  - entities:
+    - role: player
+      name: Cade Horton
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '633'
+  uuid: 2b3ef9ef-c93b-4a10-bb99-a34aef063066
+  subjects:
+  - entities:
+    - role: player
+      name: Salvador Perez
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: '643'
+  uuid: 2427004a-41eb-47b8-a5bf-49d08682addc
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Lodolo
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '646'
+  uuid: a97237be-d2cb-4da9-83a4-f58fc733c4d5
+  subjects:
+  - entities:
+    - role: player
+      name: Mark Vientos
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '650'
+  uuid: 9b8648b0-5b66-4ac9-a453-85cb9b9e4a1a
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Schwarber
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: '656'
+  uuid: 4a325470-b2e3-46a1-906f-725857659285
+  subjects:
+  - entities:
+    - role: player
+      name: Aroldis Chapman
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '658'
+  uuid: 9bec7854-34cc-49fd-8b7a-7a07aa88ac6e
+  subjects:
+  - entities:
+    - role: player
+      name: Jack Flaherty
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '659'
+  uuid: 73e94d45-5382-4325-9adb-8c7ce65f4aa5
+  subjects:
+  - entities:
+    - role: player
+      name: Harry Ford
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: '665'
+  uuid: 98962296-1515-474d-9a7d-c6407d42489a
+  subjects:
+  - entities:
+    - role: player
+      name: Jose Corniell
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: '667'
+  uuid: 600798d3-da6e-49ea-8857-70f35a95a033
+  subjects:
+  - entities:
+    - role: player
+      name: Kodai Senga
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '668'
+  uuid: 8f6fd60c-9075-4c71-89d0-2df0dfe753bf
+  subjects:
+  - entities:
+    - role: player
+      name: Petey Halpin
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '674'
+  uuid: 807dcd8a-7b24-4c10-9333-ec1ed1680402
+  subjects:
+  - entities:
+    - role: player
+      name: Andre Granillo
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: '675'
+  uuid: f0d5fba5-d0fd-4ba3-be08-82fe5cf90f48
+  subjects:
+  - entities:
+    - role: player
+      name: Steven Kwan
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '677'
+  uuid: b474b154-fbae-4c04-b3f4-69b9a192d642
+  subjects:
+  - entities:
+    - role: player
+      name: Wilyer Abreu
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '680'
+  uuid: 5dd02268-88fb-4afa-9aa5-9b30881240a9
+  subjects:
+  - entities:
+    - role: player
+      name: Carlos Correa
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '685'
+  uuid: ee12bf15-77f4-417c-828b-589afe0b44b6
+  subjects:
+  - entities:
+    - role: player
+      name: Seiya Suzuki
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '692'
+  uuid: 773f860b-f98f-4cee-a4f8-a943b48e721f
+  subjects:
+  - entities:
+    - role: player
+      name: Drake Baldwin
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: '697'
+  uuid: f1c798dd-2a24-47ff-af7e-a2d1718f12b4
+  subjects:
+  - entities:
+    - role: player
+      name: Bryan Reynolds
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '700'
+  uuid: 0e479fd1-e61b-4eab-bcf6-babe9c427e79
+  subjects:
+  - entities:
+    - role: player
+      name: Freddie Freeman
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 

--- a/data/baseball/2026-topps-series-2/checklists/cover-athlete-autographs.yaml
+++ b/data/baseball/2026-topps-series-2/checklists/cover-athlete-autographs.yaml
@@ -1,0 +1,90 @@
+- number: COVR-AJ
+  uuid: 11ec1afb-58e7-4999-b73e-345e0d89613c
+  subjects:
+  - entities:
+    - role: player
+      name: Aaron Judge
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: COVR-BH
+  uuid: 6ffef300-098f-4093-bc7f-3c91e24e0c70
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Harper
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: COVR-BP
+  uuid: 0e187e58-aa80-493d-adbd-c93401aabd75
+  subjects:
+  - entities:
+    - role: player
+      name: Buster Posey
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: COVR-FTJ
+  uuid: 1052f156-1b96-48cb-8f75-2866077fd93d
+  subjects:
+  - entities:
+    - role: player
+      name: Fernando Tatis Jr.
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: COVR-KER
+  uuid: b2b40b79-0f6a-43c2-8258-6b467ed90ad2
+  subjects:
+  - entities:
+    - role: player
+      name: Clayton Kershaw
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: COVR-MT
+  uuid: 8cd5712a-a773-4233-9b3d-999f23282fed
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Trout
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: COVR-SHO
+  uuid: 510da703-bfed-471a-83f4-5e59c200b10b
+  subjects:
+  - entities:
+    - role: player
+      name: Shohei Ohtani
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: COVR-TRO
+  uuid: 6c961b97-9ee0-4d59-b0c1-da23269662fb
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Trout
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: COVR-VGJ
+  uuid: b3978fe1-78e8-4555-b268-236c804561ac
+  subjects:
+  - entities:
+    - role: player
+      name: Vladimir Guerrero Jr.
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 

--- a/data/baseball/2026-topps-series-2/checklists/cover-athletes.yaml
+++ b/data/baseball/2026-topps-series-2/checklists/cover-athletes.yaml
@@ -1,0 +1,100 @@
+- number: CA-11
+  uuid: ea5074d9-d96a-4799-ac7a-295323b42372
+  subjects:
+  - entities:
+    - role: player
+      name: Joe Mauer
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: CA-12
+  uuid: 37bc139a-0f42-47ac-8e7e-ce5305a330db
+  subjects:
+  - entities:
+    - role: player
+      name: Buster Posey
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: CA-13
+  uuid: a52e7f08-f60f-41a9-bea0-1e26e988d89f
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Harper
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: CA-14
+  uuid: 5c0f734e-cb5c-41d9-9483-14bdb63a2b09
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Trout
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: CA-15
+  uuid: f73b59d4-6209-4107-9388-1517ce182d08
+  subjects:
+  - entities:
+    - role: player
+      name: Fernando Tatis Jr.
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: CA-16
+  uuid: def60859-91a6-4671-9366-27aafdb5bf9a
+  subjects:
+  - entities:
+    - role: player
+      name: Vladimir Guerrero Jr.
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: CA-17
+  uuid: 9feefae1-7ecb-437a-9246-316e7a49d3b0
+  subjects:
+  - entities:
+    - role: player
+      name: Aaron Judge
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: CA-18
+  uuid: fe379445-aa36-4016-a4a3-6e834f3c5658
+  subjects:
+  - entities:
+    - role: player
+      name: Shohei Ohtani
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: CA-19
+  uuid: ef6cd52c-5e97-4006-b314-30f6a3fe108b
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Trout
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: CA-20
+  uuid: f9fd974b-61aa-4205-b75c-c0616c3f60f0
+  subjects:
+  - entities:
+    - role: player
+      name: Clayton Kershaw
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 

--- a/data/baseball/2026-topps-series-2/checklists/crooked-numbers.yaml
+++ b/data/baseball/2026-topps-series-2/checklists/crooked-numbers.yaml
@@ -1,0 +1,250 @@
+- number: CN-1
+  uuid: ecbe10d4-4a14-417d-8bde-32bec3f6c837
+  subjects:
+  - entities:
+    - role: player
+      name: Aaron Judge
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: CN-2
+  uuid: 62619144-4c98-4459-aa92-5385fe2f2891
+  subjects:
+  - entities:
+    - role: player
+      name: Rickey Henderson
+      ref: 
+    - role: team
+      name: Oakland Athletics
+      ref: 
+- number: CN-3
+  uuid: 99df814e-d023-4fe8-b162-b70153c80b9e
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: CN-4
+  uuid: ba57ee81-72ff-4404-a4aa-35c66bdc69d7
+  subjects:
+  - entities:
+    - role: player
+      name: Ichiro
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: CN-5
+  uuid: 56f38899-dbdd-4a69-9ee5-45488408378d
+  subjects:
+  - entities:
+    - role: player
+      name: Cal Raleigh
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: CN-6
+  uuid: 9acdb5ec-4afd-4ed7-bca6-f6784cea09ea
+  subjects:
+  - entities:
+    - role: player
+      name: Mark McGwire
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: CN-7
+  uuid: 35c2fe6a-b615-42e7-8ca4-119c5342e303
+  subjects:
+  - entities:
+    - role: player
+      name: Lou Gehrig
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: CN-8
+  uuid: 6b3dc274-fa01-4d7b-81a1-937b944bd923
+  subjects:
+  - entities:
+    - role: player
+      name: Bobby Witt Jr.
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: CN-9
+  uuid: c2cec2d7-e2eb-4295-90c2-91db725dff50
+  subjects:
+  - entities:
+    - role: player
+      name: Shohei Ohtani
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: CN-10
+  uuid: fbf5c132-07a5-4ff1-b39f-18ccadfb944c
+  subjects:
+  - entities:
+    - role: player
+      name: Aaron Judge
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: CN-11
+  uuid: 6d1e9d47-342d-49ee-a844-a45f52222b4f
+  subjects:
+  - entities:
+    - role: player
+      name: Elly De La Cruz
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: CN-12
+  uuid: c51a0854-9621-497d-97f3-4b9a4b80c7f0
+  subjects:
+  - entities:
+    - role: player
+      name: Ronald Acuña Jr.
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: CN-13
+  uuid: 7ce02a9b-5147-403a-a6f8-0645ed8bfb16
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Schwarber
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: CN-14
+  uuid: 90f1294e-9f40-4ea7-b735-12e4099f175e
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan Ryan
+      ref: 
+    - role: team
+      name: California Angels
+      ref: 
+- number: CN-15
+  uuid: 9949c6e2-b661-4f72-b54b-01c6ddfebcbd
+  subjects:
+  - entities:
+    - role: player
+      name: Sandy Koufax
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: CN-16
+  uuid: f2ced3b0-cce9-4184-a56a-fb200af7269c
+  subjects:
+  - entities:
+    - role: player
+      name: Randy Johnson
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: CN-17
+  uuid: a5ba211a-41b0-4cf5-86cc-cf9b064b3f22
+  subjects:
+  - entities:
+    - role: player
+      name: Ken Griffey Jr.
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: CN-18
+  uuid: ff6d5e73-86f1-4c26-aee8-0811a71e6197
+  subjects:
+  - entities:
+    - role: player
+      name: Mickey Mantle
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: CN-19
+  uuid: c012537f-7acd-4932-921b-18eb65554391
+  subjects:
+  - entities:
+    - role: player
+      name: Ted Williams
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: CN-20
+  uuid: 20ff4388-f648-410c-8fb3-d990fefa9a5a
+  subjects:
+  - entities:
+    - role: player
+      name: Derek Jeter
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: CN-21
+  uuid: cfd47140-cbfc-4738-9610-0b94824f1e92
+  subjects:
+  - entities:
+    - role: player
+      name: Tony Gwynn
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: CN-22
+  uuid: c712818d-8f7e-46e4-9211-8ddde524a098
+  subjects:
+  - entities:
+    - role: player
+      name: Babe Ruth
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: CN-23
+  uuid: 806b463b-41c6-4418-bda0-fe08b6b2b618
+  subjects:
+  - entities:
+    - role: player
+      name: Clayton Kershaw
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: CN-24
+  uuid: 6bfe982f-3006-4378-8188-0f498ece42b0
+  subjects:
+  - entities:
+    - role: player
+      name: Paul Skenes
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: CN-25
+  uuid: a9d207b1-1f04-4cad-b9f2-555b912180c4
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Trout
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 

--- a/data/baseball/2026-topps-series-2/checklists/diamond-dust.yaml
+++ b/data/baseball/2026-topps-series-2/checklists/diamond-dust.yaml
@@ -1,0 +1,100 @@
+- number: DD-1
+  uuid: 72519e0d-6aa7-4551-92d9-cb13d6ae59df
+  subjects:
+  - entities:
+    - role: player
+      name: Aaron Judge
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: DD-2
+  uuid: fa983d7e-b10b-4533-b2dd-249395ee93a9
+  subjects:
+  - entities:
+    - role: player
+      name: Shohei Ohtani
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: DD-3
+  uuid: c4421857-7e23-482a-ab8b-90c9fa73e154
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: DD-4
+  uuid: dd1e6bce-2489-43fc-b8b6-76dfed7efebc
+  subjects:
+  - entities:
+    - role: player
+      name: Bobby Witt Jr.
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: DD-5
+  uuid: eb9bab96-7569-4434-9948-4e50cdbcb54c
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Trout
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: DD-6
+  uuid: 0ffac4bc-04ff-4442-bb00-e68ca621f224
+  subjects:
+  - entities:
+    - role: player
+      name: Ronald Acuña Jr.
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: DD-7
+  uuid: ae545ea0-57fb-4357-b50d-a80974c7a4bd
+  subjects:
+  - entities:
+    - role: player
+      name: Ken Griffey Jr.
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: DD-8
+  uuid: 07de1620-b08b-4809-8381-6a325d50aff1
+  subjects:
+  - entities:
+    - role: player
+      name: Babe Ruth
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: DD-9
+  uuid: adbad802-502e-43ef-bcb8-3210b29bbee2
+  subjects:
+  - entities:
+    - role: player
+      name: Willie Mays
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: DD-10
+  uuid: 96a185a9-30fb-4bc7-a42b-f40895d0a651
+  subjects:
+  - entities:
+    - role: player
+      name: Ted Williams
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 

--- a/data/baseball/2026-topps-series-2/checklists/fanatics-authentics-redemptions.yaml
+++ b/data/baseball/2026-topps-series-2/checklists/fanatics-authentics-redemptions.yaml
@@ -1,0 +1,300 @@
+- number: FAR-1
+  uuid: 712021e2-b1ad-4cf9-bce3-3aca3c6e35eb
+  subjects:
+  - entities:
+    - role: player
+      name: Buster Posey
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: FAR-2
+  uuid: 1593192b-9c60-4b08-8c3d-6628f8321bfc
+  subjects:
+  - entities:
+    - role: player
+      name: Cal Raleigh
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: FAR-3
+  uuid: 12ae8b0c-83b4-429a-ad13-5c927566645a
+  subjects:
+  - entities:
+    - role: player
+      name: Fernando Tatis Jr.
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: FAR-4
+  uuid: 45a31afa-d8b3-4c36-843f-ea88fb1b39bd
+  subjects:
+  - entities:
+    - role: player
+      name: Paul Skenes
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: FAR-5
+  uuid: 2eb2e404-8df3-47fc-a0ea-57db4513ba7d
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Kurtz
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: FAR-6
+  uuid: 0bff7bad-966c-4697-9358-a90dee766179
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Schmidt
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: FAR-7
+  uuid: 284db480-3849-40b7-b8e4-407f5af61baa
+  subjects:
+  - entities:
+    - role: player
+      name: Yadier Molina
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: FAR-8
+  uuid: 2fec0811-e2c2-4620-a237-044da67c9270
+  subjects:
+  - entities:
+    - role: player
+      name: Junior Caminero
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: FAR-9
+  uuid: cf534921-33f9-4069-b10b-9ffa46ac2c51
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Teel
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: FAR-10
+  uuid: f96acd82-6dad-4091-874c-21aa60288f07
+  subjects:
+  - entities:
+    - role: player
+      name: Zac Veen
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: FAR-11
+  uuid: 87412093-dcc3-40ab-80a1-7c35b2db68c6
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Crow-Armstrong
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: FAR-12
+  uuid: 2f88a079-34fc-49d1-b775-c248108d0db1
+  subjects:
+  - entities:
+    - role: player
+      name: Dylan Crews
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: FAR-13
+  uuid: c678e35c-e10b-4813-ae82-7b351c868991
+  subjects:
+  - entities:
+    - role: player
+      name: Adrian Beltre
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: FAR-14
+  uuid: 679c1b84-6181-4f34-9a01-fe933c404ce2
+  subjects:
+  - entities:
+    - role: player
+      name: Trey Yesavage
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: FAR-15
+  uuid: 0c5bdb88-82a6-40bb-86c2-374bfab621e7
+  subjects:
+  - entities:
+    - role: player
+      name: Max Fried
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: FAR-16
+  uuid: 8ceea131-869a-4938-9eda-49a216da773b
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Piazza
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: FAR-17
+  uuid: f2015eab-a9eb-49c1-9f69-cad630cd9350
+  subjects:
+  - entities:
+    - role: player
+      name: Steven Kwan
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: FAR-18
+  uuid: 57919a68-a756-4a0b-a7fb-1fc76d9cf1ce
+  subjects:
+  - entities:
+    - role: player
+      name: Kerry Carpenter
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: FAR-19
+  uuid: fa057b85-c0df-48db-8834-d84d389e52ac
+  subjects:
+  - entities:
+    - role: player
+      name: Gavin Lux
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: FAR-20
+  uuid: 64130329-4e1e-4ca8-ad60-211a32b2db09
+  subjects:
+  - entities:
+    - role: player
+      name: Carl Yastrzemski
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: FAR-21
+  uuid: 28af1c66-84d8-4b49-a48a-254c02931b53
+  subjects:
+  - entities:
+    - role: player
+      name: Chipper Jones
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: FAR-22
+  uuid: 252d2520-1f05-4d1b-ba9d-5557d949d6ea
+  subjects:
+  - entities:
+    - role: player
+      name: Cal Ripken Jr.
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: FAR-23
+  uuid: 56896038-26a8-4bc2-a824-8e808b238d17
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan Ryan
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: FAR-24
+  uuid: 16d2746e-2947-46d3-bf76-b7af7966de4d
+  subjects:
+  - entities:
+    - role: player
+      name: Jac Caglianone
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: FAR-25
+  uuid: 9b962b11-32ba-4ec0-be5e-359aea5be7c4
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Chourio
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: FAR-26
+  uuid: 50f1ef92-c428-44bf-9ea9-85c5b2d98d31
+  subjects:
+  - entities:
+    - role: player
+      name: Byron Buxton
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: FAR-27
+  uuid: 01b717d3-c68e-4bf2-89a4-51f781780f7e
+  subjects:
+  - entities:
+    - role: player
+      name: Ichiro
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: FAR-28
+  uuid: 4dd8e133-51a6-4982-91f4-0c99a120d06c
+  subjects:
+  - entities:
+    - role: player
+      name: Roki Sasaki
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: FAR-29
+  uuid: fd6c12fa-2f36-4a9b-987a-4f52e1ba1aef
+  subjects:
+  - entities:
+    - role: player
+      name: Albert Pujols
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: FAR-30
+  uuid: b9b858f7-56ef-4fa5-8cbd-3635b2e375c8
+  subjects:
+  - entities:
+    - role: player
+      name: Corbin Carroll
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 

--- a/data/baseball/2026-topps-series-2/checklists/first-pitch-autographs.yaml
+++ b/data/baseball/2026-topps-series-2/checklists/first-pitch-autographs.yaml
@@ -1,0 +1,60 @@
+- number: FP-10
+  uuid: ab0e6d20-af04-498b-9355-7fd5bea9a2ad
+  subjects:
+  - entities:
+    - role: player
+      name: Jerry Seinfeld
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: FP-11
+  uuid: 621b4948-7949-401e-8944-dcd8c9c4d107
+  subjects:
+  - entities:
+    - role: player
+      name: Maria Taylor
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: FP-12
+  uuid: e139d8b3-8cde-4d0b-9b10-d0b2e0f32029
+  subjects:
+  - entities:
+    - role: player
+      name: Yandel
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: FP-13
+  uuid: 8b1beeca-e120-486a-9984-a5b27f1232dc
+  subjects:
+  - entities:
+    - role: player
+      name: Scott Yager
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: FP-14
+  uuid: f5e65bc8-4f53-4d38-b78f-3660eabd5e38
+  subjects:
+  - entities:
+    - role: player
+      name: Madison Marilla
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: FP-15
+  uuid: 18a4b2b4-11d4-4072-baba-84575fd11629
+  subjects:
+  - entities:
+    - role: player
+      name: Hayden Christensen
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 

--- a/data/baseball/2026-topps-series-2/checklists/first-pitch.yaml
+++ b/data/baseball/2026-topps-series-2/checklists/first-pitch.yaml
@@ -1,0 +1,60 @@
+- number: FP-10
+  uuid: 5cf76255-b072-4bfc-9d16-948097d6ca18
+  subjects:
+  - entities:
+    - role: player
+      name: Jerry Seinfeld
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: FP-11
+  uuid: 5ea8b789-a167-4667-8907-34afa7d45b98
+  subjects:
+  - entities:
+    - role: player
+      name: Maria Taylor
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: FP-12
+  uuid: d2144b73-8b1a-4fb9-b8bc-2f9256b6b0f3
+  subjects:
+  - entities:
+    - role: player
+      name: Yandel
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: FP-13
+  uuid: 5b0faeea-6c87-438c-a3fe-a125a25d8f3d
+  subjects:
+  - entities:
+    - role: player
+      name: Scott Yager
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: FP-14
+  uuid: f3fc2455-c375-4d58-b858-8cfbc399a878
+  subjects:
+  - entities:
+    - role: player
+      name: Madison Marilla
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: FP-15
+  uuid: 03313e48-ac58-4736-b920-dd919f8e5638
+  subjects:
+  - entities:
+    - role: player
+      name: Hayden Christensen
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 

--- a/data/baseball/2026-topps-series-2/checklists/flagship-real-one-autographs.yaml
+++ b/data/baseball/2026-topps-series-2/checklists/flagship-real-one-autographs.yaml
@@ -1,0 +1,660 @@
+- number: '5'
+  uuid: 204fd28b-376e-4d3a-b402-b7dace8ce2e3
+  subjects:
+  - entities:
+    - role: player
+      name: Nico Hoerner
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '22'
+  uuid: 20c5d9fb-ecdc-4ee3-950c-1ceb12b88203
+  subjects:
+  - entities:
+    - role: player
+      name: Clayton Kershaw
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '39'
+  uuid: def22eaa-ed02-46a6-86dd-5b7720478932
+  subjects:
+  - entities:
+    - role: player
+      name: Matt Olson
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: '46'
+  uuid: a2ced243-f55d-4f52-823f-eb8f513d9f0b
+  subjects:
+  - entities:
+    - role: player
+      name: Gunnar Henderson
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '53'
+  uuid: deeb15c3-5c06-4ba6-bd6d-4596469d98bf
+  subjects:
+  - entities:
+    - role: player
+      name: Garrett Crochet
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '60'
+  uuid: 0f764b2b-77f3-4f07-bb2c-9731983648ee
+  subjects:
+  - entities:
+    - role: player
+      name: Rhett Lowder
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '67'
+  uuid: b8419f3f-64a9-44ae-8d55-a5e4102d098c
+  subjects:
+  - entities:
+    - role: player
+      name: Parker Messick
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '90'
+  uuid: cfef82fc-0eb3-45df-a3a0-a703720bb60a
+  subjects:
+  - entities:
+    - role: player
+      name: Yoshinobu Yamamoto
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '98'
+  uuid: 6e75603c-f089-4840-8469-f9621ac69cbe
+  subjects:
+  - entities:
+    - role: player
+      name: Josh Jung
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: '115'
+  uuid: 6ab8c1e6-a587-45aa-b1c4-2e736dad6e64
+  subjects:
+  - entities:
+    - role: player
+      name: Royce Lewis
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: '129'
+  uuid: e907ac20-202a-4a75-814a-60199a125970
+  subjects:
+  - entities:
+    - role: player
+      name: Cole Young
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: '143'
+  uuid: 35862404-dafe-4702-b87f-e78c0975dfc9
+  subjects:
+  - entities:
+    - role: player
+      name: Zach Maxwell
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '154'
+  uuid: cbc172fb-f3a4-4de4-8433-f9bfaab0103f
+  subjects:
+  - entities:
+    - role: player
+      name: Christian Yelich
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: '178'
+  uuid: 1024724d-9bff-4a5a-afa1-9efcc2652923
+  subjects:
+  - entities:
+    - role: player
+      name: Shota Imanaga
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '184'
+  uuid: 45a6b189-2784-4c53-b7db-f92487056256
+  subjects:
+  - entities:
+    - role: player
+      name: Carson Whisenhunt
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '205'
+  uuid: 55c0aac1-2a72-4b9b-85b0-857f94ce5640
+  subjects:
+  - entities:
+    - role: player
+      name: Bobby Witt Jr.
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: '212'
+  uuid: e2ed37c3-e54d-4b9f-9c26-64179e8a9771
+  subjects:
+  - entities:
+    - role: player
+      name: Troy Melton
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '213'
+  uuid: fdfd17ce-41bc-4c25-a4c0-18ea7775ce1f
+  subjects:
+  - entities:
+    - role: player
+      name: Colby Thomas
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: '214'
+  uuid: e84a136e-3a58-4cf6-ac01-9d79b6868630
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan McLean
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '219'
+  uuid: 26889ef6-a105-444a-a53a-53dba3a14e95
+  subjects:
+  - entities:
+    - role: player
+      name: Rafael Devers
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '224'
+  uuid: 0362ae5f-0008-4df9-9c44-2d31ebd0cf4b
+  subjects:
+  - entities:
+    - role: player
+      name: Cody Freeman
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: '229'
+  uuid: 6acc3048-06b2-4ff9-8759-4d4d9e4f6f8b
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Merrill
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: '238'
+  uuid: 92ef070f-4ab5-4f62-8a59-9c2ef6d0a600
+  subjects:
+  - entities:
+    - role: player
+      name: Austin Riley
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: '240'
+  uuid: 3cf7c4d6-0148-4694-943a-723c7149ec1d
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Wilson
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: '250'
+  uuid: d1d81dfc-7cfc-43ca-b6aa-54170577d5b6
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Harper
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: '255'
+  uuid: b07992bf-d918-4eb1-98ac-04ea076b6f19
+  subjects:
+  - entities:
+    - role: player
+      name: Byron Buxton
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: '259'
+  uuid: c9af8c0a-086d-4508-ab0d-f1b93d47a49f
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Morales
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: '261'
+  uuid: c99db849-dcf8-418b-aed3-56741e308a48
+  subjects:
+  - entities:
+    - role: player
+      name: Zack Wheeler
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: '273'
+  uuid: b4237a57-c636-4d8d-90fe-24d5d9b2dfe8
+  subjects:
+  - entities:
+    - role: player
+      name: Mason Barnett
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: '277'
+  uuid: '058628c2-8675-4aef-bfb9-c6b0b0615392'
+  subjects:
+  - entities:
+    - role: player
+      name: Jeremiah Jackson
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '278'
+  uuid: bf5a51e4-1ce2-4081-8a7a-b4885215cbbf
+  subjects:
+  - entities:
+    - role: player
+      name: Jose Altuve
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '296'
+  uuid: aa999d4a-58da-4b88-bcc6-ecaf8bf3e608
+  subjects:
+  - entities:
+    - role: player
+      name: Hayden Birdsong
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '308'
+  uuid: fbb8ba27-1b63-42d2-a43c-3f817e60e6da
+  subjects:
+  - entities:
+    - role: player
+      name: Anthony Volpe
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '328'
+  uuid: 9dd6fbbc-1360-4727-8eaf-3e4a9593d46d
+  subjects:
+  - entities:
+    - role: player
+      name: Junior Caminero
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: '333'
+  uuid: bffa7689-16c6-4500-9a9c-42f12e28a615
+  subjects:
+  - entities:
+    - role: player
+      name: Fernando Tatis Jr.
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: '334'
+  uuid: d5b2f266-430c-475b-a539-e81bc7161a96
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Karros
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: '339'
+  uuid: 2393c65e-ce4d-4f68-85d2-4aeb9c213349
+  subjects:
+  - entities:
+    - role: player
+      name: Dylan Beavers
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '342'
+  uuid: da197611-d48a-485b-81ab-815ea3e6e853
+  subjects:
+  - entities:
+    - role: player
+      name: Chandler Simpson
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: '371'
+  uuid: 3fc976ae-4385-4046-9151-326b4bafe451
+  subjects:
+  - entities:
+    - role: player
+      name: Brent Rooker
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: '372'
+  uuid: ffa8e366-deda-485b-9e64-fadba8012ba8
+  subjects:
+  - entities:
+    - role: player
+      name: Sal Stewart
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '383'
+  uuid: ffc5be1c-e231-42cb-81e1-860cccdcf145
+  subjects:
+  - entities:
+    - role: player
+      name: Wyatt Langford
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: '406'
+  uuid: fafe4ff3-8171-45ce-8400-9a6d93bca4ab
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Eldridge
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '435'
+  uuid: ede907de-14fa-4744-80a3-52ba86b9a817
+  subjects:
+  - entities:
+    - role: player
+      name: Denzer Guzman
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: '443'
+  uuid: 75e4a4ff-7035-4604-85f3-7380ae7df52f
+  subjects:
+  - entities:
+    - role: player
+      name: Kazuma Okamoto
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '448'
+  uuid: 5f801eff-a99b-42a4-8242-97b427914fb7
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Chourio
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: '458'
+  uuid: fafe7e7c-c215-428d-acde-94dce64f354d
+  subjects:
+  - entities:
+    - role: player
+      name: Chase DeLauter
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '500'
+  uuid: d99941c0-8394-468d-8fd0-1fdeb752feff
+  subjects:
+  - entities:
+    - role: player
+      name: Shohei Ohtani
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '501'
+  uuid: ecb9fc63-f249-427e-8733-7e946239620b
+  subjects:
+  - entities:
+    - role: player
+      name: Connelly Early
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '503'
+  uuid: 0c9493cc-558e-428e-9ca9-a9c79e8c5e6d
+  subjects:
+  - entities:
+    - role: player
+      name: Munetaka Murakami
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: '526'
+  uuid: 4bfa22fe-df4d-4b42-abba-edb55bd3b114
+  subjects:
+  - entities:
+    - role: player
+      name: Masyn Winn
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: '530'
+  uuid: f9208e93-b323-4f81-bede-b04ebd2ae8a2
+  subjects:
+  - entities:
+    - role: player
+      name: Carter Jensen
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: '533'
+  uuid: 2d8f48e3-e0fb-4953-952c-c8d4a7d25102
+  subjects:
+  - entities:
+    - role: player
+      name: Jasson Domínguez
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '541'
+  uuid: 4ad96806-0f4b-4af0-bef5-f168608f7395
+  subjects:
+  - entities:
+    - role: player
+      name: Jung Hoo Lee
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '560'
+  uuid: a6aa5ffa-be2b-44d0-a9ae-73b083ac827b
+  subjects:
+  - entities:
+    - role: player
+      name: Jarren Duran
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '570'
+  uuid: 25061d37-58b3-4c7a-982e-28260ea74d31
+  subjects:
+  - entities:
+    - role: player
+      name: Rolddy Muñoz
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: '578'
+  uuid: 95dece43-f46f-4aaf-940f-5fcc487caea3
+  subjects:
+  - entities:
+    - role: player
+      name: Heriberto Hernández
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: '600'
+  uuid: be9c0d42-a5a6-4575-a4e2-b01ed1de1579
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '601'
+  uuid: e8779476-f328-46dc-a7e0-3f1548a11f08
+  subjects:
+  - entities:
+    - role: player
+      name: Zach Cole
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '614'
+  uuid: bbe3cdda-220f-4786-bfcf-f08f2e92636c
+  subjects:
+  - entities:
+    - role: player
+      name: Manny Machado
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: '620'
+  uuid: 0535d8e2-4426-40e5-ad5f-bbb6c92bf004
+  subjects:
+  - entities:
+    - role: player
+      name: Trey Yesavage
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '623'
+  uuid: 8e504b31-9cd6-470c-9529-f9ee441b06ed
+  subjects:
+  - entities:
+    - role: player
+      name: Rafael Flores
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '631'
+  uuid: 187d1666-34f0-41a7-8cf9-8cd7cd7c901e
+  subjects:
+  - entities:
+    - role: player
+      name: Will Smith
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '632'
+  uuid: 3cac6892-8864-4252-a775-19d4fbc9eab2
+  subjects:
+  - entities:
+    - role: player
+      name: Cade Horton
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '665'
+  uuid: 4bda8a7b-6aed-4e0f-8804-4f77df6f4bfd
+  subjects:
+  - entities:
+    - role: player
+      name: Jose Corniell
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: '675'
+  uuid: 9ddb4f9a-4a78-4b48-a8ad-f7e38b865c28
+  subjects:
+  - entities:
+    - role: player
+      name: Steven Kwan
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '692'
+  uuid: 70b03ce6-ea6d-4e33-846e-e5390e8f840a
+  subjects:
+  - entities:
+    - role: player
+      name: Drake Baldwin
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 

--- a/data/baseball/2026-topps-series-2/checklists/funko-pops.yaml
+++ b/data/baseball/2026-topps-series-2/checklists/funko-pops.yaml
@@ -1,0 +1,50 @@
+- number: '41'
+  uuid: '0852c648-9dd0-45d8-b6f7-da7b21037f02'
+  subjects:
+  - entities:
+    - role: player
+      name: Mookie Betts
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '46'
+  uuid: a827cca2-2e4c-4be0-9364-2b41b986ab04
+  subjects:
+  - entities:
+    - role: player
+      name: Gunnar Henderson
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '50'
+  uuid: 9ec02919-5fc5-405c-91f4-3805627bc50c
+  subjects:
+  - entities:
+    - role: player
+      name: Ronald Acuña Jr.
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: '123'
+  uuid: a769a820-a6bf-4d09-8e99-8b4a93d3c9ec
+  subjects:
+  - entities:
+    - role: player
+      name: Francisco Lindor
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '278'
+  uuid: 3146aa9a-e42c-49f8-85f9-9828500e9915
+  subjects:
+  - entities:
+    - role: player
+      name: Jose Altuve
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 

--- a/data/baseball/2026-topps-series-2/checklists/glove-work.yaml
+++ b/data/baseball/2026-topps-series-2/checklists/glove-work.yaml
@@ -1,0 +1,650 @@
+- number: GW-1
+  uuid: 7559c92b-d9e6-4a2d-8fc1-bad41131cf63
+  subjects:
+  - entities:
+    - role: player
+      name: Ozzie Smith
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: GW-2
+  uuid: 7e930d3a-ac7f-46eb-b2b4-a18010f83428
+  subjects:
+  - entities:
+    - role: player
+      name: George Brett
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: GW-3
+  uuid: 34ab2fc8-18eb-415e-869d-b2a66876fe9e
+  subjects:
+  - entities:
+    - role: player
+      name: Brooks Robinson
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: GW-4
+  uuid: 3b2f7ab0-6e0e-46cf-86b6-c3c450861932
+  subjects:
+  - entities:
+    - role: player
+      name: Roberto Clemente
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: GW-5
+  uuid: 01defe0c-30f8-4950-92d2-2d18220af1b6
+  subjects:
+  - entities:
+    - role: player
+      name: Jimmy Rollins
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: GW-6
+  uuid: 8004303f-c935-445e-af9e-cb7808627861
+  subjects:
+  - entities:
+    - role: player
+      name: Willie Mays
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: GW-7
+  uuid: 519b2201-7b0e-47ca-9226-fdfdd161154e
+  subjects:
+  - entities:
+    - role: player
+      name: Ivan Rodriguez
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: GW-8
+  uuid: b7392072-d54d-49c7-908f-741fa05910aa
+  subjects:
+  - entities:
+    - role: player
+      name: Andruw Jones
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: GW-9
+  uuid: 168c1e4e-333c-47ce-b01c-efba9e509405
+  subjects:
+  - entities:
+    - role: player
+      name: Yadier Molina
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: GW-10
+  uuid: 840815cd-1764-4c42-99dc-cf6644b11a43
+  subjects:
+  - entities:
+    - role: player
+      name: Adrian Beltré
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: GW-11
+  uuid: 61178390-e54f-47b1-b26b-599ef08afe8a
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan Arenado
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: GW-12
+  uuid: 4e09318a-68cd-40da-a9c1-d27faf7a4071
+  subjects:
+  - entities:
+    - role: player
+      name: Greg Maddux
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: GW-13
+  uuid: aa56f5bb-971f-47cf-9f16-76296bdc796b
+  subjects:
+  - entities:
+    - role: player
+      name: Johnny Bench
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: GW-14
+  uuid: 7e1bc8f8-26d0-412b-9d7f-e64ec07551ef
+  subjects:
+  - entities:
+    - role: player
+      name: Cal Ripken Jr.
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: GW-15
+  uuid: 55e9c49c-f11a-479e-8651-33d91660acd1
+  subjects:
+  - entities:
+    - role: player
+      name: Ken Griffey Jr.
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: GW-16
+  uuid: 76d10a86-f643-44dd-b01d-29b4de5475e1
+  subjects:
+  - entities:
+    - role: player
+      name: Ichiro
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: GW-17
+  uuid: 6317722f-0b7e-4b08-ac0b-69c5a1df4319
+  subjects:
+  - entities:
+    - role: player
+      name: Manny Machado
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: GW-18
+  uuid: fd7a4625-a321-4283-ada8-08cffb06d861
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Crow-Armstrong
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: GW-19
+  uuid: 3b753390-aa14-4eec-9f01-4778ee46afca
+  subjects:
+  - entities:
+    - role: player
+      name: Matt Chapman
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: GW-20
+  uuid: 40ac2ff1-6f62-4854-befb-061ae2af5a12
+  subjects:
+  - entities:
+    - role: player
+      name: Mookie Betts
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: GW-21
+  uuid: 2fdf45f5-f67a-4b2e-8931-5f7f511e52a5
+  subjects:
+  - entities:
+    - role: player
+      name: Francisco Lindor
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: GW-22
+  uuid: 5f85ad77-1271-4f1a-95d6-cfab868ae503
+  subjects:
+  - entities:
+    - role: player
+      name: Javier Báez
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: GW-23
+  uuid: 13da1bea-8718-42e8-b0dd-cf020cce04c0
+  subjects:
+  - entities:
+    - role: player
+      name: Dansby Swanson
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: GW-24
+  uuid: 525518cf-17b4-4b49-a58f-cf9d2fde276f
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Trout
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: GW-25
+  uuid: 3b7e6b7d-c774-482c-9ed4-b95810b1ff93
+  subjects:
+  - entities:
+    - role: player
+      name: Fernando Tatis Jr.
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: GW-26
+  uuid: 5c527ff4-3e11-42be-aa99-5b47430a25cf
+  subjects:
+  - entities:
+    - role: player
+      name: Bobby Witt Jr.
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: GW-27
+  uuid: 7e325564-ad98-4c1c-9ddb-b07546787e37
+  subjects:
+  - entities:
+    - role: player
+      name: Steven Kwan
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: GW-28
+  uuid: b666c447-60f4-4b04-a49a-ee70cb467439
+  subjects:
+  - entities:
+    - role: player
+      name: Byron Buxton
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: GW-29
+  uuid: ebc19aac-064d-4116-a161-c8b1a74d909d
+  subjects:
+  - entities:
+    - role: player
+      name: Freddie Freeman
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: GW-30
+  uuid: 95b44bae-9fc6-4732-b69b-b3b7870d78eb
+  subjects:
+  - entities:
+    - role: player
+      name: Vladimir Guerrero Jr.
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: GW-31
+  uuid: '04885e03-3a4e-43a0-b383-3a5f9cd17fe2'
+  subjects:
+  - entities:
+    - role: player
+      name: Julio Rodríguez
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: GW-32
+  uuid: 674debfa-1408-4708-aead-18a5245dfcc0
+  subjects:
+  - entities:
+    - role: player
+      name: Aaron Judge
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: GW-33
+  uuid: 3648dc53-cf85-4997-8bf3-a7a47db74529
+  subjects:
+  - entities:
+    - role: player
+      name: Patrick Bailey
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: GW-34
+  uuid: 6f265333-117f-4d8f-9ee5-faad0aa9075d
+  subjects:
+  - entities:
+    - role: player
+      name: Matt Olson
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: GW-35
+  uuid: b03467ef-afd4-4fae-b313-dd64d0c8e2c1
+  subjects:
+  - entities:
+    - role: player
+      name: Nico Hoerner
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: GW-36
+  uuid: 3d8b5c94-4621-4a4e-99aa-8cb09e6f1fd5
+  subjects:
+  - entities:
+    - role: player
+      name: Andrés Giménez
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: GW-37
+  uuid: b196bad0-92ca-4565-b6db-93e53ff500c1
+  subjects:
+  - entities:
+    - role: player
+      name: Cal Raleigh
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: GW-38
+  uuid: a8211471-0e53-4623-900b-0b7abf78a23b
+  subjects:
+  - entities:
+    - role: player
+      name: Carl Yastrzemski
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: GW-39
+  uuid: ef06ff35-8fc7-4273-b90b-9f5b68bc6a57
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Schmidt
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: GW-40
+  uuid: 84ff5919-7d2d-4ece-b18a-2717458ac84a
+  subjects:
+  - entities:
+    - role: player
+      name: Honus Wagner
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: GW-41
+  uuid: ff582724-90d3-4157-b85b-16560649933c
+  subjects:
+  - entities:
+    - role: player
+      name: Scott Rolen
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: GW-42
+  uuid: ebae3793-6044-433a-b1a5-332d46e7cc89
+  subjects:
+  - entities:
+    - role: player
+      name: Ryne Sandberg
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: GW-43
+  uuid: 79c1835c-637d-4457-9f01-4313d22da70a
+  subjects:
+  - entities:
+    - role: player
+      name: Hank Aaron
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: GW-44
+  uuid: ff207c2f-7973-46fd-aa10-8e18a7569ed7
+  subjects:
+  - entities:
+    - role: player
+      name: Derek Jeter
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: GW-45
+  uuid: ecafdff0-8157-4a81-ae86-0f20c7dc91a1
+  subjects:
+  - entities:
+    - role: player
+      name: Don Mattingly
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: GW-46
+  uuid: 8de9d9ca-29f8-4980-b4dd-1477cf7cd500
+  subjects:
+  - entities:
+    - role: player
+      name: Chase Utley
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: GW-47
+  uuid: be0bcbf9-edca-4527-9b96-c38d44c92e94
+  subjects:
+  - entities:
+    - role: player
+      name: Dustin Pedroia
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: GW-48
+  uuid: 4e1f5718-90e8-4478-9d2f-721cd20377e0
+  subjects:
+  - entities:
+    - role: player
+      name: Alex Gordon
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: GW-49
+  uuid: 4b8cee00-731c-43f1-a795-5b8d5f90dbba
+  subjects:
+  - entities:
+    - role: player
+      name: Kirby Puckett
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: GW-50
+  uuid: 7545c874-6671-4d1b-b1e2-5e1cec4acde3
+  subjects:
+  - entities:
+    - role: player
+      name: Bill Mazeroski
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: GW-51
+  uuid: 4cd31e93-c1c8-4de3-bdb7-3146879d7881
+  subjects:
+  - entities:
+    - role: player
+      name: Jim Edmonds
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: GW-52
+  uuid: d80e3653-59a8-4a78-b0a7-c18fd9a2a3ee
+  subjects:
+  - entities:
+    - role: player
+      name: Carlos Correa
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: GW-53
+  uuid: c1788046-786f-4cd0-b17b-020244438822
+  subjects:
+  - entities:
+    - role: player
+      name: Ke'Bryan Hayes
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: GW-54
+  uuid: c3df38a0-7fe5-49dd-bbcf-17d10d0e3892
+  subjects:
+  - entities:
+    - role: player
+      name: Ceddanne Rafaela
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: GW-55
+  uuid: 4b1bfd24-db16-4326-9e4a-bdd20949c2a0
+  subjects:
+  - entities:
+    - role: player
+      name: Daulton Varsho
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: GW-56
+  uuid: 3b0639dc-631d-4ea1-a212-16c9a0edfc44
+  subjects:
+  - entities:
+    - role: player
+      name: Corbin Carroll
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: GW-57
+  uuid: 60802d5a-858b-47f8-b479-f80c0bf893b7
+  subjects:
+  - entities:
+    - role: player
+      name: Zach Neto
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: GW-58
+  uuid: 0dcad9f8-4354-4d72-b4b2-0845bf418628
+  subjects:
+  - entities:
+    - role: player
+      name: Brice Turang
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: GW-59
+  uuid: feed4e3f-5a04-4116-b216-6f7c2038b6e0
+  subjects:
+  - entities:
+    - role: player
+      name: Masyn Winn
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: GW-60
+  uuid: 14d352a6-8f32-4040-bf66-544e8fcc4ef9
+  subjects:
+  - entities:
+    - role: player
+      name: Max Fried
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: GW-61
+  uuid: ecf9e053-80f6-47cd-9a24-61128abcb4f9
+  subjects:
+  - entities:
+    - role: player
+      name: Jackie Robinson
+      ref: 
+    - role: team
+      name: Brooklyn Dodgers
+      ref: 
+- number: GW-62
+  uuid: 9a2c6d3f-f6fa-47dc-9c5c-94ef6c46e6e4
+  subjects:
+  - entities:
+    - role: player
+      name: Tom Glavine
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: GW-63
+  uuid: bea66a7c-95c2-4727-85b6-545e77acd1b8
+  subjects:
+  - entities:
+    - role: player
+      name: Mark Grace
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: GW-64
+  uuid: 3604c248-7ec7-41b9-afc8-de0164558a2e
+  subjects:
+  - entities:
+    - role: player
+      name: Wyatt Langford
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: GW-65
+  uuid: 60bb29c2-a29c-45ab-b155-1de2a85b2059
+  subjects:
+  - entities:
+    - role: player
+      name: Elly De La Cruz
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 

--- a/data/baseball/2026-topps-series-2/checklists/golden-mirror-legend-variations.yaml
+++ b/data/baseball/2026-topps-series-2/checklists/golden-mirror-legend-variations.yaml
@@ -1,0 +1,500 @@
+- number: '351'
+  uuid: cbac09cd-bf40-4406-892a-b830bf7ce946
+  subjects:
+  - entities:
+    - role: player
+      name: Al Kaline
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '352'
+  uuid: db37bf64-a0d1-49fd-9931-427f33b08508
+  subjects:
+  - entities:
+    - role: player
+      name: Miguel Cabrera
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '358'
+  uuid: cbd0b116-dadb-43fb-8ee5-b8bb8b36fe13
+  subjects:
+  - entities:
+    - role: player
+      name: Josh Gibson
+      ref: 
+    - role: team
+      name: Pittsburgh
+      ref: 
+- number: '365'
+  uuid: 51ac2416-8d94-4b77-8064-330194dfe412
+  subjects:
+  - entities:
+    - role: player
+      name: Johnny Bench
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '371'
+  uuid: df6bef8b-317d-49c9-9df6-9b0b31c5d76f
+  subjects:
+  - entities:
+    - role: player
+      name: Mark McGwire
+      ref: 
+    - role: team
+      name: Oakland Athletics
+      ref: 
+- number: '393'
+  uuid: 93a186ce-8b1f-4ab4-8637-2be244ec4621
+  subjects:
+  - entities:
+    - role: player
+      name: Alex Rodriguez
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '396'
+  uuid: 19bf9b43-718d-41b2-ad43-1b0b7a6399e5
+  subjects:
+  - entities:
+    - role: player
+      name: Warren Spahn
+      ref: 
+    - role: team
+      name: Milwaukee Braves
+      ref: 
+- number: '414'
+  uuid: 4e31a8fb-2134-4a1a-833b-b2207a118a2a
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Piazza
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '415'
+  uuid: 7b053fd3-181a-43f4-a7ab-e8e9821f7413
+  subjects:
+  - entities:
+    - role: player
+      name: Christy Mathewson
+      ref: 
+    - role: team
+      name: New York Giants
+      ref: 
+- number: '423'
+  uuid: 482d919b-322d-4f75-b169-0d67a4fb5a71
+  subjects:
+  - entities:
+    - role: player
+      name: Tim Raines
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: '425'
+  uuid: 85c7733f-6669-42d6-b0db-244d5d39eca4
+  subjects:
+  - entities:
+    - role: player
+      name: Yogi Berra
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '427'
+  uuid: 69d9e081-508a-45d3-9c93-31a6a4ea6450
+  subjects:
+  - entities:
+    - role: player
+      name: Tom Glavine
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: '431'
+  uuid: 44b8ed80-12e6-47e9-b0e3-da7514cc3a1a
+  subjects:
+  - entities:
+    - role: player
+      name: Ichiro
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: '441'
+  uuid: afc62940-790e-49b4-a7e8-43b12f0ea442
+  subjects:
+  - entities:
+    - role: player
+      name: Johnny Mize
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: '450'
+  uuid: 898a6dee-6b7d-4183-9465-49b0f0995b27
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan Ryan
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: '460'
+  uuid: 789c8c37-9aa1-4046-b1f0-cb11b7af8a02
+  subjects:
+  - entities:
+    - role: player
+      name: Carlton Fisk
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '463'
+  uuid: 412b7dfc-6cdc-46ac-8a06-41eb00260d91
+  subjects:
+  - entities:
+    - role: player
+      name: Steve Carlton
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: '465'
+  uuid: 3e1dc46f-0142-43d5-94fc-c76dfd9cf7f6
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Gonzalez
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: '468'
+  uuid: cccd0c71-65f0-4d30-aeb9-295d87dc6c0e
+  subjects:
+  - entities:
+    - role: player
+      name: Craig Biggio
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '483'
+  uuid: 7572d86d-f555-4abc-ae2c-950a21a15757
+  subjects:
+  - entities:
+    - role: player
+      name: Rod Carew
+      ref: 
+    - role: team
+      name: California Angels
+      ref: 
+- number: '489'
+  uuid: 7e1a5dda-2fc1-4e28-a84a-e81bcf537579
+  subjects:
+  - entities:
+    - role: player
+      name: Harmon Killebrew
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: '493'
+  uuid: e7e3eb71-48a4-453d-82a4-ac885af944eb
+  subjects:
+  - entities:
+    - role: player
+      name: Randy Johnson
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: '500'
+  uuid: b4763081-c742-45db-9b4f-2df3c0a08956
+  subjects:
+  - entities:
+    - role: player
+      name: Honus Wagner
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '504'
+  uuid: d69a28f9-b879-4357-843d-5b681b06158a
+  subjects:
+  - entities:
+    - role: player
+      name: Tris Speaker
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '532'
+  uuid: 78666972-a132-4077-8875-c9d3cdfe99b3
+  subjects:
+  - entities:
+    - role: player
+      name: Walter Johnson
+      ref: 
+    - role: team
+      name: Washington Senators
+      ref: 
+- number: '533'
+  uuid: 89e4d6f8-f30d-43d5-a5df-083cabf4712f
+  subjects:
+  - entities:
+    - role: player
+      name: Reggie Jackson
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '536'
+  uuid: 570b8629-ed68-4563-8840-6974fcbc2db7
+  subjects:
+  - entities:
+    - role: player
+      name: Wade Boggs
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '542'
+  uuid: 7f01bf8f-fac3-48d0-901d-5bed423ddd4f
+  subjects:
+  - entities:
+    - role: player
+      name: Paul Molitor
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: '549'
+  uuid: 7de978c8-28c2-48ed-95a0-5955e85132c2
+  subjects:
+  - entities:
+    - role: player
+      name: Rickey Henderson
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '560'
+  uuid: e5889f62-9d16-4070-831b-cbb44275cd88
+  subjects:
+  - entities:
+    - role: player
+      name: Ted Williams
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '561'
+  uuid: 3957c299-fd5f-4bb7-bd47-d8b3cfa9d701
+  subjects:
+  - entities:
+    - role: player
+      name: Will Clark
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '562'
+  uuid: 0b5e8806-9c4b-4adf-9459-75a5e3429aa6
+  subjects:
+  - entities:
+    - role: player
+      name: Chase Utley
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: '569'
+  uuid: '091c3e36-b3a6-4c92-adda-fd72617377bc'
+  subjects:
+  - entities:
+    - role: player
+      name: Roger Clemens
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '573'
+  uuid: 505b977b-1678-457a-b3cc-98f96409cf4f
+  subjects:
+  - entities:
+    - role: player
+      name: Albert Pujols
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: '587'
+  uuid: 90c2e459-650d-4ba1-98b8-ef81bc3cebf2
+  subjects:
+  - entities:
+    - role: player
+      name: Rogers Hornsby
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: '597'
+  uuid: 1230659c-d6cf-4dfc-abc6-ef8007a71cea
+  subjects:
+  - entities:
+    - role: player
+      name: Lou Gehrig
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '613'
+  uuid: 7fa93472-0fed-4edd-b931-12d5bcfbef85
+  subjects:
+  - entities:
+    - role: player
+      name: Brooks Robinson
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '618'
+  uuid: 2455519e-7e10-42cf-8d72-f9d1a80309f9
+  subjects:
+  - entities:
+    - role: player
+      name: Bob Feller
+      ref: 
+    - role: team
+      name: Cleveland
+      ref: 
+- number: '620'
+  uuid: 7fea0ddf-e5b5-4c82-8b8a-940945076833
+  subjects:
+  - entities:
+    - role: player
+      name: Bob Gibson
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: '629'
+  uuid: e098991c-8eb7-4b6f-a4fd-85a7812e707c
+  subjects:
+  - entities:
+    - role: player
+      name: Sandy Koufax
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '631'
+  uuid: 7629cb86-2960-4577-be86-6174070fcd75
+  subjects:
+  - entities:
+    - role: player
+      name: Duke Snider
+      ref: 
+    - role: team
+      name: Brooklyn Dodgers
+      ref: 
+- number: '632'
+  uuid: c0ba0724-8e2d-4280-b1c1-6463f5cae071
+  subjects:
+  - entities:
+    - role: player
+      name: Greg Maddux
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '633'
+  uuid: 970e9c20-9540-424b-a325-b56c7117672b
+  subjects:
+  - entities:
+    - role: player
+      name: George Brett
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: '646'
+  uuid: 2dac9da5-b2f0-434f-b5f7-df909ed188b6
+  subjects:
+  - entities:
+    - role: player
+      name: Darryl Strawberry
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '656'
+  uuid: d5d9a372-c468-445e-8787-ccf4d731ff76
+  subjects:
+  - entities:
+    - role: player
+      name: Pedro Martinez
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '670'
+  uuid: b11d6b7f-53a3-4ae8-8eb6-f570af984802
+  subjects:
+  - entities:
+    - role: player
+      name: Jimmie Foxx
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '673'
+  uuid: b02e92dc-c155-4509-974a-d211c3d2a2b9
+  subjects:
+  - entities:
+    - role: player
+      name: John Smoltz
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: '677'
+  uuid: 211f282f-36a2-4a88-9b20-28f309e9659d
+  subjects:
+  - entities:
+    - role: player
+      name: Manny Ramirez
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '685'
+  uuid: e4656fd6-3417-434b-a7d9-a874e9586b44
+  subjects:
+  - entities:
+    - role: player
+      name: Sammy Sosa
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '692'
+  uuid: 3d91dd42-5c62-4e3e-834c-69ad648d97c3
+  subjects:
+  - entities:
+    - role: player
+      name: Dale Murphy
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 

--- a/data/baseball/2026-topps-series-2/checklists/golden-mirror-variations.yaml
+++ b/data/baseball/2026-topps-series-2/checklists/golden-mirror-variations.yaml
@@ -1,0 +1,3500 @@
+- number: '351'
+  uuid: fd875a2a-f015-40ff-9bd6-20121e7f2fe7
+  subjects:
+  - entities:
+    - role: player
+      name: Dillon Dingler
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '352'
+  uuid: 39943ed5-5248-440f-85bc-d976b79fef31
+  subjects:
+  - entities:
+    - role: player
+      name: Spencer Torkelson
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '353'
+  uuid: fa205ba4-f87a-493e-baa1-ca8940c6a97f
+  subjects:
+  - entities:
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: '354'
+  uuid: 9b01648c-b40e-43eb-b255-9792ec2de714
+  subjects:
+  - entities:
+    - role: player
+      name: Gabriel Arias
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '355'
+  uuid: 8b547c30-841a-4df8-aceb-7d4c908409ae
+  subjects:
+  - entities:
+    - role: player
+      name: Nathan Eovaldi
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: '356'
+  uuid: b3785343-7fc2-45a8-baa0-991a4fc3d5e7
+  subjects:
+  - entities:
+    - role: player
+      name: Vladimir Guerrero Jr.
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '357'
+  uuid: 8abb2b1e-4318-4a03-b8b3-9a6aa4fb2033
+  subjects:
+  - entities:
+    - role: player
+      name: Gavin Lux
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: '358'
+  uuid: 202a161a-051a-4045-9047-895954496d3a
+  subjects:
+  - entities:
+    - role: player
+      name: Adley Rutschman
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '359'
+  uuid: 033b8edd-5ba4-4fa3-a1d9-4d6acb211fb3
+  subjects:
+  - entities:
+    - role: player
+      name: Adael Amador
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: '360'
+  uuid: 94f86d0c-b1fe-4cf5-bf70-53235796faea
+  subjects:
+  - entities:
+    - role: player
+      name: Ben Joyce
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: '361'
+  uuid: 481ad2bf-2c66-4a81-90d1-f5a5c07c8ed1
+  subjects:
+  - entities:
+    - role: player
+      name: Davis Schneider
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '362'
+  uuid: 705bc8eb-019b-4d44-a10b-f4eed6bbbe93
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Severino
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: '363'
+  uuid: c8c54a40-c255-499d-8f3b-fddda3d87901
+  subjects:
+  - entities:
+    - role: player
+      name: J.T. Realmuto
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: '364'
+  uuid: 80c3cbb2-6085-451b-a840-6cf85d8b362c
+  subjects:
+  - entities:
+    - role: player
+      name: Luis García Jr.
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: '365'
+  uuid: e452627b-426b-4174-8ec0-a1e18e523d23
+  subjects:
+  - entities:
+    - role: player
+      name: Spencer Steer
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '366'
+  uuid: 4de36108-945d-4355-9c74-5e751c81f40f
+  subjects:
+  - entities:
+    - role: player
+      name: Isaac Paredes
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '367'
+  uuid: b1688604-9e8c-431f-b578-864fa6af2792
+  subjects:
+  - entities:
+    - role: player
+      name: Robbie Ray
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '368'
+  uuid: 719aadf3-ec23-4891-b2b5-c74d4718d3cc
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Tucker
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '369'
+  uuid: abfb71c8-f718-4603-bd92-f94c36e7b63a
+  subjects:
+  - entities:
+    - role: player
+      name: Julio Rodríguez
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: '370'
+  uuid: 43624ed9-c0f5-4dfb-98e9-047f12549cd3
+  subjects:
+  - entities:
+    - role: player
+      name: Brayan Rocchio
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '371'
+  uuid: 93a12ebd-306f-4398-8154-e0ea1b3fbc63
+  subjects:
+  - entities:
+    - role: player
+      name: Brent Rooker
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: '372'
+  uuid: 8098e417-6d17-4e8d-834b-8f6bb1533762
+  subjects:
+  - entities:
+    - role: player
+      name: Sal Stewart
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '373'
+  uuid: 552388a6-a9d9-4d3e-8e55-b485c3128c67
+  subjects:
+  - entities:
+    - role: player
+      name: Cam Smith
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '374'
+  uuid: 408fdac5-02b2-4928-ae32-fa66ee7947db
+  subjects:
+  - entities:
+    - role: player
+      name: Kevin Alcántara
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '375'
+  uuid: dcb917f7-e3da-4bb4-a9bc-dede9a8e019b
+  subjects:
+  - entities:
+    - role: player
+      name: Denzel Clarke
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: '376'
+  uuid: 8618bac5-b9ac-4ccd-a549-b101a5816da5
+  subjects:
+  - entities:
+    - role: player
+      name: Christian Encarnacion-Strand
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '377'
+  uuid: 0fa3678f-dc29-4465-b12c-bb51f47ec400
+  subjects:
+  - entities:
+    - role: player
+      name: Alec Bohm
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: '378'
+  uuid: 1f0d27b9-71ca-4b6d-85ac-1df5024df167
+  subjects:
+  - entities:
+    - role: player
+      name: Kyren Paris
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: '379'
+  uuid: 319ea773-6cc2-4782-862e-869220a2e074
+  subjects:
+  - entities:
+    - role: player
+      name: Blake Perkins
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: '380'
+  uuid: ef67a38c-3a01-4172-bdc3-4358e29b5933
+  subjects:
+  - entities:
+    - role: player
+      name: Framber Valdez
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '381'
+  uuid: e046a243-7c78-43f9-b902-91cd34e8c43f
+  subjects:
+  - entities:
+    - role: player
+      name: Brian Van Belle
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: '382'
+  uuid: c0453efc-6d39-4b2a-b4f9-6a1872b99d7c
+  subjects:
+  - entities:
+    - role: player
+      name: Hunter Greene
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '383'
+  uuid: 9135ee3c-30d6-42c5-b034-c173d20188db
+  subjects:
+  - entities:
+    - role: player
+      name: Wyatt Langford
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: '384'
+  uuid: 559faa4d-55ff-4ffc-9a2a-73541f364102
+  subjects:
+  - entities:
+    - role: player
+      name: Taijuan Walker
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: '385'
+  uuid: f67de47f-0951-4ec8-baad-5d697cb102e7
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Raquet
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: '386'
+  uuid: 64638dc2-7f30-42e9-aa98-3ef6cbb3041a
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Curvelo
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: '387'
+  uuid: 3b977cf8-53b9-447e-a4bc-d0fa4c00775c
+  subjects:
+  - entities:
+    - role: player
+      name: Drew Sommers
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '388'
+  uuid: f1715caf-85dd-47eb-80ef-1bccfdf6ace1
+  subjects:
+  - entities:
+    - role: player
+      name: Yandy Díaz
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: '389'
+  uuid: d2fa6573-49e0-452b-9e03-175cfa27d802
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Allen
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '390'
+  uuid: ad4ceced-7df5-4a8c-a8f2-f2d845919924
+  subjects:
+  - entities:
+    - role: player
+      name: Jack Dreyer
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '391'
+  uuid: e7db61d3-b01c-4bbe-9c6a-752d114c06d1
+  subjects:
+  - entities:
+    - role: player
+      name: Justin Wrobleski
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '392'
+  uuid: 7bf443e2-9be9-4661-a557-821339554819
+  subjects:
+  - entities:
+    - role: player
+      name: Xavier Edwards
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: '393'
+  uuid: d80a4add-c726-4752-93e2-57a08432a228
+  subjects:
+  - entities:
+    - role: player
+      name: Jazz Chisholm Jr.
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '394'
+  uuid: ab60c7b1-b4fd-4905-aab2-76a7b5269bca
+  subjects:
+  - entities:
+    - role: player
+      name: Eric Wagaman
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: '395'
+  uuid: 105f4926-5c62-4e62-aff7-12e19de2b036
+  subjects:
+  - entities:
+    - role: player
+      name: Josh Naylor
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: '396'
+  uuid: d7a9b8b6-5a0a-4468-aafc-2a0f05e6d419
+  subjects:
+  - entities:
+    - role: player
+      name: Raisel Iglesias
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: '397'
+  uuid: 44893356-f53c-4a17-b4af-8a728972ccb0
+  subjects:
+  - entities:
+    - role: player
+      name: Jordan Lawlar
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: '398'
+  uuid: 6cc646fe-6287-4877-b831-0ebf8b622b0f
+  subjects:
+  - entities:
+    - role: player
+      name: Hunter Barco
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '399'
+  uuid: ed0a4037-6393-4bb5-b80d-ede4f1aab32b
+  subjects:
+  - entities:
+    - role: player
+      name: Javier Sanoja
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: '400'
+  uuid: 4e91e913-b4ea-43c1-bba5-459736eb87d5
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Alonso
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '401'
+  uuid: '06908c34-104e-404a-b8b8-b94b37a2c622'
+  subjects:
+  - entities:
+    - role: player
+      name: Eduarniel Núñez
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: '402'
+  uuid: 96b5fc37-371c-444a-ab10-080f9efd62a0
+  subjects:
+  - entities:
+    - role: player
+      name: Anthony Santander
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '403'
+  uuid: 955dc877-a982-4634-9d99-eddb4f499816
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Johnson
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: '404'
+  uuid: a000abf2-3c07-4fc6-b812-b69afe05d0dd
+  subjects:
+  - entities:
+    - role: player
+      name: Parker Meadows
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '405'
+  uuid: 06af8310-fa9f-4ff2-8df3-3749ec74be09
+  subjects:
+  - entities:
+    - role: player
+      name: PJ Poulin
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: '406'
+  uuid: 3dfdac55-b420-404e-a372-7bc61c9f2fb9
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Eldridge
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '407'
+  uuid: 4ff849de-cf40-4121-9974-8a51c57ac2e0
+  subjects:
+  - entities:
+    - role: player
+      name: Hurston Waldrep
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: '408'
+  uuid: 5c41a9ee-e337-4f1a-9751-d1fd7bfa9c66
+  subjects:
+  - entities:
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: '409'
+  uuid: 01e8b0b8-eed8-4227-8c23-85e3d9f9f26b
+  subjects:
+  - entities:
+    - role: player
+      name: Logan Henderson
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: '410'
+  uuid: 24eb5e9c-bb16-4c72-86b7-f3e58c389715
+  subjects:
+  - entities:
+    - role: player
+      name: Hayden Harris
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: '411'
+  uuid: 90ed3eba-cc86-459d-8a41-7d1e5a4111b9
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Tauchman
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '412'
+  uuid: 35def642-9aa7-48e2-a422-8f2144bce518
+  subjects:
+  - entities:
+    - role: player
+      name: Robert Stephenson
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: '413'
+  uuid: 04b6c9a3-922a-428b-a666-313ce80521ee
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Burrows
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '414'
+  uuid: 18c7eb75-49bc-4aa2-9c84-20e1ea537fd1
+  subjects:
+  - entities:
+    - role: player
+      name: Andy Pages
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '415'
+  uuid: 4542015d-58ff-4d35-8d2b-77b344ba5c22
+  subjects:
+  - entities:
+    - role: player
+      name: Justin Verlander
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '416'
+  uuid: b3e8dd79-45c8-408b-8272-4e0f1c0e20ed
+  subjects:
+  - entities:
+    - role: player
+      name: Austin Martin
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: '417'
+  uuid: 7777802d-0981-420e-b256-23ddeb64331b
+  subjects:
+  - entities:
+    - role: player
+      name: Eduardo Rodriguez
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: '418'
+  uuid: 7f84f83e-7375-4f08-93b0-2537fd920011
+  subjects:
+  - entities:
+    - role: player
+      name: Cade Cavalli
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: '419'
+  uuid: 6335d4e0-de32-4c11-8c1d-70933bc557d1
+  subjects:
+  - entities:
+    - role: player
+      name: Jared Jones
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '420'
+  uuid: 4d859781-3cdc-4ba4-a422-80bd3b096393
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Arraez
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '421'
+  uuid: 6e557520-d11b-4415-b54c-0f39029754c1
+  subjects:
+  - entities:
+    - role: player
+      name: Taylor Walls
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: '422'
+  uuid: 140a024b-8c0e-4f21-a763-bd0a1b5c1e9f
+  subjects:
+  - entities:
+    - role: player
+      name: Shane Bieber
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '423'
+  uuid: 7616f7ba-138d-4298-877c-7feb969c84cb
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Robert Jr.
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '424'
+  uuid: c6e3cf09-fab0-42da-935f-76f0a39adc8d
+  subjects:
+  - entities:
+    - role: player
+      name: Zack Gelof
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: '425'
+  uuid: 2beaaa16-ec21-42a3-a450-6e2d0a369fb5
+  subjects:
+  - entities:
+    - role: player
+      name: Trent Grisham
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '426'
+  uuid: 672aee95-496a-4719-8e40-65432241bf5a
+  subjects:
+  - entities:
+    - role: player
+      name: Matt Wallner
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: '427'
+  uuid: 948c105e-b72e-4e37-942c-26806c9ded3c
+  subjects:
+  - entities:
+    - role: player
+      name: Chris Sale
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: '428'
+  uuid: 4c90dd2b-f3f1-480c-babe-b73659e306cb
+  subjects:
+  - entities:
+    - role: player
+      name: Kris Bryant
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: '429'
+  uuid: 13ffce85-ce56-45a6-b716-049227bc4726
+  subjects:
+  - entities:
+    - role: player
+      name: Logan Allen
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '430'
+  uuid: ed7b120b-d68a-490c-9b18-7581ad1e1d77
+  subjects:
+  - entities:
+    - role: player
+      name: Tyler Locklear
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: '431'
+  uuid: 91792bbb-ef94-4c64-920f-ab24aeefcee0
+  subjects:
+  - entities:
+    - role: player
+      name: Randy Arozarena
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: '432'
+  uuid: 8fc9e7bc-0adc-4e7d-bdf0-696bae405524
+  subjects:
+  - entities:
+    - role: player
+      name: Ryan Feltner
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: '433'
+  uuid: bee7a9af-eb11-41ec-bfba-012e5410931f
+  subjects:
+  - entities:
+    - role: player
+      name: Tyler O'Neill
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '434'
+  uuid: e82082aa-5b53-49c0-9874-600055b8ce2e
+  subjects:
+  - entities:
+    - role: player
+      name: Graham Pauley
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: '435'
+  uuid: 8ff4728a-fed0-4811-8630-333613f9e96d
+  subjects:
+  - entities:
+    - role: player
+      name: Denzer Guzman
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: '436'
+  uuid: ee8e455c-eedf-4391-85c7-d0c7dca3aedd
+  subjects:
+  - entities:
+    - role: player
+      name: Mitch Keller
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '437'
+  uuid: 111b8529-2f56-4266-8755-b5a09b4630bf
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Castellanos
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: '438'
+  uuid: ca165789-2ac4-42cd-b522-c6fe5f9f04eb
+  subjects:
+  - entities:
+    - role: player
+      name: Jake Cronenworth
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: '439'
+  uuid: f3a5f46b-5491-43e6-8b6e-1caa0c9919b4
+  subjects:
+  - entities:
+    - role: player
+      name: Gleyber Torres
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '440'
+  uuid: 51233130-3150-4e77-a0df-65dfec86e731
+  subjects:
+  - entities:
+    - role: player
+      name: Ranger Suárez
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '441'
+  uuid: 57ac68da-3be4-45ac-9f15-eddc45bd6aaf
+  subjects:
+  - entities:
+    - role: player
+      name: Lars Nootbaar
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: '442'
+  uuid: 6a68a87e-a693-4a5c-8f5d-bd33e721cfed
+  subjects:
+  - entities:
+    - role: player
+      name: Ryan O'Hearn
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '443'
+  uuid: a592c455-2be7-4c0b-b959-4cc866cae18a
+  subjects:
+  - entities:
+    - role: player
+      name: Kazuma Okamoto
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '444'
+  uuid: 5089eb52-f862-46d9-89b8-225ac102bc76
+  subjects:
+  - entities:
+    - role: player
+      name: Tanner Gordon
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: '445'
+  uuid: d696a6f0-95f2-42ea-a0b7-4f61b93d813e
+  subjects:
+  - entities:
+    - role: player
+      name: Michael Massey
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: '446'
+  uuid: 81493cb0-2fed-4f4b-9174-a00d84247eb6
+  subjects:
+  - entities:
+    - role: player
+      name: Eugenio Suárez
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '447'
+  uuid: 0205f29d-ad33-4b01-8db2-2c34df08621e
+  subjects:
+  - entities:
+    - role: player
+      name: Joe Boyle
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: '448'
+  uuid: 9257069c-7b86-4e43-b5fc-2c1d27fa4ecc
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Chourio
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: '449'
+  uuid: 0cf41725-b1ac-4a95-adcc-28707fa1437e
+  subjects:
+  - entities:
+    - role: player
+      name: Sandy Alcantara
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: '450'
+  uuid: e6f1f881-a44a-409d-85df-7f095bc9e46b
+  subjects:
+  - entities:
+    - role: player
+      name: Gerrit Cole
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '451'
+  uuid: 8e6cee40-6d54-4e77-9e60-2296ae13da16
+  subjects:
+  - entities:
+    - role: player
+      name: Jake Burger
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: '452'
+  uuid: 1a47cc52-c396-45ac-a06c-d9fa2a8ae355
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Loftin
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: '453'
+  uuid: 1371587d-2619-44e2-aeee-3359ab395f3d
+  subjects:
+  - entities:
+    - role: player
+      name: Chase Dollander
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: '454'
+  uuid: 5306160f-510b-40e1-bb43-cae4caa8ecf2
+  subjects:
+  - entities:
+    - role: player
+      name: Josh Hader
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '455'
+  uuid: 156ba962-607e-4fed-ad09-c846583fe605
+  subjects:
+  - entities:
+    - role: player
+      name: George Springer
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '456'
+  uuid: d2618c48-2166-4f64-a44b-2e6b85d38321
+  subjects:
+  - entities:
+    - role: player
+      name: Justin Dean
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '457'
+  uuid: e1de4f75-7c56-4f6e-a5f6-d9d7f493ad22
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Yorke
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '458'
+  uuid: 5a33c9e8-625e-49bf-b24f-885a588e62c5
+  subjects:
+  - entities:
+    - role: player
+      name: Chase DeLauter
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '459'
+  uuid: c8cf47f0-163d-4b29-b3e7-86fd48fde5f9
+  subjects:
+  - entities:
+    - role: player
+      name: Ketel Marte
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: '460'
+  uuid: 978c3e86-3f35-45c6-ad4c-81ba2400fdf2
+  subjects:
+  - entities:
+    - role: player
+      name: Adrian Del Castillo
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: '461'
+  uuid: 95dd78e6-6546-4884-991c-4410600102fe
+  subjects:
+  - entities:
+    - role: player
+      name: Noah Cameron
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: '462'
+  uuid: 3cb02ded-d4cf-4f23-a1a3-fddbe71c4298
+  subjects:
+  - entities:
+    - role: player
+      name: Andrés Chaparro
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: '463'
+  uuid: '08836221-b7ff-4619-8b5b-5d86b992e1fa'
+  subjects:
+  - entities:
+    - role: player
+      name: Aaron Nola
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: '464'
+  uuid: 2fa774cd-3706-4bb1-9377-f24ec7dfb34d
+  subjects:
+  - entities:
+    - role: player
+      name: Triston Casas
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '465'
+  uuid: 62a522ba-7bdd-4c09-9cdf-9d1a2c3d03f8
+  subjects:
+  - entities:
+    - role: player
+      name: Lourdes Gurriel Jr.
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: '466'
+  uuid: a2c27912-73b6-4e7f-8ee9-1d296879d02c
+  subjects:
+  - entities:
+    - role: player
+      name: Trevor McDonald
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '467'
+  uuid: b68e2b2e-1c86-49d3-9054-6e66448eed8b
+  subjects:
+  - entities:
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '468'
+  uuid: b8c09117-a7ff-4b89-9c69-4e78f6d3bea1
+  subjects:
+  - entities:
+    - role: player
+      name: Yordan Alvarez
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '469'
+  uuid: 47ebc10e-c489-4f7c-837c-0f96176a8128
+  subjects:
+  - entities:
+    - role: player
+      name: Jonathan Pintaro
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '470'
+  uuid: 07764bcb-067f-4602-92c3-19868bc47894
+  subjects:
+  - entities:
+    - role: player
+      name: Brandon Nimmo
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: '471'
+  uuid: 6ddee7fb-8042-434e-8554-c67a1a84a2da
+  subjects:
+  - entities:
+    - role: player
+      name: J.P. Crawford
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: '472'
+  uuid: b4ed10c8-222e-4db4-8175-788730d08483
+  subjects:
+  - entities:
+    - role: player
+      name: Christian Koss
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '473'
+  uuid: 61455784-8a78-4504-821c-1f3639c097f9
+  subjects:
+  - entities:
+    - role: player
+      name: Bo Bichette
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '474'
+  uuid: 82bfedfd-f756-40b6-89d8-f00e06b2af68
+  subjects:
+  - entities:
+    - role: player
+      name: Joel Peguero
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '475'
+  uuid: 152816ce-d702-4134-9647-bf1c4c7ff57d
+  subjects:
+  - entities:
+    - role: player
+      name: Shane Baz
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '476'
+  uuid: 32e41dfe-3f98-4f22-ba7f-9a71c8b26972
+  subjects:
+  - entities:
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: '477'
+  uuid: 63dee669-d6dc-4648-a39f-632733ed058f
+  subjects:
+  - entities:
+    - role: player
+      name: Jesús Sánchez
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '478'
+  uuid: eba6cc8a-1870-461b-a2a6-fafa2b154265
+  subjects:
+  - entities:
+    - role: player
+      name: Tyler Wells
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '479'
+  uuid: 1ca2b2dd-a68e-42a7-8563-578979a0ce94
+  subjects:
+  - entities:
+    - role: player
+      name: Aaron Judge
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '480'
+  uuid: 11920639-2ecc-4071-8fcc-7c15f7f31757
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Torrens
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '481'
+  uuid: e1127ff5-eac3-49fc-88e2-45f6b4168357
+  subjects:
+  - entities:
+    - role: player
+      name: Tyrone Taylor
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '482'
+  uuid: e2cb3bbc-bfa7-4dc0-9c27-bf7ebd11beec
+  subjects:
+  - entities:
+    - role: player
+      name: Alek Thomas
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: '483'
+  uuid: 48356958-a04d-44a2-8bff-93c62c1d61d9
+  subjects:
+  - entities:
+    - role: player
+      name: Logan O'Hoppe
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: '484'
+  uuid: c4969f16-f9e1-41d4-af2d-489e4fad593e
+  subjects:
+  - entities:
+    - role: player
+      name: Cole Ragans
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: '485'
+  uuid: 4eb7e08b-c043-4851-86fe-3dd18fedc3cd
+  subjects:
+  - entities:
+    - role: player
+      name: Jake Mangum
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '486'
+  uuid: 2f1292fb-0387-4d06-ac3b-f14ab555a1da
+  subjects:
+  - entities:
+    - role: player
+      name: Justin Steele
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '487'
+  uuid: 7a797d63-0a3c-4b6a-80b8-129f7a319466
+  subjects:
+  - entities:
+    - role: player
+      name: Jake Irvin
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: '488'
+  uuid: 1fd09dbc-1656-433f-b674-61822d9300ad
+  subjects:
+  - entities:
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '489'
+  uuid: 3414d1b5-33a5-48bd-be16-a365c77ba60d
+  subjects:
+  - entities:
+    - role: player
+      name: James Outman
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: '490'
+  uuid: 9b0e06eb-e598-4111-b4bf-f439ee2b6854
+  subjects:
+  - entities:
+    - role: player
+      name: Oswaldo Cabrera
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '491'
+  uuid: bee97126-28ac-4be0-8e2f-10eed8fb6106
+  subjects:
+  - entities:
+    - role: team
+      name: Minnesota Twins
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: '492'
+  uuid: a0ca18b8-52a9-4b02-a6e3-554908a17843
+  subjects:
+  - entities:
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '493'
+  uuid: df3b8948-388a-4862-b17b-5c8070ab9d76
+  subjects:
+  - entities:
+    - role: player
+      name: George Kirby
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: '494'
+  uuid: 29c50709-1ee1-44f5-a298-63c816fd8797
+  subjects:
+  - entities:
+    - role: player
+      name: Jake Palisch
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: '495'
+  uuid: 636277ac-f57d-4fb5-a582-60bae10532b3
+  subjects:
+  - entities:
+    - role: player
+      name: Christian Walker
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '496'
+  uuid: b710ffb7-57b5-43d8-ae7d-c72be9ecfc67
+  subjects:
+  - entities:
+    - role: team
+      name: San Francisco Giants
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '497'
+  uuid: f46fa08e-a201-4e49-adab-5b708fd5a683
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Leahy
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: '498'
+  uuid: d6a7bcef-1e7e-46e3-8659-5511b725316f
+  subjects:
+  - entities:
+    - role: player
+      name: Ryan Helsley
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '499'
+  uuid: dbe375c3-3bdc-474e-99a6-fa9cffd44c0a
+  subjects:
+  - entities:
+    - role: player
+      name: James Wood
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: '500'
+  uuid: 8ac63298-8d5d-4fdf-ae49-d3f8c5f551ac
+  subjects:
+  - entities:
+    - role: player
+      name: Shohei Ohtani
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '501'
+  uuid: 6e348378-7522-4904-a6ad-5db5dc7bc6dd
+  subjects:
+  - entities:
+    - role: player
+      name: Connelly Early
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '502'
+  uuid: 76bab1d4-131f-4256-9dc0-545a084b92ad
+  subjects:
+  - entities:
+    - role: player
+      name: Miguel Rojas
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '503'
+  uuid: 6fccd4d2-545a-4aa9-bad7-7652e555237a
+  subjects:
+  - entities:
+    - role: player
+      name: Munetaka Murakami
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: '504'
+  uuid: 424e4203-4324-404f-b01e-e3b5ab383276
+  subjects:
+  - entities:
+    - role: player
+      name: Tanner Houck
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '505'
+  uuid: 326a3d3e-0513-4cdb-931a-3a5d0d576b2f
+  subjects:
+  - entities:
+    - role: player
+      name: Ernie Clement
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '506'
+  uuid: dd57e2f1-8eff-4494-8f43-e15bfaa1e83b
+  subjects:
+  - entities:
+    - role: player
+      name: Edwin Díaz
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '507'
+  uuid: b9a7ca04-f8d9-42d0-9326-c137eca59933
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Castillo
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: '508'
+  uuid: 959c1222-e1e2-4531-bb87-5e1ec5a1373b
+  subjects:
+  - entities:
+    - role: team
+      name: Colorado Rockies
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: '509'
+  uuid: 69a48090-1341-448c-8066-2e4c34dcf002
+  subjects:
+  - entities:
+    - role: player
+      name: Pablo López
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: '510'
+  uuid: e86559a4-eb94-45cf-89c1-aa406310bc9e
+  subjects:
+  - entities:
+    - role: player
+      name: Philip Abner
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: '511'
+  uuid: a56f7788-b0f4-493b-9fa8-9b3648b5d7c9
+  subjects:
+  - entities:
+    - role: player
+      name: Jayvien Sandridge
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: '512'
+  uuid: b8aaff70-aca1-4fcd-9ef6-1d07a606e53f
+  subjects:
+  - entities:
+    - role: player
+      name: Simeon Woods Richardson
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: '513'
+  uuid: 6ad0b734-12ce-40ce-8336-db2bc3afa533
+  subjects:
+  - entities:
+    - role: player
+      name: Tatsuya Imai
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '514'
+  uuid: 7f0b44b5-d223-443f-a033-f8656295224c
+  subjects:
+  - entities:
+    - role: player
+      name: Zac Veen
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: '515'
+  uuid: 5353611a-eff1-4c4b-8ad0-1116b80b26b8
+  subjects:
+  - entities:
+    - role: player
+      name: Blaze Alexander
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '516'
+  uuid: 6e1200c1-18c9-4d25-a666-776079cfe461
+  subjects:
+  - entities:
+    - role: player
+      name: Korey Lee
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: '517'
+  uuid: 34f87c9a-d619-41dc-9072-5ebd5532cb57
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Trout
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: '518'
+  uuid: 6591cbf6-1a05-47b7-8cff-ddafddc6af3d
+  subjects:
+  - entities:
+    - role: player
+      name: Brandon Woodruff
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: '519'
+  uuid: d3c8cd73-9cbb-4d32-9ac3-fe663c7337b7
+  subjects:
+  - entities:
+    - role: player
+      name: Ramón Laureano
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: '520'
+  uuid: a20702f3-99f3-470f-b65f-581befe7367e
+  subjects:
+  - entities:
+    - role: player
+      name: Andrew Alvarez
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: '521'
+  uuid: ff9b4359-e37b-4788-ac75-31cbf727d23e
+  subjects:
+  - entities:
+    - role: player
+      name: Henry Davis
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '522'
+  uuid: 71b49f04-f823-49a9-b782-65ee8b2f6843
+  subjects:
+  - entities:
+    - role: team
+      name: Miami Marlins
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: '523'
+  uuid: bd2a6692-263d-41d3-bda6-214b953a5e07
+  subjects:
+  - entities:
+    - role: player
+      name: Heston Kjerstad
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '524'
+  uuid: 6239e2aa-c7d1-457f-97aa-fb00f5c687be
+  subjects:
+  - entities:
+    - role: player
+      name: Emmet Sheehan
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '525'
+  uuid: e1811afb-e0d2-4610-ab57-617687efdf8c
+  subjects:
+  - entities:
+    - role: team
+      name: Seattle Mariners
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: '526'
+  uuid: b66e5027-b578-4c16-ada3-641c5e04c7b2
+  subjects:
+  - entities:
+    - role: player
+      name: Masyn Winn
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: '527'
+  uuid: 20d094b7-55fa-4fd9-a71f-652e9a288cfa
+  subjects:
+  - entities:
+    - role: player
+      name: Maikel Garcia
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: '528'
+  uuid: 227b1050-1b1b-4070-9787-0e4b2bdde783
+  subjects:
+  - entities:
+    - role: player
+      name: Jared Triolo
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '529'
+  uuid: 4ef201bc-17cf-4183-b277-2ff629f7e09e
+  subjects:
+  - entities:
+    - role: player
+      name: Griffin Conine
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: '530'
+  uuid: 8e6c7296-c747-4f18-b6d5-f890afcdd3e1
+  subjects:
+  - entities:
+    - role: player
+      name: Carter Jensen
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: '531'
+  uuid: d003f99e-1705-4865-80f7-1bb95f1a6717
+  subjects:
+  - entities:
+    - role: player
+      name: Alejandro Carrillo
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '532'
+  uuid: 5aeb61ff-7261-445b-a1bc-8aa871c89b24
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Jobe
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '533'
+  uuid: ab06ddd3-9403-4911-bb6d-3fabd21e94db
+  subjects:
+  - entities:
+    - role: player
+      name: Jasson Domínguez
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '534'
+  uuid: 42bafcee-3c59-430a-bc6c-74b55ad85ce3
+  subjects:
+  - entities:
+    - role: player
+      name: Brandon Sproat
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: '535'
+  uuid: 8d3fca3f-edf1-41c8-acda-b2b9c451d1de
+  subjects:
+  - entities:
+    - role: player
+      name: Javier Assad
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '536'
+  uuid: 155ee6c9-c438-48dc-845a-3986ac093541
+  subjects:
+  - entities:
+    - role: player
+      name: Trevor Story
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '537'
+  uuid: c0a36594-fe42-49d7-8ab8-61066dd56bde
+  subjects:
+  - entities:
+    - role: player
+      name: Jameson Taillon
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '538'
+  uuid: d5671c58-90f9-45eb-8863-d609fbea3149
+  subjects:
+  - entities:
+    - role: player
+      name: Tommy Nance
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '539'
+  uuid: 31d5c57e-be80-4a58-a118-83be7459fe12
+  subjects:
+  - entities:
+    - role: player
+      name: Lucas Erceg
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: '540'
+  uuid: 42441710-b1a2-4bf2-9e3e-7ed0df72de60
+  subjects:
+  - entities:
+    - role: player
+      name: Ryan Walker
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '541'
+  uuid: b2c4ea1b-0de0-44a9-a0fe-c3c3f9aac6b9
+  subjects:
+  - entities:
+    - role: player
+      name: Jung Hoo Lee
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '542'
+  uuid: b03d4860-86ca-4748-94ca-88dc7c132147
+  subjects:
+  - entities:
+    - role: player
+      name: Joey Ortiz
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: '543'
+  uuid: 1ce5ff90-27f1-4f16-9ad9-a9f4750eaac6
+  subjects:
+  - entities:
+    - role: player
+      name: Jonny DeLuca
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: '544'
+  uuid: 3854bc0d-726f-4bb7-9a03-6f80805ada3a
+  subjects:
+  - entities:
+    - role: player
+      name: Kutter Crawford
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '545'
+  uuid: 8ab3092c-dd89-4435-990e-8a09085ab4c0
+  subjects:
+  - entities:
+    - role: player
+      name: Austin Hedges
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '546'
+  uuid: 60d9fb62-4006-403c-85ff-4855e6067ba7
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Fortes
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: '547'
+  uuid: bbd0abd1-bb53-43c6-826b-131ce443a2a3
+  subjects:
+  - entities:
+    - role: player
+      name: Dylan Cease
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '548'
+  uuid: f228e8f3-63ee-4b87-a16d-36f267799dfa
+  subjects:
+  - entities:
+    - role: player
+      name: Steven Kwan
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '549'
+  uuid: 87c2c839-1a2a-4f80-965e-d067e25798b1
+  subjects:
+  - entities:
+    - role: player
+      name: Daylen Lile
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: '550'
+  uuid: d739d242-e751-4722-94a1-fa817d32829c
+  subjects:
+  - entities:
+    - role: player
+      name: Dansby Swanson
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '551'
+  uuid: 5b2c537d-2aeb-4326-8fcc-f0440063b196
+  subjects:
+  - entities:
+    - role: player
+      name: Taylor Ward
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '552'
+  uuid: a6557fd3-1ba6-40a9-a578-ec96a98e0d4f
+  subjects:
+  - entities:
+    - role: player
+      name: Merrill Kelly
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: '553'
+  uuid: fb2224fb-1feb-489f-b82f-83577cb44cef
+  subjects:
+  - entities:
+    - role: player
+      name: Elly De La Cruz
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '554'
+  uuid: dca73710-9169-485e-81d9-3b5309750a44
+  subjects:
+  - entities:
+    - role: player
+      name: Ezequiel Duran
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: '555'
+  uuid: ab6b54c2-06fe-4e8b-bd10-6dad00977011
+  subjects:
+  - entities:
+    - role: player
+      name: Cade Povich
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '556'
+  uuid: 432987a0-b9c7-4b13-9c41-2cb2c5345e75
+  subjects:
+  - entities:
+    - role: player
+      name: Lance McCullers Jr.
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '557'
+  uuid: f6539b83-9d41-4fd8-bdbe-bb59a278298d
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Higashioka
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: '558'
+  uuid: 9f704bc7-9c92-4f46-bb3d-c1d0ecad7c94
+  subjects:
+  - entities:
+    - role: player
+      name: Michael King
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: '559'
+  uuid: eba46aba-417a-4084-8c86-319047d90074
+  subjects:
+  - entities:
+    - role: player
+      name: JP Sears
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: '560'
+  uuid: c0ef7e5f-3540-4e3e-ad54-1f517647549b
+  subjects:
+  - entities:
+    - role: player
+      name: Jarren Duran
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '561'
+  uuid: d7dd6758-2b70-45c5-b6db-2d37891ca7b4
+  subjects:
+  - entities:
+    - role: player
+      name: Matt Chapman
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '562'
+  uuid: e57e98a2-cfbc-4714-a519-b49f9b036837
+  subjects:
+  - entities:
+    - role: player
+      name: Bryson Stott
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: '563'
+  uuid: 8f120f9f-f27e-4f40-8e81-b72e928d7761
+  subjects:
+  - entities:
+    - role: player
+      name: Ji Hwan Bae
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '564'
+  uuid: f6a983d9-9ff6-4807-aa52-538aa94311e8
+  subjects:
+  - entities:
+    - role: player
+      name: Tyler Soderstrom
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: '565'
+  uuid: 9a562a08-13fb-4c88-b9c3-748367c39557
+  subjects:
+  - entities:
+    - role: player
+      name: Jordan Walker
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: '566'
+  uuid: 3350807e-5f42-4d8a-aa6d-d14f565e6371
+  subjects:
+  - entities:
+    - role: player
+      name: Jack Little
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '567'
+  uuid: f4d61ec9-6f89-47fc-bd90-cdecb3c72c9c
+  subjects:
+  - entities:
+    - role: player
+      name: Thomas Saggese
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: '568'
+  uuid: 645e8370-a188-4d4d-a540-3d5552f9cd00
+  subjects:
+  - entities:
+    - role: player
+      name: Ozzie Albies
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: '569'
+  uuid: 68ec38a3-3353-4d84-a310-28a66b925e14
+  subjects:
+  - entities:
+    - role: player
+      name: Max Scherzer
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '570'
+  uuid: 2b88f96f-a16d-4d43-b8b3-dd00cfc70264
+  subjects:
+  - entities:
+    - role: player
+      name: Rolddy Muñoz
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: '571'
+  uuid: 261566c4-9b22-4ad6-b5e3-8c8d4c19d77c
+  subjects:
+  - entities:
+    - role: player
+      name: Kiké Hernández
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '572'
+  uuid: 2bab7a8b-fad4-48de-aba8-30557eca9da0
+  subjects:
+  - entities:
+    - role: player
+      name: Alan Rangel
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: '573'
+  uuid: bbdb10cc-979f-46b6-bdb9-04be5c273ce8
+  subjects:
+  - entities:
+    - role: player
+      name: Alec Burleson
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: '574'
+  uuid: 6cda2703-961c-4184-ba65-aa103d8a2090
+  subjects:
+  - entities:
+    - role: player
+      name: Andrés Muñoz
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: '575'
+  uuid: c6bfb160-8579-4731-81ef-a57f13f37d21
+  subjects:
+  - entities:
+    - role: player
+      name: Jake Meyers
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '576'
+  uuid: 297c5f09-d92f-46ee-a695-cd5b15d7ad1d
+  subjects:
+  - entities:
+    - role: player
+      name: Jarren Duran
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '577'
+  uuid: 31a4267a-a4c3-4a63-883a-c76a2fe2fcac
+  subjects:
+  - entities:
+    - role: player
+      name: Grayson Rodriguez
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: '578'
+  uuid: 18f8599b-fd08-4b7d-bf1e-f5be669d2990
+  subjects:
+  - entities:
+    - role: player
+      name: Heriberto Hernández
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: '579'
+  uuid: 4a2dd100-59d2-4bac-be65-3c9c863b70aa
+  subjects:
+  - entities:
+    - role: player
+      name: Brandon Lowe
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '580'
+  uuid: c509e500-50a7-445c-bd8b-8b5905776cdb
+  subjects:
+  - entities:
+    - role: player
+      name: Marcell Ozuna
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '581'
+  uuid: be3c215d-89b3-4e53-bdd7-364fa7fb15ab
+  subjects:
+  - entities:
+    - role: player
+      name: Chase Meidroth
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: '582'
+  uuid: 312a02d9-77d1-4788-93fd-ff0f76f1f8c2
+  subjects:
+  - entities:
+    - role: player
+      name: Robert Hassell III
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: '583'
+  uuid: da9f66e6-8759-47d6-981d-99bd3d40462f
+  subjects:
+  - entities:
+    - role: player
+      name: Josh Simpson
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: '584'
+  uuid: 1d5fd8a9-f26d-44ad-a036-4db0bb9b808f
+  subjects:
+  - entities:
+    - role: player
+      name: Moisés Ballesteros
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '585'
+  uuid: 063d91e6-324c-4b62-b452-723472325300
+  subjects:
+  - entities:
+    - role: player
+      name: Ian Happ
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '586'
+  uuid: 680436de-685b-4a10-acad-bdc060a3a1c2
+  subjects:
+  - entities:
+    - role: player
+      name: Marcus Semien
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '587'
+  uuid: 14b88697-584a-4609-a388-b8053fca130c
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan Gorman
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: '588'
+  uuid: 0adccd30-707d-45d2-a86f-c8a83408e518
+  subjects:
+  - entities:
+    - role: player
+      name: Andrés Giménez
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '589'
+  uuid: 77aad52b-6d30-467b-8af9-88f98363308d
+  subjects:
+  - entities:
+    - role: player
+      name: Braxton Ashcraft
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '590'
+  uuid: 55268576-6129-4c08-a236-e9cf39ed6d9f
+  subjects:
+  - entities:
+    - role: player
+      name: Austin Wynns
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: '591'
+  uuid: 6dc67ecf-af7c-4169-88b9-e2ebde967694
+  subjects:
+  - entities:
+    - role: player
+      name: Jahmai Jones
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '592'
+  uuid: 074b3150-f61c-41ae-950a-7223ec264f58
+  subjects:
+  - entities:
+    - role: player
+      name: Joc Pederson
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: '593'
+  uuid: 83804da5-43ba-4c6c-b13d-81bf69c27ebf
+  subjects:
+  - entities:
+    - role: player
+      name: Sal Frelick
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: '594'
+  uuid: c886cb46-e7a0-4b64-82a1-bba1320e129b
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Gil
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '595'
+  uuid: 8b469a3f-e477-4ce6-bd3a-efdfe1c42311
+  subjects:
+  - entities:
+    - role: player
+      name: McCade Brown
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: '596'
+  uuid: 1ba0c136-995c-4e2b-9c5c-8fd43f57ef57
+  subjects:
+  - entities:
+    - role: player
+      name: Liam Hicks
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: '597'
+  uuid: 550c82f4-8cdd-4694-ad89-c84e9c01dd2d
+  subjects:
+  - entities:
+    - role: player
+      name: Paul Goldschmidt
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '598'
+  uuid: 97b17e7f-333c-45c0-9d1b-783b86848e32
+  subjects:
+  - entities:
+    - role: player
+      name: Jack Winkler
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '599'
+  uuid: 60f5d3a6-985f-473e-8f30-76d360f674fa
+  subjects:
+  - entities:
+    - role: player
+      name: Cristian Javier
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '600'
+  uuid: fb040772-d564-4e98-8b3b-20e6352ea381
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '601'
+  uuid: 99eadc16-1143-4165-bfe1-619c17c385f4
+  subjects:
+  - entities:
+    - role: player
+      name: Zach Cole
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '602'
+  uuid: cb0d2869-29b3-453d-a97b-dafd9385aa07
+  subjects:
+  - entities:
+    - role: player
+      name: Shane McClanahan
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: '603'
+  uuid: 135a4c4d-5a77-459f-963e-06d2a8d945be
+  subjects:
+  - entities:
+    - role: player
+      name: George Valera
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '604'
+  uuid: c3605898-298c-4afe-a70e-5aec7864248d
+  subjects:
+  - entities:
+    - role: player
+      name: Jake Bauers
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: '605'
+  uuid: 14ee693f-2d02-4ca5-8d9f-40375a397eb3
+  subjects:
+  - entities:
+    - role: player
+      name: Xander Bogaerts
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: '606'
+  uuid: 69094190-1bb8-4b14-a4f9-284000fb1a0e
+  subjects:
+  - entities:
+    - role: player
+      name: Zebby Matthews
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: '607'
+  uuid: 0ff51d26-2a02-4e2b-a92d-0f29ddabbd21
+  subjects:
+  - entities:
+    - role: player
+      name: Cody Bellinger
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '608'
+  uuid: 96ac8822-21bc-4482-b380-d9f102e388ee
+  subjects:
+  - entities:
+    - role: player
+      name: Cody Laweryson
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: '609'
+  uuid: 1f461218-fabe-401a-975e-dec369804d01
+  subjects:
+  - entities:
+    - role: player
+      name: Mitch Farris
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: '610'
+  uuid: c0149144-8dd9-416d-89ee-47956e9aef79
+  subjects:
+  - entities:
+    - role: player
+      name: Brooks Lee
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: '611'
+  uuid: 915b40fa-b8ca-461b-9abf-db1e986a6650
+  subjects:
+  - entities:
+    - role: player
+      name: Paul Gervase
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '612'
+  uuid: e323be1a-b905-4257-9676-2a2922234064
+  subjects:
+  - entities:
+    - role: player
+      name: José Fermín
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: '613'
+  uuid: 2e6ad535-1d33-4ab4-bd1b-6708d5fb178e
+  subjects:
+  - entities:
+    - role: player
+      name: Jordan Westburg
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '614'
+  uuid: 741a6384-076d-4ba5-a42b-4bf26b242fdc
+  subjects:
+  - entities:
+    - role: player
+      name: Manny Machado
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: '615'
+  uuid: cf61ee5b-662d-4733-875c-f177309e54f8
+  subjects:
+  - entities:
+    - role: player
+      name: Taylor Rashi
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: '616'
+  uuid: '08dc8dde-8f23-4091-bb32-669c7f6ccfbf'
+  subjects:
+  - entities:
+    - role: player
+      name: Hoby Milner
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '617'
+  uuid: 6ea82839-2af9-42d3-abd3-59aee8deb6ef
+  subjects:
+  - entities:
+    - role: player
+      name: Caden Dana
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: '618'
+  uuid: f33623a1-82f2-495e-98c0-edaf1f2cc65b
+  subjects:
+  - entities:
+    - role: player
+      name: Tanner Bibee
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '619'
+  uuid: e4c5a440-cc55-47af-87bc-d72003697ec9
+  subjects:
+  - entities:
+    - role: player
+      name: Brooks Baldwin
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: '620'
+  uuid: 22a66065-7b17-4953-9542-250228b73bbd
+  subjects:
+  - entities:
+    - role: player
+      name: Trey Yesavage
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '621'
+  uuid: a3b42c7f-e028-4129-b5a8-578d4bf1596c
+  subjects:
+  - entities:
+    - role: player
+      name: Matthew Liberatore
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: '622'
+  uuid: 6121c5ef-057f-4f14-bd22-9053138987fc
+  subjects:
+  - entities:
+    - role: player
+      name: Cade Smith
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '623'
+  uuid: f8e4b6ff-e026-4170-ae0a-32777608dcb1
+  subjects:
+  - entities:
+    - role: player
+      name: Rafael Flores
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '624'
+  uuid: aa1a3eac-d78e-4e39-a1bc-d95c482b1d25
+  subjects:
+  - entities:
+    - role: player
+      name: Harrison Bader
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '625'
+  uuid: d794f3a5-51da-4433-85d4-a2d0f1bc39a2
+  subjects:
+  - entities:
+    - role: player
+      name: Yoán Moncada
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: '626'
+  uuid: a4a897c8-9b66-40c4-afbb-d12f552cc89a
+  subjects:
+  - entities:
+    - role: player
+      name: Max Muncy
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: '627'
+  uuid: f90fd54a-7373-4c48-8bc9-7f9e39ccbf3c
+  subjects:
+  - entities:
+    - role: player
+      name: Gustavo Campero
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: '628'
+  uuid: 25ae8bc7-3288-4ee4-b124-6ba698ee17ee
+  subjects:
+  - entities:
+    - role: team
+      name: New York Yankees
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '629'
+  uuid: bc18790f-d6af-4ce7-b806-cceb4a4ef99c
+  subjects:
+  - entities:
+    - role: player
+      name: Tyler Glasnow
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '630'
+  uuid: c261a171-70c6-4100-9a70-e4c2be063fa9
+  subjects:
+  - entities:
+    - role: player
+      name: Corbin Burnes
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: '631'
+  uuid: 57e9c242-11a1-4ead-8be7-128d714c1a53
+  subjects:
+  - entities:
+    - role: player
+      name: Will Smith
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '632'
+  uuid: f0feeef0-7902-4777-841b-488c362dbf4f
+  subjects:
+  - entities:
+    - role: player
+      name: Cade Horton
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '633'
+  uuid: 8c4f8059-c817-4a3e-a936-bddeb5d23b56
+  subjects:
+  - entities:
+    - role: player
+      name: Salvador Perez
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: '634'
+  uuid: 3e6c2c4c-7131-44bb-bddd-a68d41bfc23d
+  subjects:
+  - entities:
+    - role: player
+      name: Ryan Weathers
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '635'
+  uuid: 55cbb322-f47f-4846-be76-d8e79fb7b048
+  subjects:
+  - entities:
+    - role: player
+      name: Edgar Quero
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: '636'
+  uuid: ea08b6cc-74f7-4306-94f8-a2a2f1514d10
+  subjects:
+  - entities:
+    - role: player
+      name: Joe Musgrove
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: '637'
+  uuid: ca597837-5ef0-438b-af4b-a100566dce70
+  subjects:
+  - entities:
+    - role: player
+      name: Johan Rojas
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: '638'
+  uuid: 90d6e72d-c5f4-4b7b-a8d9-7bd7d7d10856
+  subjects:
+  - entities:
+    - role: player
+      name: Seth Lugo
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: '639'
+  uuid: afc3028d-16d6-4d53-a0b5-d364c9469648
+  subjects:
+  - entities:
+    - role: player
+      name: Reese Olson
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '640'
+  uuid: c297c9cb-1159-4920-b267-b253ce3fd8d4
+  subjects:
+  - entities:
+    - role: team
+      name: Atlanta Braves
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: '641'
+  uuid: 9383f4b9-ed33-40ce-8913-fbcb8fff3e20
+  subjects:
+  - entities:
+    - role: player
+      name: Slade Cecconi
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '642'
+  uuid: dfeee26b-dcd2-4397-8156-b4951faa5ca9
+  subjects:
+  - entities:
+    - role: player
+      name: Yoshinobu Yamamoto
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '643'
+  uuid: e92b3ff2-677a-4e91-a598-21d87da4c085
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Lodolo
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '644'
+  uuid: 05c4583c-4456-4140-a4e1-592487c99c54
+  subjects:
+  - entities:
+    - role: player
+      name: Christian Montes De Oca
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: '645'
+  uuid: 3f0ece16-7858-4725-84be-f56645e94629
+  subjects:
+  - entities:
+    - role: player
+      name: Nasim Nuñez
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: '646'
+  uuid: 7efc37f5-c78f-4bd0-880f-270c33043c7d
+  subjects:
+  - entities:
+    - role: player
+      name: Mark Vientos
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '647'
+  uuid: abf60926-bd85-4bd2-b485-1aa39b96279f
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Bradish
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '648'
+  uuid: a756960a-e408-4181-8da0-a97763f407c4
+  subjects:
+  - entities:
+    - role: player
+      name: Jonathan Cannon
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: '649'
+  uuid: 2b1ca157-1a1f-4252-b88d-037f131f55c3
+  subjects:
+  - entities:
+    - role: player
+      name: Leo Rivas
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: '650'
+  uuid: 42aa6813-0e9b-4458-a174-0d619fa2517c
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Schwarber
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: '651'
+  uuid: 851cb36c-5d10-4028-819e-84519051a9ae
+  subjects:
+  - entities:
+    - role: player
+      name: Abner Uribe
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: '652'
+  uuid: 61019e0e-a22e-492a-8b69-a88cf0471eb9
+  subjects:
+  - entities:
+    - role: player
+      name: Ryan Mountcastle
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '653'
+  uuid: 4f61c8e4-89cb-4a0a-860d-59ab4c8f53c5
+  subjects:
+  - entities:
+    - role: player
+      name: Andruw Monasterio
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '654'
+  uuid: caacf6bf-1115-4cfb-a9b6-8290c9febaa3
+  subjects:
+  - entities:
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '655'
+  uuid: 140e30ea-0b27-45d4-8830-4c842039138f
+  subjects:
+  - entities:
+    - role: player
+      name: Jack Suwinski
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '656'
+  uuid: 4a6da5b7-ca8e-4791-9e69-70b58fe191c5
+  subjects:
+  - entities:
+    - role: player
+      name: Aroldis Chapman
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '657'
+  uuid: 941aeefb-6d78-430d-ab46-e456d7617b44
+  subjects:
+  - entities:
+    - role: player
+      name: Freddy Peralta
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '658'
+  uuid: ab5b18eb-0c4e-4a65-9cd2-bb3c68a66b9c
+  subjects:
+  - entities:
+    - role: player
+      name: Jack Flaherty
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '659'
+  uuid: 0b7cbf0d-cac4-4ec5-a108-bd531319b108
+  subjects:
+  - entities:
+    - role: player
+      name: Harry Ford
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: '660'
+  uuid: 7a1c87a9-f914-458e-9498-065d8b2cc303
+  subjects:
+  - entities:
+    - role: player
+      name: Edouard Julien
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: '661'
+  uuid: 967e874a-6b62-4ae3-83be-999e045f52a6
+  subjects:
+  - entities:
+    - role: team
+      name: Chicago White Sox
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: '662'
+  uuid: a75a2fbc-54cc-4bc9-b6cb-6a03922bab16
+  subjects:
+  - entities:
+    - role: player
+      name: Jeff McNeil
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: '663'
+  uuid: 847ba915-c9e3-4076-a258-ebaab82bd731
+  subjects:
+  - entities:
+    - role: player
+      name: Hyeseong Kim
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '664'
+  uuid: ad21acc2-236a-4653-b46a-a1522362fa8f
+  subjects:
+  - entities:
+    - role: player
+      name: Jayden Murray
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '665'
+  uuid: fbcce2a6-b12c-4059-b015-0e10c319a5d1
+  subjects:
+  - entities:
+    - role: player
+      name: Jose Corniell
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: '666'
+  uuid: e9cd4b62-8401-4c2c-8815-a782a05b9646
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan Hoffman
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: '667'
+  uuid: 5fa165a6-968b-4c30-9fcb-4d29418b5289
+  subjects:
+  - entities:
+    - role: player
+      name: Kodai Senga
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '668'
+  uuid: 85202009-2bd7-4558-b013-b70e8f6fd2d5
+  subjects:
+  - entities:
+    - role: player
+      name: Petey Halpin
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '669'
+  uuid: 9fe4f758-fbad-4373-9f68-b4dcaf21fb97
+  subjects:
+  - entities:
+    - role: player
+      name: Randy Vásquez
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: '670'
+  uuid: 99cfa988-ecf6-4011-9e46-1676715ecaf4
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Harrison
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: '671'
+  uuid: 92f94766-d0e4-4286-aea6-c88870a752a6
+  subjects:
+  - entities:
+    - role: player
+      name: JJ Bleday
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '672'
+  uuid: 9ef2b04e-b0e4-4108-828b-359cb026cfb8
+  subjects:
+  - entities:
+    - role: player
+      name: Yainer Diaz
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '673'
+  uuid: 151d288d-de98-4466-af7a-0f4562b843f5
+  subjects:
+  - entities:
+    - role: player
+      name: Reynaldo López
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: '674'
+  uuid: 2c7a73fa-efd0-435d-8b06-7a1069ede7a0
+  subjects:
+  - entities:
+    - role: player
+      name: Andre Granillo
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: '675'
+  uuid: cdac067e-2dca-42c1-9520-fba2783d315a
+  subjects:
+  - entities:
+    - role: player
+      name: Steven Kwan
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '676'
+  uuid: 1e21121b-19d2-4088-800a-5e0d567d0d53
+  subjects:
+  - entities:
+    - role: player
+      name: Jorge Polanco
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '677'
+  uuid: 9fa26ab3-b589-461f-9c78-2934fd9bfc37
+  subjects:
+  - entities:
+    - role: player
+      name: Wilyer Abreu
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '678'
+  uuid: fa41ce50-5e9d-4bee-9c69-884e6a989348
+  subjects:
+  - entities:
+    - role: player
+      name: Darell Hernaiz
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: '679'
+  uuid: 8ff0f8ad-547b-4e4f-a265-9b99f8d977fa
+  subjects:
+  - entities:
+    - role: player
+      name: Cam Sanders
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '680'
+  uuid: 9e43b513-bb8e-4b7b-b3fc-c527d4abbb3d
+  subjects:
+  - entities:
+    - role: player
+      name: Carlos Correa
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '681'
+  uuid: 7a8ebc7e-ef61-4bb3-a059-4d8f2cd49009
+  subjects:
+  - entities:
+    - role: player
+      name: Nathan Lukes
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '682'
+  uuid: 45684917-2a59-47be-a998-c134ae2b65f6
+  subjects:
+  - entities:
+    - role: player
+      name: Wenceel Pérez
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '683'
+  uuid: 9d599f68-4f13-4f7d-8b17-5111e94526da
+  subjects:
+  - entities:
+    - role: player
+      name: Dugan Darnell
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '684'
+  uuid: 6f0e54bc-9a60-41a7-a251-da81738ce734
+  subjects:
+  - entities:
+    - role: player
+      name: Quinn Priester
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: '685'
+  uuid: 63f314c3-2d73-4641-8513-ff69077e4ea5
+  subjects:
+  - entities:
+    - role: player
+      name: Seiya Suzuki
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '686'
+  uuid: b800c2c9-2527-4979-82f2-291fa3470d2c
+  subjects:
+  - entities:
+    - role: player
+      name: Carson Kelly
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '687'
+  uuid: 41654837-fd2e-474f-9fa2-dcaf569ba790
+  subjects:
+  - entities:
+    - role: player
+      name: Noelvi Marte
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '688'
+  uuid: 20945562-6ddf-4b79-8a2b-18b5dd42a0ff
+  subjects:
+  - entities:
+    - role: player
+      name: Blas Castaño
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: '689'
+  uuid: fc5ab57d-4b0f-4e19-9e44-7f71d924f26d
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Isbel
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: '690'
+  uuid: 685c1923-e98b-4b3b-b73f-ef7462967349
+  subjects:
+  - entities:
+    - role: player
+      name: Cedric Mullins
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: '691'
+  uuid: eb443d5c-a5ae-427b-b75b-66655f38b884
+  subjects:
+  - entities:
+    - role: player
+      name: Joey Cantillo
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '692'
+  uuid: 2e6b1870-0540-42d5-b5db-3966c96063ba
+  subjects:
+  - entities:
+    - role: player
+      name: Drake Baldwin
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: '693'
+  uuid: 0b75ccc6-a3df-43cd-b146-d7b67b5a82f1
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Matos
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '694'
+  uuid: 900cda80-6715-4940-8736-86ee4c97651a
+  subjects:
+  - entities:
+    - role: player
+      name: Tyler Anderson
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: '695'
+  uuid: 58e42c2e-8a4f-42ab-9a7b-1efe8a40f682
+  subjects:
+  - entities:
+    - role: player
+      name: Connor Norby
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: '696'
+  uuid: 80f7fb45-c72d-4bde-a25d-6b2876cb9700
+  subjects:
+  - entities:
+    - role: player
+      name: Andrew Hoffmann
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: '697'
+  uuid: d271a1c3-73a6-40ff-81dd-f0dc2e8dc261
+  subjects:
+  - entities:
+    - role: player
+      name: Bryan Reynolds
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '698'
+  uuid: 6782c1fb-8587-4664-a953-cff70dcf0da5
+  subjects:
+  - entities:
+    - role: player
+      name: Andre Pallante
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: '699'
+  uuid: c71e0d4c-cdbd-41f2-8ac2-a4afc6ef23bc
+  subjects:
+  - entities:
+    - role: player
+      name: Jared Young
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '700'
+  uuid: e1034956-7ae7-4846-93f6-5aa7ebafac3f
+  subjects:
+  - entities:
+    - role: player
+      name: Freddie Freeman
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 

--- a/data/baseball/2026-topps-series-2/checklists/heavy-lumber-autograph-relics.yaml
+++ b/data/baseball/2026-topps-series-2/checklists/heavy-lumber-autograph-relics.yaml
@@ -1,0 +1,430 @@
+- number: HL2-ABR
+  uuid: 74896e66-ae64-42d6-8de9-afda67cb674d
+  subjects:
+  - entities:
+    - role: player
+      name: Alex Bregman
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: HL2-AP
+  uuid: a8d13021-ec80-441f-a81a-baf2fada4ae7
+  subjects:
+  - entities:
+    - role: player
+      name: Albert Pujols
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: HL2-AV
+  uuid: 6ce351b5-255f-4cac-ac2a-f6ece36cc409
+  subjects:
+  - entities:
+    - role: player
+      name: Anthony Volpe
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: HL2-BH
+  uuid: 1816b5e0-6caf-47d3-8e6b-2727e28a780a
+  subjects:
+  - entities:
+    - role: player
+      name: Brady House
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: HL2-BL
+  uuid: 542e4681-aee9-4889-9262-f73b02bfeffc
+  subjects:
+  - entities:
+    - role: player
+      name: Barry Larkin
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: HL2-BR
+  uuid: dcfa2572-539b-48a2-b03d-82af7a8b2a7c
+  subjects:
+  - entities:
+    - role: player
+      name: Brent Rooker
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: HL2-DB
+  uuid: 3a7f196b-88aa-4061-9804-e1c8064e65df
+  subjects:
+  - entities:
+    - role: player
+      name: Dylan Beavers
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: HL2-DM
+  uuid: 4d5bf921-418c-4997-911b-b70a57128904
+  subjects:
+  - entities:
+    - role: player
+      name: Don Mattingly
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: HL2-DS
+  uuid: 6f07e7fd-075d-4330-a7ff-3200c2acb9c9
+  subjects:
+  - entities:
+    - role: player
+      name: Darryl Strawberry
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: HL2-ED
+  uuid: 7bf3dfb0-6805-4102-845b-558887e89823
+  subjects:
+  - entities:
+    - role: player
+      name: Eric Davis
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: HL2-EM
+  uuid: 78f6c435-686b-4110-ad9a-8fb5c50d3ec4
+  subjects:
+  - entities:
+    - role: player
+      name: Edgar Martinez
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: HL2-FM
+  uuid: 3c0567b9-5d74-420f-8a9b-b1b1e4bb837c
+  subjects:
+  - entities:
+    - role: player
+      name: Fred McGriff
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: HL2-FMC
+  uuid: 5e7f890a-1424-4961-88c2-b837a385b6c0
+  subjects:
+  - entities:
+    - role: player
+      name: Fred McGriff
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: HL2-FMF
+  uuid: cf993515-c252-430e-a610-2b0d937a9297
+  subjects:
+  - entities:
+    - role: player
+      name: Fred McGriff
+      ref: 
+    - role: team
+      name: Tampa Bay Devil Rays
+      ref: 
+- number: HL2-GSH
+  uuid: 4fed068b-00a6-4a67-83ed-28292463ad1f
+  subjects:
+  - entities:
+    - role: player
+      name: Gary Sheffield
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: HL2-JCA
+  uuid: 43e82936-76d2-4876-bfdc-9a29a7a7566a
+  subjects:
+  - entities:
+    - role: player
+      name: Jose Canseco
+      ref: 
+    - role: team
+      name: Oakland Athletics
+      ref: 
+- number: HL2-JGO
+  uuid: 833b4c84-6e77-4f87-9db1-758950179361
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Gonzalez
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: HL2-JP
+  uuid: e67db84c-3496-4b14-bbe6-705a2f7f26e0
+  subjects:
+  - entities:
+    - role: player
+      name: Jorge Posada
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: HL2-MM
+  uuid: be8fdd8a-75d2-4e5f-8617-5d72fb20ad42
+  subjects:
+  - entities:
+    - role: player
+      name: Mark McGwire
+      ref: 
+    - role: team
+      name: Oakland Athletics
+      ref: 
+- number: HL2-MP
+  uuid: c9823349-b4c5-4d59-a18f-2699b062baa7
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Piazza
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: HL2-MW
+  uuid: 7c57eee7-e5d2-4abc-b267-51700e062839
+  subjects:
+  - entities:
+    - role: player
+      name: Masyn Winn
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: HL2-NK
+  uuid: 8f896d51-b5ac-4ab5-8e2a-0124d19b9adb
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Kurtz
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: HL2-PM
+  uuid: fe65974d-7782-489d-8678-cb497d1b2cde
+  subjects:
+  - entities:
+    - role: player
+      name: Paul Molitor
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: HL2-RG
+  uuid: a5e75d5b-c774-4b86-a0fe-f589effc6c1e
+  subjects:
+  - entities:
+    - role: player
+      name: Riley Greene
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: HL2-RH
+  uuid: 8b65950c-f336-40b3-abaf-d8bfdcb4a7f0
+  subjects:
+  - entities:
+    - role: player
+      name: Ryan Howard
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: HL2-SB
+  uuid: 341dcc7d-b13e-43fc-b57d-2a890f93fd53
+  subjects:
+  - entities:
+    - role: player
+      name: Samuel Basallo
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: HL2-SSU
+  uuid: 65efa2bc-b0fb-4938-bc9c-daea24412635
+  subjects:
+  - entities:
+    - role: player
+      name: Seiya Suzuki
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: HL2-TO
+  uuid: abfdcc8f-fce0-4677-b5fc-21cd3924fccc
+  subjects:
+  - entities:
+    - role: player
+      name: Tony Oliva
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: HL2-WBS
+  uuid: 31efd304-229b-46d2-b58f-7101c775a039
+  subjects:
+  - entities:
+    - role: player
+      name: Wade Boggs
+      ref: 
+    - role: team
+      name: Tampa Bay Devil Rays
+      ref: 
+- number: HL2-WL
+  uuid: 4630af94-9b98-4b5b-8ea1-1f7899d52e20
+  subjects:
+  - entities:
+    - role: player
+      name: Wyatt Langford
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: HLAR-ARD
+  uuid: 1a4c8c42-6219-44a4-9e9d-861478a2d76d
+  subjects:
+  - entities:
+    - role: player
+      name: Alex Rodríguez
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: HLAR-ARI
+  uuid: '05299bfa-6508-4887-8b2f-12a33386b6df'
+  subjects:
+  - entities:
+    - role: player
+      name: Austin Riley
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: HLAR-ARO
+  uuid: f383008d-9aa1-4b16-a5f4-c69ed20eb639
+  subjects:
+  - entities:
+    - role: player
+      name: Alex Rodríguez
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: HLAR-AROD
+  uuid: e61e75b5-d907-497a-ad75-f203021a20f8
+  subjects:
+  - entities:
+    - role: player
+      name: Alex Rodríguez
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: HLAR-DWI
+  uuid: 5f75bebf-822b-4db0-be50-bce3811bf650
+  subjects:
+  - entities:
+    - role: player
+      name: Dave Winfield
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: HLAR-ED
+  uuid: 680e4ee9-0ed1-48c2-95fa-01f4436f4e11
+  subjects:
+  - entities:
+    - role: player
+      name: Elly De La Cruz
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: HLAR-JM
+  uuid: e4b1122d-dea7-449d-8b5b-405486fde781
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Merrill
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: HLAR-LA
+  uuid: 2f7a5ff2-d12c-43b2-bb02-6a8e6cdced64
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Arraez
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: HLAR-MC
+  uuid: 4ad67db2-907e-47d2-b329-13fc431f345a
+  subjects:
+  - entities:
+    - role: player
+      name: Matt Chapman
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: HLAR-MG
+  uuid: 25a25109-4e3c-4f26-b415-c66d4a7c1771
+  subjects:
+  - entities:
+    - role: player
+      name: Mark Grace
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: HLAR-RA
+  uuid: c828fa28-bd7c-4945-afcc-7174aae3e354
+  subjects:
+  - entities:
+    - role: player
+      name: Randy Arozarena
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: HLAR-TH
+  uuid: 9c118562-051b-4d8e-afac-df4ca0e981ec
+  subjects:
+  - entities:
+    - role: player
+      name: Torii Hunter
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: HLAR-WS
+  uuid: fc81eecd-72d7-4153-89fd-5bd518fd49d5
+  subjects:
+  - entities:
+    - role: player
+      name: Will Smith
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 

--- a/data/baseball/2026-topps-series-2/checklists/heavy-lumber.yaml
+++ b/data/baseball/2026-topps-series-2/checklists/heavy-lumber.yaml
@@ -1,0 +1,250 @@
+- number: HL-21
+  uuid: 3f2941af-f536-4e0e-9f14-dba043c96d4a
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: HL-22
+  uuid: 718c5e71-eddc-411c-9c82-e1259b3dff7b
+  subjects:
+  - entities:
+    - role: player
+      name: Julio Rodríguez
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: HL-23
+  uuid: 51cbe991-96d3-4f68-858f-56a31e9fb45d
+  subjects:
+  - entities:
+    - role: player
+      name: Corbin Carroll
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: HL-24
+  uuid: b355110d-ddd0-4818-a8ba-b01287d65991
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Kurtz
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: HL-25
+  uuid: 11d17f86-237d-4184-b335-332fb515630f
+  subjects:
+  - entities:
+    - role: player
+      name: Hank Aaron
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: HL-26
+  uuid: cdf7380e-a117-4b62-b95f-afdcaef309c8
+  subjects:
+  - entities:
+    - role: player
+      name: Gunnar Henderson
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: HL-27
+  uuid: 057fa15b-6e6e-48a6-bf9a-44ae1c8f7c17
+  subjects:
+  - entities:
+    - role: player
+      name: Ted Williams
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: HL-28
+  uuid: d8cd99b5-b646-4de5-9b15-9f1232c451ab
+  subjects:
+  - entities:
+    - role: player
+      name: Jackie Robinson
+      ref: 
+    - role: team
+      name: Brooklyn Dodgers
+      ref: 
+- number: HL-29
+  uuid: bdf4ca59-32f1-41af-a00b-a61a156d1d10
+  subjects:
+  - entities:
+    - role: player
+      name: Seiya Suzuki
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: HL-30
+  uuid: 6a964398-9daa-42e0-a4ab-522478ef4b4b
+  subjects:
+  - entities:
+    - role: player
+      name: Colson Montgomery
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: HL-31
+  uuid: c3a33c6c-37ac-4a8e-93c0-db9030218160
+  subjects:
+  - entities:
+    - role: player
+      name: José Ramírez
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: HL-32
+  uuid: 0e6d6d8c-a1a9-4d2a-8267-0f62f9cf29a7
+  subjects:
+  - entities:
+    - role: player
+      name: Yordan Alvarez
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: HL-33
+  uuid: ef6113c9-705a-4141-b249-d70c1c0c2689
+  subjects:
+  - entities:
+    - role: player
+      name: Freddie Freeman
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: HL-34
+  uuid: fe447b3d-46af-4ce1-800c-9a9bd385a061
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Alonso
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: HL-35
+  uuid: fb958604-e979-4657-8840-45bcfee66358
+  subjects:
+  - entities:
+    - role: player
+      name: Mickey Mantle
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: HL-36
+  uuid: 5de78758-38af-4c6f-a333-87663b7ca1b0
+  subjects:
+  - entities:
+    - role: player
+      name: Derek Jeter
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: HL-37
+  uuid: 43e4b200-4fdd-4bd6-996f-db0ab7ba9d12
+  subjects:
+  - entities:
+    - role: player
+      name: Mark McGwire
+      ref: 
+    - role: team
+      name: Oakland Athletics
+      ref: 
+- number: HL-38
+  uuid: 7ae05d6b-b5af-43b0-99b2-7b1321fffc86
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Schwarber
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: HL-39
+  uuid: 127deb83-f89d-4d7b-9bcf-94a7cdbb9aeb
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Schmidt
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: HL-40
+  uuid: 776c5a44-56fd-4c25-8405-b29c8875682d
+  subjects:
+  - entities:
+    - role: player
+      name: Willie Mays
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: HL-41
+  uuid: 3fe0441e-a1af-4a27-9792-71131c8e17a0
+  subjects:
+  - entities:
+    - role: player
+      name: Munetaka Murakami
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: HL-42
+  uuid: c97044a7-114b-42a9-b412-52abc67a3ee9
+  subjects:
+  - entities:
+    - role: player
+      name: Albert Pujols
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: HL-43
+  uuid: a8058ed2-1d08-489e-99ca-9bc54e745c7e
+  subjects:
+  - entities:
+    - role: player
+      name: Carson Williams
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: HL-44
+  uuid: 65e6d0e7-789e-4821-a668-84a33c5aaa18
+  subjects:
+  - entities:
+    - role: player
+      name: Vladimir Guerrero Jr.
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: HL-45
+  uuid: 2c73c92e-6837-4295-a55c-a809ad77c580
+  subjects:
+  - entities:
+    - role: player
+      name: Roberto Clemente
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 

--- a/data/baseball/2026-topps-series-2/checklists/highlight-reels-autographs.yaml
+++ b/data/baseball/2026-topps-series-2/checklists/highlight-reels-autographs.yaml
@@ -1,0 +1,50 @@
+- number: HR-3
+  uuid: cc21dff3-5749-4625-8407-b1bd0c966d47
+  subjects:
+  - entities:
+    - role: player
+      name: Fernando Tatis Jr.
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: HR-4
+  uuid: c1180df9-135c-4fbb-9907-e5478603a9a1
+  subjects:
+  - entities:
+    - role: player
+      name: Vladimir Guerrero Jr.
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: HR-5
+  uuid: fd3f28a2-4042-465d-a76b-e95a1b0c9043
+  subjects:
+  - entities:
+    - role: player
+      name: Julio Rodríguez
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: HR-6
+  uuid: b2a642fc-b0d8-4042-b23e-7680a341a3ac
+  subjects:
+  - entities:
+    - role: player
+      name: Ronald Acuña Jr.
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: HR-8
+  uuid: a6bde71e-e904-40f0-87d9-f720fd419c64
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Trout
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 

--- a/data/baseball/2026-topps-series-2/checklists/highlight-reels.yaml
+++ b/data/baseball/2026-topps-series-2/checklists/highlight-reels.yaml
@@ -1,0 +1,100 @@
+- number: HR-1
+  uuid: ac15e602-bd6c-45b6-938b-3f52ffb769a0
+  subjects:
+  - entities:
+    - role: player
+      name: Shohei Ohtani
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: HR-2
+  uuid: 88da1450-4cf9-44c8-94d4-28b41ca17694
+  subjects:
+  - entities:
+    - role: player
+      name: Aaron Judge
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: HR-3
+  uuid: 73e85345-3522-4532-8892-e004b070e1b2
+  subjects:
+  - entities:
+    - role: player
+      name: Fernando Tatis Jr.
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: HR-4
+  uuid: 84172e90-5208-405a-b13e-05c66f9fac65
+  subjects:
+  - entities:
+    - role: player
+      name: Vladimir Guerrero Jr.
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: HR-5
+  uuid: ef2e0592-100e-433c-a919-7399cf746004
+  subjects:
+  - entities:
+    - role: player
+      name: Julio Rodríguez
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: HR-6
+  uuid: a560c6c3-4af0-4980-8100-777ba55bb4e2
+  subjects:
+  - entities:
+    - role: player
+      name: Ronald Acuña Jr.
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: HR-7
+  uuid: acb0dea0-281b-4b7e-acd8-973a82322189
+  subjects:
+  - entities:
+    - role: player
+      name: Bobby Witt Jr.
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: HR-8
+  uuid: 42344145-97bb-400e-860b-c60efeae8476
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Trout
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: HR-9
+  uuid: c3f20127-35a3-4b78-9c6e-df9731f58a00
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Crow-Armstrong
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: HR-10
+  uuid: 6db7fc8f-620a-4007-8934-6f5c2d34e5ef
+  subjects:
+  - entities:
+    - role: player
+      name: Roman Anthony
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 

--- a/data/baseball/2026-topps-series-2/checklists/holiday-variations.yaml
+++ b/data/baseball/2026-topps-series-2/checklists/holiday-variations.yaml
@@ -1,0 +1,1000 @@
+- number: '352'
+  uuid: '09c7ee7e-0f7c-4915-9495-a16890de7540'
+  subjects:
+  - entities:
+    - role: player
+      name: Spencer Torkelson
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '355'
+  uuid: 07310e5a-4c8c-4286-b338-7d8e9f2abab0
+  subjects:
+  - entities:
+    - role: player
+      name: Nathan Eovaldi
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: '358'
+  uuid: 486b125a-3c26-44ea-b103-975a7d7dd401
+  subjects:
+  - entities:
+    - role: player
+      name: Adley Rutschman
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '363'
+  uuid: 30fb58d8-a8e1-42ff-9822-eedabb45cfb8
+  subjects:
+  - entities:
+    - role: player
+      name: J.T. Realmuto
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: '365'
+  uuid: 827515fe-48eb-4d5b-8d7e-813645396f09
+  subjects:
+  - entities:
+    - role: player
+      name: Spencer Steer
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '367'
+  uuid: a3bac2b2-c2e0-482e-8e68-ae783ebe14f2
+  subjects:
+  - entities:
+    - role: player
+      name: Robbie Ray
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '368'
+  uuid: 527be037-608a-4b8a-9b72-50045f065cf4
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Tucker
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '371'
+  uuid: 25b714df-46f2-445b-a527-87396db17e83
+  subjects:
+  - entities:
+    - role: player
+      name: Brent Rooker
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: '372'
+  uuid: 19dbc2c2-ae37-4120-8ddf-5fea36713839
+  subjects:
+  - entities:
+    - role: player
+      name: Sal Stewart
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '382'
+  uuid: abd3eca0-9164-47d0-ae5f-2ac45d8ffcc4
+  subjects:
+  - entities:
+    - role: player
+      name: Hunter Greene
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '383'
+  uuid: 2af9d299-9c58-442d-8a1a-4570509e0daf
+  subjects:
+  - entities:
+    - role: player
+      name: Wyatt Langford
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: '386'
+  uuid: 420e6fdd-23a5-42b1-a520-0259676fb73d
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Curvelo
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: '387'
+  uuid: c31a7471-2635-4ea6-9b17-4c109066065b
+  subjects:
+  - entities:
+    - role: player
+      name: Drew Sommers
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '393'
+  uuid: 952cbc62-95ad-4ca4-b156-f7c71d58b11d
+  subjects:
+  - entities:
+    - role: player
+      name: Jazz Chisholm Jr.
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '395'
+  uuid: 5706007f-550d-4323-b045-276cf58e171d
+  subjects:
+  - entities:
+    - role: player
+      name: Josh Naylor
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: '398'
+  uuid: 87039193-acf1-47f8-8b19-41ace30d1054
+  subjects:
+  - entities:
+    - role: player
+      name: Hunter Barco
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '400'
+  uuid: 8d989fb4-9bd2-4bdb-b908-6efc4f8aa3bc
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Alonso
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '406'
+  uuid: ef793658-7b3e-4f5b-a096-d68db03905f8
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Eldridge
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '410'
+  uuid: 37497b91-57c5-4ef2-8727-e69280a89696
+  subjects:
+  - entities:
+    - role: player
+      name: Hayden Harris
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: '415'
+  uuid: c1e39127-9f83-48d7-b39d-107241a05904
+  subjects:
+  - entities:
+    - role: player
+      name: Justin Verlander
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '422'
+  uuid: 8fe070b2-38e1-4a07-8c10-95a31b0f6f70
+  subjects:
+  - entities:
+    - role: player
+      name: Shane Bieber
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '423'
+  uuid: e01da555-ee37-458c-9fb8-dbcf7253fd4c
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Robert Jr.
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '425'
+  uuid: 3c18e7d0-f59f-4108-9de2-36d13e46e30b
+  subjects:
+  - entities:
+    - role: player
+      name: Trent Grisham
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '427'
+  uuid: e1265677-6246-4f8c-9ba4-a288d2d238c4
+  subjects:
+  - entities:
+    - role: player
+      name: Chris Sale
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: '431'
+  uuid: 9997bac2-2df5-45b5-94fc-6bd43bb18210
+  subjects:
+  - entities:
+    - role: player
+      name: Randy Arozarena
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: '435'
+  uuid: 69cd3ab7-d59d-427e-87fb-e7e1d42adf73
+  subjects:
+  - entities:
+    - role: player
+      name: Denzer Guzman
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: '439'
+  uuid: 31cec1c4-1abd-48c4-ab6b-8cc2cc109de4
+  subjects:
+  - entities:
+    - role: player
+      name: Gleyber Torres
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '441'
+  uuid: 8079b126-e27b-4729-b2c8-8630a403f4fe
+  subjects:
+  - entities:
+    - role: player
+      name: Lars Nootbaar
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: '446'
+  uuid: 1fb9196d-2dd0-4136-bfd9-122b40467680
+  subjects:
+  - entities:
+    - role: player
+      name: Eugenio Suárez
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '448'
+  uuid: 262e319f-b9e3-47b8-a31c-f23ac7577718
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Chourio
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: '450'
+  uuid: fc0421bb-1c2f-4181-9686-5d31a72ea62c
+  subjects:
+  - entities:
+    - role: player
+      name: Gerrit Cole
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '455'
+  uuid: 19d77fca-226b-4a07-9bc8-d231a3cf29e6
+  subjects:
+  - entities:
+    - role: player
+      name: George Springer
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '458'
+  uuid: bfeeb385-f17c-413e-9849-090009f6322e
+  subjects:
+  - entities:
+    - role: player
+      name: Chase DeLauter
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '459'
+  uuid: 2272a5ee-c2b3-4544-b852-a0ea5cadc26f
+  subjects:
+  - entities:
+    - role: player
+      name: Ketel Marte
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: '463'
+  uuid: 713d43e2-079f-4aa5-830e-df8d0d402d93
+  subjects:
+  - entities:
+    - role: player
+      name: Aaron Nola
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: '468'
+  uuid: 2ef6a70f-3faa-43ca-ab18-53d2526a5de1
+  subjects:
+  - entities:
+    - role: player
+      name: Yordan Alvarez
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '470'
+  uuid: 3b097ba6-8187-419a-80f5-3e56071ca1bf
+  subjects:
+  - entities:
+    - role: player
+      name: Brandon Nimmo
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: '471'
+  uuid: 1b137a77-d4f0-4da4-8721-bec5f9c4124e
+  subjects:
+  - entities:
+    - role: player
+      name: J.P. Crawford
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: '473'
+  uuid: 6d33d501-7a7f-456a-9657-3ba0a66ee2af
+  subjects:
+  - entities:
+    - role: player
+      name: Bo Bichette
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '483'
+  uuid: 7d8688d5-8886-4462-89e0-4a91c330712f
+  subjects:
+  - entities:
+    - role: player
+      name: Logan O'Hoppe
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: '493'
+  uuid: fcbf9dcf-0047-4c15-ac71-912ae8aba8cb
+  subjects:
+  - entities:
+    - role: player
+      name: George Kirby
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: '500'
+  uuid: 0a87590b-c4b3-4eee-a4b5-238fe0a07074
+  subjects:
+  - entities:
+    - role: player
+      name: Shohei Ohtani
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '501'
+  uuid: be79615f-3fa0-4847-bbfa-990718268485
+  subjects:
+  - entities:
+    - role: player
+      name: Connelly Early
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '503'
+  uuid: 0ec94028-fa52-4d7d-889b-fbb376c5bc06
+  subjects:
+  - entities:
+    - role: player
+      name: Munetaka Murakami
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: '507'
+  uuid: d3986ae3-f13a-4b5e-93dd-54a43b7c706e
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Castillo
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: '510'
+  uuid: 22bb3f0d-b7ac-44b0-93ca-cec1de967eb6
+  subjects:
+  - entities:
+    - role: player
+      name: Philip Abner
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: '520'
+  uuid: 647dfc1e-63b4-4a2e-8f03-37fe60d3271c
+  subjects:
+  - entities:
+    - role: player
+      name: Andrew Alvarez
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: '526'
+  uuid: 56c8436c-2ed7-4c52-a78e-b7750c011995
+  subjects:
+  - entities:
+    - role: player
+      name: Masyn Winn
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: '530'
+  uuid: bd21cd57-5d25-4f88-9791-7473c5bdd922
+  subjects:
+  - entities:
+    - role: player
+      name: Carter Jensen
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: '533'
+  uuid: a5ec11d1-e31d-4f6f-8a5e-cde7aa7a9f9b
+  subjects:
+  - entities:
+    - role: player
+      name: Jasson Domínguez
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '534'
+  uuid: 2641ad5a-22e6-4398-84e5-65b2bb95d2ae
+  subjects:
+  - entities:
+    - role: player
+      name: Brandon Sproat
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: '536'
+  uuid: c0cdb41f-56bf-413b-a3c7-a992790ba2fc
+  subjects:
+  - entities:
+    - role: player
+      name: Trevor Story
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '541'
+  uuid: 7a7df611-2cd9-41a0-a8b4-59acaaba41aa
+  subjects:
+  - entities:
+    - role: player
+      name: Jung Hoo Lee
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '547'
+  uuid: 5a49bdfd-a0e5-47ff-be33-01dafd094f73
+  subjects:
+  - entities:
+    - role: player
+      name: Dylan Cease
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '550'
+  uuid: 7061d94f-6b22-4e7c-94be-1456a7616a58
+  subjects:
+  - entities:
+    - role: player
+      name: Dansby Swanson
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '551'
+  uuid: e5bf9eae-7a4f-419b-8e72-850d47afcc60
+  subjects:
+  - entities:
+    - role: player
+      name: Taylor Ward
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '560'
+  uuid: 86ea01af-a515-4a2e-83c1-b41d0bfb3b4e
+  subjects:
+  - entities:
+    - role: player
+      name: Jarren Duran
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '561'
+  uuid: 340193fa-3514-46dd-b3df-0b1a88eb1078
+  subjects:
+  - entities:
+    - role: player
+      name: Matt Chapman
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '562'
+  uuid: b6e78f0e-f8a9-4041-ade2-f7818630c424
+  subjects:
+  - entities:
+    - role: player
+      name: Bryson Stott
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: '564'
+  uuid: 7cf2a300-1be2-4ddb-be5d-e7e4229a58a9
+  subjects:
+  - entities:
+    - role: player
+      name: Tyler Soderstrom
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: '568'
+  uuid: 49721b9e-8348-418a-a81f-be06e9a1344e
+  subjects:
+  - entities:
+    - role: player
+      name: Ozzie Albies
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: '569'
+  uuid: 0ff35424-a086-40a8-bbfe-6e08fd60d3e6
+  subjects:
+  - entities:
+    - role: player
+      name: Max Scherzer
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '570'
+  uuid: 4c2f0a16-522d-4031-9299-c9b90ff747f6
+  subjects:
+  - entities:
+    - role: player
+      name: Rolddy Muñoz
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: '578'
+  uuid: ef068f67-22ce-47f5-812d-37746801da2f
+  subjects:
+  - entities:
+    - role: player
+      name: Heriberto Hernández
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: '585'
+  uuid: 6c1d0360-3fdb-4909-a978-c4a1ff69eb21
+  subjects:
+  - entities:
+    - role: player
+      name: Ian Happ
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '586'
+  uuid: b20a7d63-75c4-440f-be16-b6d098bb0983
+  subjects:
+  - entities:
+    - role: player
+      name: Marcus Semien
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '594'
+  uuid: a9bcd98f-1e3c-4023-9590-a01d7b43f784
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Gil
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '597'
+  uuid: ed149caf-9402-4c88-99e2-b1ebb7372c77
+  subjects:
+  - entities:
+    - role: player
+      name: Paul Goldschmidt
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '598'
+  uuid: 0f0ee258-5671-4382-8eb6-c8ab4f219b24
+  subjects:
+  - entities:
+    - role: player
+      name: Jack Winkler
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '600'
+  uuid: d237849b-654c-4731-be77-fc904938e4dc
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '601'
+  uuid: 38f1ac6c-319c-4a93-a266-6792e66fc21f
+  subjects:
+  - entities:
+    - role: player
+      name: Zach Cole
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '603'
+  uuid: 22347f47-ff4f-4992-875b-ddf4b594a16b
+  subjects:
+  - entities:
+    - role: player
+      name: George Valera
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '607'
+  uuid: de191837-daa1-4b72-b1d2-1764f4bae587
+  subjects:
+  - entities:
+    - role: player
+      name: Cody Bellinger
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '611'
+  uuid: 22603b29-166d-4ef1-86dc-10ea0cdca43b
+  subjects:
+  - entities:
+    - role: player
+      name: Paul Gervase
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '613'
+  uuid: bf27c5e3-fbf5-4284-b55a-5153135b65cc
+  subjects:
+  - entities:
+    - role: player
+      name: Jordan Westburg
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '614'
+  uuid: 9c9eebdf-e9cb-44e0-aebf-4450668627b1
+  subjects:
+  - entities:
+    - role: player
+      name: Manny Machado
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: '618'
+  uuid: e909169b-1b91-42b5-a729-4465f84893f6
+  subjects:
+  - entities:
+    - role: player
+      name: Tanner Bibee
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '620'
+  uuid: 6fd8b367-9d68-4a2f-8390-30c276a5d2ea
+  subjects:
+  - entities:
+    - role: player
+      name: Trey Yesavage
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '623'
+  uuid: 26d2367c-99ef-4c66-9c80-987c3ed2f52a
+  subjects:
+  - entities:
+    - role: player
+      name: Rafael Flores
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '629'
+  uuid: 2f9ad1b1-0fb8-4c19-8398-2cc5c34cc39d
+  subjects:
+  - entities:
+    - role: player
+      name: Tyler Glasnow
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '631'
+  uuid: 17aaf17f-10a4-4b19-bbd6-038fa5dbf03e
+  subjects:
+  - entities:
+    - role: player
+      name: Will Smith
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '632'
+  uuid: 64bce325-da68-435c-89e9-8a140052b3c6
+  subjects:
+  - entities:
+    - role: player
+      name: Cade Horton
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '633'
+  uuid: e3234db8-9475-47e0-bd15-b7acc9da35f1
+  subjects:
+  - entities:
+    - role: player
+      name: Salvador Perez
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: '643'
+  uuid: e7b84f96-0e0a-4f96-8c40-a92bf344f186
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Lodolo
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '646'
+  uuid: f12882a6-eb5c-4913-8963-4f5f7c6eedc5
+  subjects:
+  - entities:
+    - role: player
+      name: Mark Vientos
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '650'
+  uuid: 7c01b404-19d6-46b1-a9c7-0daa98957072
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Schwarber
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: '656'
+  uuid: 95a31ac1-e945-46db-aa96-77b9ef8ebcf1
+  subjects:
+  - entities:
+    - role: player
+      name: Aroldis Chapman
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '658'
+  uuid: 2cc5d90b-c5d3-4f5a-b063-f7fb3ff2cc6f
+  subjects:
+  - entities:
+    - role: player
+      name: Jack Flaherty
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '659'
+  uuid: 8d9a835f-b967-409f-acae-7ee6f68925b7
+  subjects:
+  - entities:
+    - role: player
+      name: Harry Ford
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: '665'
+  uuid: 88e48230-2450-4c75-9e60-f63f2d3152cd
+  subjects:
+  - entities:
+    - role: player
+      name: Jose Corniell
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: '667'
+  uuid: 8e5f25b4-9d13-43b9-847b-53f0e5e25d21
+  subjects:
+  - entities:
+    - role: player
+      name: Kodai Senga
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '668'
+  uuid: 204f92cc-676a-4233-8054-595c1d369503
+  subjects:
+  - entities:
+    - role: player
+      name: Petey Halpin
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '674'
+  uuid: cc40d82e-8130-45f8-9c55-258765253aad
+  subjects:
+  - entities:
+    - role: player
+      name: Andre Granillo
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: '675'
+  uuid: 32c4814b-b8f0-4bc2-bea0-3f704300ffab
+  subjects:
+  - entities:
+    - role: player
+      name: Steven Kwan
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '677'
+  uuid: 939b91af-b815-4749-bfcd-2d9b16348dc2
+  subjects:
+  - entities:
+    - role: player
+      name: Wilyer Abreu
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '680'
+  uuid: 28394364-4b24-4c5d-a238-72c21dabbabe
+  subjects:
+  - entities:
+    - role: player
+      name: Carlos Correa
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '685'
+  uuid: f122d263-bfd4-4ac0-9409-0cfbbce853c7
+  subjects:
+  - entities:
+    - role: player
+      name: Seiya Suzuki
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '692'
+  uuid: 9bf2c458-7d1a-4946-befb-c96d351121c0
+  subjects:
+  - entities:
+    - role: player
+      name: Drake Baldwin
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: '697'
+  uuid: e3110404-c0e8-45d8-aa31-30d26b61e3d3
+  subjects:
+  - entities:
+    - role: player
+      name: Bryan Reynolds
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '700'
+  uuid: 76272574-2766-45e2-adad-42e41962449a
+  subjects:
+  - entities:
+    - role: player
+      name: Freddie Freeman
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 

--- a/data/baseball/2026-topps-series-2/checklists/home-field-fanfest.yaml
+++ b/data/baseball/2026-topps-series-2/checklists/home-field-fanfest.yaml
@@ -1,0 +1,10 @@
+- number: HA-LL
+  uuid: 9a9970b8-c256-40ff-a58d-364b6f1fc746
+  subjects:
+  - entities:
+    - role: player
+      name: Lady Liberty
+      ref: 
+    - role: team
+      name: United States of America
+      ref: 

--- a/data/baseball/2026-topps-series-2/checklists/home-field.yaml
+++ b/data/baseball/2026-topps-series-2/checklists/home-field.yaml
@@ -1,0 +1,200 @@
+- number: HA-21
+  uuid: '09fcf958-9b6d-4fa9-b8fd-ff2ddae771cb'
+  subjects:
+  - entities:
+    - role: player
+      name: Cam Schlittler
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: HA-22
+  uuid: d46aca27-1e29-4752-b6da-4cae5de72350
+  subjects:
+  - entities:
+    - role: player
+      name: Elly De La Cruz
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: HA-23
+  uuid: b40f2148-9bb2-44f5-9c60-372874ae9627
+  subjects:
+  - entities:
+    - role: player
+      name: Mark McGwire
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: HA-24
+  uuid: 8857e33b-de6f-4c18-816c-e37bdc67e5aa
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: HA-25
+  uuid: b52037b8-0501-42cf-a825-8b25d1e0184b
+  subjects:
+  - entities:
+    - role: player
+      name: Vladimir Guerrero Jr.
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: HA-26
+  uuid: e743f2fd-8aa8-4f0c-9357-33b558629b02
+  subjects:
+  - entities:
+    - role: player
+      name: Vladimir Guerrero
+      ref: 
+    - role: team
+      name: Montréal Expos
+      ref: 
+- number: HA-27
+  uuid: 149ba38c-8684-4e6c-9a39-99ac34af424b
+  subjects:
+  - entities:
+    - role: player
+      name: Paul Skenes
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: HA-28
+  uuid: 1137a246-3332-4f64-a49b-fde184e761c0
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Eldridge
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: HA-29
+  uuid: 181dc341-7392-4262-8288-aa9c04190df3
+  subjects:
+  - entities:
+    - role: player
+      name: Barry Larkin
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: HA-30
+  uuid: a864598f-2541-428c-a80b-6e8855172b00
+  subjects:
+  - entities:
+    - role: player
+      name: Sammy Sosa
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: HA-31
+  uuid: 39647780-b345-423a-a1c6-14d35f9a0974
+  subjects:
+  - entities:
+    - role: player
+      name: Cole Young
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: HA-32
+  uuid: 60b58a7e-25ae-4ee8-8b3d-2a6982f4798c
+  subjects:
+  - entities:
+    - role: player
+      name: Carson Williams
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: HA-33
+  uuid: 80538370-a523-4c22-87ff-24e74ed421fd
+  subjects:
+  - entities:
+    - role: player
+      name: Cal Raleigh
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: HA-34
+  uuid: eb425127-2bf2-478d-8472-65ccf7b3c1fc
+  subjects:
+  - entities:
+    - role: player
+      name: Trey Yesavage
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: HA-35
+  uuid: 6aa41316-7bf2-46a9-bb37-d7bfdde2c9c4
+  subjects:
+  - entities:
+    - role: player
+      name: Chase DeLauter
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: HA-36
+  uuid: 04ba486b-6a81-4eca-9e74-7e98af43ed3c
+  subjects:
+  - entities:
+    - role: player
+      name: Carl Yastrzemski
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: HA-37
+  uuid: a900d5c0-6e02-4de4-96cb-ecd432e97e47
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Kurtz
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: HA-38
+  uuid: f464809f-9b3a-439d-b386-e1da59222e8f
+  subjects:
+  - entities:
+    - role: player
+      name: Alex Freeland
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: HA-39
+  uuid: e94ce0e7-7095-45af-b7cf-0b0ab0b39aca
+  subjects:
+  - entities:
+    - role: player
+      name: Munetaka Murakami
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: HA-40
+  uuid: a3e7bb6c-2816-4e2a-86ae-e44ce4fbd0ef
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Trout
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 

--- a/data/baseball/2026-topps-series-2/checklists/iconic-topps-buyback-cards.yaml
+++ b/data/baseball/2026-topps-series-2/checklists/iconic-topps-buyback-cards.yaml
@@ -1,0 +1,197 @@
+- number: 1952 Topps,
+  uuid: 404157fe-7c8b-4f90-8d5f-46f9ea8a1c1d
+  subjects:
+  - entities:
+    - role: player
+      name: 'Andy Pafko #1 Graded'
+      ref: 
+    - role: team
+      name: Brooklyn Dodgers
+      ref: 
+  - entities:
+    - role: player
+      name: 'Eddie Matthews #407 Graded'
+      ref: 
+    - role: team
+      name: Milwaukee Braves
+      ref: 
+- number: 1953 Topps,
+  uuid: 4d9b26ff-8acd-41c0-8805-5f2e1cb7e88a
+  subjects:
+  - entities:
+    - role: player
+      name: 'Jackie Robinson #1 Graded'
+      ref: 
+    - role: team
+      name: Brooklyn Dodgers
+      ref: 
+- number: 1954 Topps,
+  uuid: b0800f25-cdf3-475f-b11a-c2687c61ea29
+  subjects:
+  - entities:
+    - role: player
+      name: 'Hank Aaron #128 Graded'
+      ref: 
+    - role: team
+      name: Milwaukee Braves
+      ref: 
+- number: 1955 Topps,
+  uuid: 9a8a3ff5-5c31-46c6-a475-51ee7f205028
+  subjects:
+  - entities:
+    - role: player
+      name: 'Roberto Clemente #164 Graded'
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: 1956 Topps,
+  uuid: c1fe639e-5bcc-4b8f-befa-d148e1829000
+  subjects:
+  - entities:
+    - role: player
+      name: 'Mickey Mantle #135 Graded'
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: 1957 Topps,
+  uuid: 25287d98-3606-4b53-87e8-ed211b526894
+  subjects:
+  - entities:
+    - role: player
+      name: 'Hank Aaron #20 Graded'
+      ref: 
+    - role: team
+      name: Milwaukee Braves
+      ref: 
+- number: 1960 Topps,
+  uuid: 5983c731-07e4-4b15-88c2-48f42f418f39
+  subjects:
+  - entities:
+    - role: player
+      name: 'Mickey Mantle All Star #563 Graded'
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: 1961 Topps,
+  uuid: ae626133-338f-42ca-a0a7-69b9d7c37e5c
+  subjects:
+  - entities:
+    - role: player
+      name: 'Roger Maris #2 Graded'
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: 1969 Topps,
+  uuid: b35f7967-2688-4106-b5ea-9474072f04ab
+  subjects:
+  - entities:
+    - role: player
+      name: 'Reggie Jackson #260 Graded'
+      ref: 
+    - role: team
+      name: Oakland Athletics
+      ref: 
+- number: 1975 Topps,
+  uuid: 6dd459c8-5e66-4a77-93c4-13e2056b31a8
+  subjects:
+  - entities:
+    - role: player
+      name: 'George Brett #228 Graded'
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: 1977 Topps,
+  uuid: ccb54240-9820-49d4-895d-6d476df0f3b1
+  subjects:
+  - entities:
+    - role: player
+      name: 'Reggie Jackson #10 Graded'
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: 1982 Topps,
+  uuid: c9898fc4-610b-479a-bcec-a866cb0a9db1
+  subjects:
+  - entities:
+    - role: player
+      name: Cal Ripken 98T Graded
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: 1985 Topps,
+  uuid: a1d3d6d0-685a-41c4-abe8-9f38b7b4620d
+  subjects:
+  - entities:
+    - role: player
+      name: 'Kirby Puckett #536 Graded'
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: 1986 Topps,
+  uuid: 3160a354-73c3-45d8-b5a6-f0e3342b0a5a
+  subjects:
+  - entities:
+    - role: player
+      name: 'Bo Jackson #50T Graded'
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: 1989 Topps,
+  uuid: c5dfaa2b-b17b-4b42-9ce7-13ebe7eb20dc
+  subjects:
+  - entities:
+    - role: player
+      name: 'Ken Griffey Jr #41TGraded'
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: 1993 Topps,
+  uuid: e70db547-b5f0-4d5c-9194-3266edeec690
+  subjects:
+  - entities:
+    - role: player
+      name: 'Derek Jeter #98 Graded'
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: 2008 Topps,
+  uuid: a0f088df-7268-4d4e-a01b-c053a34d3c76
+  subjects:
+  - entities:
+    - role: player
+      name: 'Clayton Kershaw #UH240 Graded'
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: 2012 Topps,
+  uuid: 0a5c0942-39cd-4710-8442-a2ae29b266c8
+  subjects:
+  - entities:
+    - role: player
+      name: 'Bryce Harper #661 Graded'
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: 2018 Topps,
+  uuid: '092dfe70-65cc-4885-821d-33f540ad481b'
+  subjects:
+  - entities:
+    - role: player
+      name: 'Ronald Acuna Jr. Bat Down #698 Graded'
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 

--- a/data/baseball/2026-topps-series-2/checklists/in-the-name-relics.yaml
+++ b/data/baseball/2026-topps-series-2/checklists/in-the-name-relics.yaml
@@ -1,0 +1,910 @@
+- number: ITN-AB
+  uuid: c9e318b8-a604-4960-9c6f-19917d2377da
+  subjects:
+  - entities:
+    - role: player
+      name: Alec Bohm
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: ITN-ABE
+  uuid: ff8bae98-bdd0-4e72-b779-aab09e3427de
+  subjects:
+  - entities:
+    - role: player
+      name: Andrew Benintendi
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: ITN-AM
+  uuid: 73e529e3-576e-4076-a5d3-e306c8102a2e
+  subjects:
+  - entities:
+    - role: player
+      name: Andrew McCutchen
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: ITN-AN
+  uuid: ddbd6d83-bcfc-4112-add4-d8e67e8de2e7
+  subjects:
+  - entities:
+    - role: player
+      name: Aaron Nola
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: ITN-AR
+  uuid: b60ccdd3-91ae-41dc-b95b-128c228ddaaf
+  subjects:
+  - entities:
+    - role: player
+      name: Adley Rutschman
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: ITN-BB
+  uuid: 22d92de6-f60e-4c28-89c0-476941624a06
+  subjects:
+  - entities:
+    - role: player
+      name: Bo Bichette
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: ITN-BBX
+  uuid: 7f938b43-e064-401c-977f-d88503e01517
+  subjects:
+  - entities:
+    - role: player
+      name: Byron Buxton
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: ITN-BH
+  uuid: 9c5448fc-95ea-4772-86ac-7c6fad0e6301
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Harper
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: ITN-BL
+  uuid: af4c6bba-24f7-4322-8dc2-26b4901f5426
+  subjects:
+  - entities:
+    - role: player
+      name: Brandon Lowe
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: ITN-BN
+  uuid: 3b0e509f-f375-4651-ae9e-bcee8f00a016
+  subjects:
+  - entities:
+    - role: player
+      name: Brandon Nimmo
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: ITN-BR
+  uuid: 6f309504-aef2-4b58-8f51-887f6f848cb3
+  subjects:
+  - entities:
+    - role: player
+      name: Bryan Reynolds
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: ITN-BS
+  uuid: 53c35dc4-f129-4eb0-bd86-15d047a064dc
+  subjects:
+  - entities:
+    - role: player
+      name: Bryson Stott
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: ITN-BW
+  uuid: e74f7aaa-f06c-4bb7-8fc4-0a5e25283a36
+  subjects:
+  - entities:
+    - role: player
+      name: Bobby Witt Jr.
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: ITN-CC
+  uuid: 05c58d62-befe-41a3-a403-52c08bf9d924
+  subjects:
+  - entities:
+    - role: player
+      name: Carlos Correa
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: ITN-CCA
+  uuid: ebc77171-043c-497f-b4b7-d96b28e9894b
+  subjects:
+  - entities:
+    - role: player
+      name: Corbin Carroll
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: ITN-CCO
+  uuid: ca49a157-8ee9-4a8b-8fd2-53c55d7d3eff
+  subjects:
+  - entities:
+    - role: player
+      name: Carlos Correa
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: ITN-CR
+  uuid: da964ad0-1984-467c-80bf-cd6e2f31e63b
+  subjects:
+  - entities:
+    - role: player
+      name: Cal Raleigh
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: ITN-CRA
+  uuid: 19bbbb91-cbec-4264-b0f5-1d432e81a89f
+  subjects:
+  - entities:
+    - role: player
+      name: Ceddanne Rafaela
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: ITN-CS
+  uuid: f346a166-7f94-4f71-9425-157cfb71f3fb
+  subjects:
+  - entities:
+    - role: player
+      name: Chris Sale
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: ITN-CY
+  uuid: 15174121-ed61-46e1-84b7-1d3da9e84b3e
+  subjects:
+  - entities:
+    - role: player
+      name: Christian Yelich
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: ITN-DS
+  uuid: f9afeb5e-1438-47ce-be23-da27ba1e5af4
+  subjects:
+  - entities:
+    - role: player
+      name: Dansby Swanson
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: ITN-ET
+  uuid: 5073ae22-832e-41e2-b7f5-f413f3172895
+  subjects:
+  - entities:
+    - role: player
+      name: Ezequiel Tovar
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: ITN-FA
+  uuid: 69bbe6de-f07f-41c7-b77a-6016aa6ee5f1
+  subjects:
+  - entities:
+    - role: player
+      name: Francisco Alvarez
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: ITN-FL
+  uuid: 2040d4c9-86be-4eef-ab04-32061b5b04d2
+  subjects:
+  - entities:
+    - role: player
+      name: Francisco Lindor
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: ITN-FP
+  uuid: f19ee0b1-5deb-4ef7-861f-cda548531696
+  subjects:
+  - entities:
+    - role: player
+      name: Freddy Peralta
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: ITN-FT
+  uuid: d37e42ba-8146-4b08-b314-21f5feac887d
+  subjects:
+  - entities:
+    - role: player
+      name: Fernando Tatis Jr.
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: ITN-GS
+  uuid: a4585e2e-4b44-4523-a7d3-b209d50dd583
+  subjects:
+  - entities:
+    - role: player
+      name: George Springer
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: ITN-HG
+  uuid: 79348c38-b7b4-429a-9193-078197862b17
+  subjects:
+  - entities:
+    - role: player
+      name: Hunter Goodman
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: ITN-HGR
+  uuid: 6493fcf1-fc31-48a4-8333-e87b07873fe3
+  subjects:
+  - entities:
+    - role: player
+      name: Hunter Greene
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: ITN-IH
+  uuid: d454f71e-2e97-4af4-822a-d89086ef8f45
+  subjects:
+  - entities:
+    - role: player
+      name: Ian Happ
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: ITN-JA
+  uuid: 988ff831-b845-459e-9d67-23e12b71038f
+  subjects:
+  - entities:
+    - role: player
+      name: Jose Altuve
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: ITN-JAD
+  uuid: d2c939ea-f3e3-453c-9129-035dc738e4e9
+  subjects:
+  - entities:
+    - role: player
+      name: Jo Adell
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: ITN-JB
+  uuid: 0cca8d4b-3012-4a7d-a592-a278a279fcf3
+  subjects:
+  - entities:
+    - role: player
+      name: Javier Báez
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: ITN-JC
+  uuid: 685e4489-dd16-49bb-8fc1-b704762aeb11
+  subjects:
+  - entities:
+    - role: player
+      name: Jazz Chisholm Jr.
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: ITN-JCA
+  uuid: 6ab9d9c2-97d8-48a8-807e-58ce8fc46e9a
+  subjects:
+  - entities:
+    - role: player
+      name: J.P. Crawford
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: ITN-JCH
+  uuid: 713a9b8f-260d-4812-9e57-e66a9d39fab8
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Chourio
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: ITN-JD
+  uuid: 492f66e0-2f3b-4ed6-941e-97bf5cc90725
+  subjects:
+  - entities:
+    - role: player
+      name: Jarren Duran
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: ITN-JH
+  uuid: 6e96911a-1237-4d45-92ef-e2bbcacd7b45
+  subjects:
+  - entities:
+    - role: player
+      name: Jung Hoo Lee
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: ITN-JM
+  uuid: 6281bafb-d88f-4ef2-8b88-83f0ae2a1091
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Merrill
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: ITN-JMU
+  uuid: 86babc27-83f5-441b-a719-ab273f9cea3b
+  subjects:
+  - entities:
+    - role: player
+      name: Joe Musgrove
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: ITN-JP
+  uuid: ce6f8677-f3d5-47c1-8d31-9d385012aa16
+  subjects:
+  - entities:
+    - role: player
+      name: Jeremy Peña
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: ITN-JR
+  uuid: e45a851f-3a84-40f4-8ac4-75eda77747f2
+  subjects:
+  - entities:
+    - role: player
+      name: Julio Rodríguez
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: ITN-JS
+  uuid: 2a84ef2d-90c6-45ea-8487-a417bbea2b00
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: ITN-JTR
+  uuid: f28aa414-37ba-4753-8ad5-c7ab53adb867
+  subjects:
+  - entities:
+    - role: player
+      name: J.T. Realmuto
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: ITN-JV
+  uuid: ed66f0dc-ec2e-4c9a-b199-1854acb0021c
+  subjects:
+  - entities:
+    - role: player
+      name: Justin Verlander
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: ITN-JW
+  uuid: a1d0ce25-6d9d-4b7a-a3b2-69c4f3cef5d6
+  subjects:
+  - entities:
+    - role: player
+      name: James Wood
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: ITN-JWE
+  uuid: 1365822a-bbc3-4479-8627-120f1c2954e1
+  subjects:
+  - entities:
+    - role: player
+      name: Jordan Westburg
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: ITN-JWI
+  uuid: 22351cd8-f143-4662-a510-54c8bf8ac001
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Wilson
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: ITN-KB
+  uuid: 98e95df3-a659-49ca-af73-36160a80a827
+  subjects:
+  - entities:
+    - role: player
+      name: Kris Bryant
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: ITN-KM
+  uuid: 8ab06f9a-4b58-4644-9251-100a0d472c71
+  subjects:
+  - entities:
+    - role: player
+      name: Ketel Marte
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: ITN-KS
+  uuid: 29cc711e-0d5f-421f-af4a-ba8c8f24843c
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Schwarber
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: ITN-KT
+  uuid: e035ef0c-88c8-4b52-84cc-e6dc2c1896ce
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Tucker
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: ITN-LC
+  uuid: 2b21abe7-dcaa-454a-8720-04d22b7f7601
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Castillo
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: ITN-LG
+  uuid: 26e2ad83-53a1-4a98-8442-77bbfb6a6b27
+  subjects:
+  - entities:
+    - role: player
+      name: Logan Gilbert
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: ITN-LR
+  uuid: '0881bc97-f996-4e5c-8902-148fa775c8cb'
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Robert Jr.
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: ITN-LW
+  uuid: 95a95240-a465-4458-9845-7ad78b5a0c65
+  subjects:
+  - entities:
+    - role: player
+      name: Logan Webb
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: ITN-MM
+  uuid: 0e904da4-4a01-4ce6-8a97-1eb5a661879b
+  subjects:
+  - entities:
+    - role: player
+      name: Manny Machado
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: ITN-MMU
+  uuid: c270863d-ba83-407b-818a-82abc1fccbfe
+  subjects:
+  - entities:
+    - role: player
+      name: Max Muncy
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: ITN-MT
+  uuid: 5756588f-b404-48b4-9485-42ab5efd5220
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Trout
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: ITN-NC
+  uuid: b5bafd41-1bb6-416f-8f30-04cf990a72d5
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Castellanos
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: ITN-NH
+  uuid: 5b1cc845-8266-4a93-81d4-ac390a902faa
+  subjects:
+  - entities:
+    - role: player
+      name: Nico Hoerner
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: ITN-NK
+  uuid: 44576507-5514-4cde-a0ce-6b8fb13a4e24
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Kurtz
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: ITN-OA
+  uuid: 6086651d-f3ca-4928-a00f-55a6047cb382
+  subjects:
+  - entities:
+    - role: player
+      name: Ozzie Albies
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: ITN-PA
+  uuid: 526b59bc-79ec-43d3-84f7-c4e4d896f697
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Alonso
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: ITN-PC
+  uuid: 38974ce2-cde4-44bf-aba1-fbf312b8733b
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Crow-Armstrong
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: ITN-PL
+  uuid: 10e52bb0-2024-4481-a813-63075c7c5db3
+  subjects:
+  - entities:
+    - role: player
+      name: Pablo López
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: ITN-RAJ
+  uuid: 48c6b372-703a-4713-9a6d-5fa0f5e3c170
+  subjects:
+  - entities:
+    - role: player
+      name: Ronald Acuña Jr.
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: ITN-RG
+  uuid: cad4c494-e96e-4a69-8694-5f140a4bd94a
+  subjects:
+  - entities:
+    - role: player
+      name: Riley Greene
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: ITN-RL
+  uuid: 921b840e-1e7e-4c4a-96a3-c30f263f425f
+  subjects:
+  - entities:
+    - role: player
+      name: Royce Lewis
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: ITN-RM
+  uuid: 06f678b5-5604-40e4-9b96-4aa891820d32
+  subjects:
+  - entities:
+    - role: player
+      name: Ryan Mountcastle
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: ITN-SF
+  uuid: 7a49ee7c-b065-4db6-97d6-8f0dde41d595
+  subjects:
+  - entities:
+    - role: player
+      name: Sal Frelick
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: ITN-SI
+  uuid: 38a0f3d3-3d4b-434e-ac83-40fa90412755
+  subjects:
+  - entities:
+    - role: player
+      name: Shota Imanaga
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: ITN-SL
+  uuid: 81098b3c-bfef-4759-9cc1-d49018cc1150
+  subjects:
+  - entities:
+    - role: player
+      name: Shea Langeliers
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: ITN-SM
+  uuid: 8a8fbaf9-0390-4c4f-9511-1980817a1ae9
+  subjects:
+  - entities:
+    - role: player
+      name: Shane McClanahan
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: ITN-SP
+  uuid: e29cfc18-9417-4e3c-be9a-fd184e647223
+  subjects:
+  - entities:
+    - role: player
+      name: Salvador Perez
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: ITN-SST
+  uuid: 35d543bc-d7e9-475d-bcaf-68b112074491
+  subjects:
+  - entities:
+    - role: player
+      name: Spencer Strider
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: ITN-SSU
+  uuid: 73512693-ea4b-415c-94a7-a73cb5508ac0
+  subjects:
+  - entities:
+    - role: player
+      name: Seiya Suzuki
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: ITN-ST
+  uuid: ac4cb2d7-e905-4fa2-85bc-a833965b9afe
+  subjects:
+  - entities:
+    - role: player
+      name: Spencer Torkelson
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: ITN-TS
+  uuid: 1e64fdbd-4ed3-492c-8f2b-f82bfdae3bf2
+  subjects:
+  - entities:
+    - role: player
+      name: Tarik Skubal
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: ITN-TSO
+  uuid: 55e8225e-2a32-4558-9925-cf8a28433d61
+  subjects:
+  - entities:
+    - role: player
+      name: Tyler Soderstrom
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: ITN-TST
+  uuid: aec34fe5-1744-4858-b260-8deac41dec8e
+  subjects:
+  - entities:
+    - role: player
+      name: Trevor Story
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: ITN-TT
+  uuid: c10c88c4-70d0-4ba4-b465-a44bd4fa6d3a
+  subjects:
+  - entities:
+    - role: player
+      name: Trea Turner
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: ITN-VG
+  uuid: ab47231b-5901-4623-8eff-8c2c3b50d675
+  subjects:
+  - entities:
+    - role: player
+      name: Vladimir Guerrero Jr.
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: ITN-VP
+  uuid: 468e435e-0da7-48c6-95e8-683001854842
+  subjects:
+  - entities:
+    - role: player
+      name: Vinnie Pasquantino
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: ITN-WC
+  uuid: a7114cc4-299a-42a3-9e55-0443c63c66ba
+  subjects:
+  - entities:
+    - role: player
+      name: William Contreras
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: ITN-WS
+  uuid: ab4d5ee0-fcf0-4d32-a862-70ba121835fa
+  subjects:
+  - entities:
+    - role: player
+      name: Will Smith
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: ITN-XB
+  uuid: f477ea63-1ba0-48eb-930b-95c2de68b3f4
+  subjects:
+  - entities:
+    - role: player
+      name: Xander Bogaerts
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: ITN-YA
+  uuid: 81b1ceb4-5c29-4730-9bc2-546b597a7a9f
+  subjects:
+  - entities:
+    - role: player
+      name: Yordan Alvarez
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: ITN-YD
+  uuid: e6c96f28-7a96-4b40-affd-cdea90b174b4
+  subjects:
+  - entities:
+    - role: player
+      name: Yu Darvish
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: ITN-ZN
+  uuid: dd3e1100-5a58-4c24-883c-f6efec4f7d28
+  subjects:
+  - entities:
+    - role: player
+      name: Zach Neto
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: ITN-ZW
+  uuid: 1ee4bfda-2ade-4247-b573-070fc56b01df
+  subjects:
+  - entities:
+    - role: player
+      name: Zack Wheeler
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 

--- a/data/baseball/2026-topps-series-2/checklists/major-league-material.yaml
+++ b/data/baseball/2026-topps-series-2/checklists/major-league-material.yaml
@@ -1,0 +1,980 @@
+- number: MLM2-AF
+  uuid: dc93a2db-c8bf-4636-ab0d-7c9e43c0dc25
+  subjects:
+  - entities:
+    - role: player
+      name: Alex Freeland
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: MLM2-AG
+  uuid: 25cbbaac-68f6-47c4-aab8-36c7978c29ab
+  subjects:
+  - entities:
+    - role: player
+      name: Adolis García
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: MLM2-AJ
+  uuid: 351939ee-d389-4faa-959d-b9b326982a83
+  subjects:
+  - entities:
+    - role: player
+      name: Aaron Judge
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: MLM2-AM
+  uuid: efb71338-c2d3-4ad9-98d3-096eb5cf5fb7
+  subjects:
+  - entities:
+    - role: player
+      name: Andrew McCutchen
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: MLM2-AR
+  uuid: 0f0432ce-d4a2-4a2e-9d58-e1418453142d
+  subjects:
+  - entities:
+    - role: player
+      name: Austin Riley
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: MLM2-BB
+  uuid: e4827338-5fae-47fc-9a00-0fdad76075b3
+  subjects:
+  - entities:
+    - role: player
+      name: Byron Buxton
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: MLM2-BC
+  uuid: 974bc7ee-a7e5-4b47-b647-d9d5333e8a34
+  subjects:
+  - entities:
+    - role: player
+      name: Bubba Chandler
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: MLM2-BH
+  uuid: 64c663f8-e588-446b-8179-2d96080db303
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Harper
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: MLM2-BHO
+  uuid: 3e4879e4-7e15-4713-b16d-89b4dbcc8533
+  subjects:
+  - entities:
+    - role: player
+      name: Brady House
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: MLM2-BL
+  uuid: 6da52719-c234-4c7b-8f9c-bd10b938b28f
+  subjects:
+  - entities:
+    - role: player
+      name: Barry Larkin
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: MLM2-BM
+  uuid: b7341d24-4c6e-4cb7-8501-c2d2700fff95
+  subjects:
+  - entities:
+    - role: player
+      name: Brice Matthews
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: MLM2-BW
+  uuid: ec0bed54-b693-41c8-bca7-8b1dbc64e0bc
+  subjects:
+  - entities:
+    - role: player
+      name: Bryan Woo
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: MLM2-BWJ
+  uuid: 9723a971-4a1a-4c5b-ac01-0129035cc871
+  subjects:
+  - entities:
+    - role: player
+      name: Bobby Witt Jr.
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: MLM2-CA
+  uuid: 9c97ab98-65ef-40cd-992b-3aa651558850
+  subjects:
+  - entities:
+    - role: player
+      name: CJ Abrams
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: MLM2-CB
+  uuid: 73af3441-dc6b-4eac-b965-bd228f169026
+  subjects:
+  - entities:
+    - role: player
+      name: Chase Burns
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: MLM2-CC
+  uuid: a6e8f1d3-8736-41f5-955c-71d1993735fb
+  subjects:
+  - entities:
+    - role: player
+      name: Carlos Correa
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: MLM2-CCA
+  uuid: 8dd9d13b-a681-4ffe-bb8d-0aab7db43f28
+  subjects:
+  - entities:
+    - role: player
+      name: Corbin Carroll
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: MLM2-CCS
+  uuid: 6bfb94dd-66f5-4dd5-b8ff-1b65e09facaf
+  subjects:
+  - entities:
+    - role: player
+      name: CC Sabathia
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: MLM2-CD
+  uuid: 39aa68e6-bfde-46e5-832d-e1f39fb174a0
+  subjects:
+  - entities:
+    - role: player
+      name: Chase DeLauter
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: MLM2-CH
+  uuid: e02cce98-3129-42d7-ac33-cee3defd9c40
+  subjects:
+  - entities:
+    - role: player
+      name: Cade Horton
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: MLM2-CJ
+  uuid: 7786892c-c23e-4d66-a12d-147fe8813670
+  subjects:
+  - entities:
+    - role: player
+      name: Carter Jensen
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: MLM2-CK
+  uuid: b989db22-087e-4ce3-832c-2ba9fd150a85
+  subjects:
+  - entities:
+    - role: player
+      name: C.J. Kayfus
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: MLM2-CM
+  uuid: 4261c876-0405-42b1-8d95-fda614b00846
+  subjects:
+  - entities:
+    - role: player
+      name: Colson Montgomery
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: MLM2-CMO
+  uuid: 230fc832-89c4-42aa-a44d-712a9161f073
+  subjects:
+  - entities:
+    - role: player
+      name: Christian Moore
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: MLM2-CR
+  uuid: 5299ab05-7f77-4318-8602-f35afba0f9be
+  subjects:
+  - entities:
+    - role: player
+      name: Ceddanne Rafaela
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: MLM2-CRJ
+  uuid: 39dba647-864a-4247-b0dc-9ae36751a689
+  subjects:
+  - entities:
+    - role: player
+      name: Cal Ripken Jr.
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: MLM2-CS
+  uuid: 520c90e2-0bc0-4d75-84dd-fd86f849f7ad
+  subjects:
+  - entities:
+    - role: player
+      name: Chris Sale
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: MLM2-CSC
+  uuid: aaf2f507-3e26-4f0b-af07-fd0194a1bf7d
+  subjects:
+  - entities:
+    - role: player
+      name: Cam Schlittler
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: MLM2-CSM
+  uuid: 5480963b-f6e5-4e28-9e1f-672c05656c78
+  subjects:
+  - entities:
+    - role: player
+      name: Cam Smith
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: MLM2-CT
+  uuid: 594b6d92-3853-4f91-9391-db8fdc7c18b0
+  subjects:
+  - entities:
+    - role: player
+      name: Colby Thomas
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: MLM2-CW
+  uuid: d9d38756-a428-4b9c-9e17-740368afeaa6
+  subjects:
+  - entities:
+    - role: player
+      name: Carson Williams
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: MLM2-CY
+  uuid: 4bbeca50-af94-4c46-acb0-11a48a91f457
+  subjects:
+  - entities:
+    - role: player
+      name: Christian Yelich
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: MLM2-DB
+  uuid: fac88ebf-2c64-4209-9136-7cc1e0d820c2
+  subjects:
+  - entities:
+    - role: player
+      name: Drake Baldwin
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: MLM2-DC
+  uuid: a95f894f-8950-4280-b76a-81f30f6bdf86
+  subjects:
+  - entities:
+    - role: player
+      name: Dylan Crews
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: MLM2-DO
+  uuid: 902a26a5-28c9-4896-9c32-4b4919449b57
+  subjects:
+  - entities:
+    - role: player
+      name: David Ortiz
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: MLM2-DS
+  uuid: 55c4dddb-784c-491e-bee1-d86d441de19f
+  subjects:
+  - entities:
+    - role: player
+      name: Dansby Swanson
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: MLM2-FF
+  uuid: 6a9d3f10-eb0a-4ae9-9cd8-f05d9959fc1f
+  subjects:
+  - entities:
+    - role: player
+      name: Freddie Freeman
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: MLM2-FL
+  uuid: 73af355f-40e1-43ee-81b1-5870da5c6a88
+  subjects:
+  - entities:
+    - role: player
+      name: Francisco Lindor
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: MLM2-FT
+  uuid: 5de7fa57-0b30-4218-b3b0-fe052781922f
+  subjects:
+  - entities:
+    - role: player
+      name: Frank Thomas
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: MLM2-FTJ
+  uuid: ece432ae-4c74-4927-944b-b7b22e79180e
+  subjects:
+  - entities:
+    - role: player
+      name: Fernando Tatis Jr.
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: MLM2-GS
+  uuid: e3369fb9-319a-47c3-bfb8-fbc7e52314e4
+  subjects:
+  - entities:
+    - role: player
+      name: Giancarlo Stanton
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: MLM2-JA
+  uuid: 261626b2-6c89-44a1-b93d-c023e6c74b3a
+  subjects:
+  - entities:
+    - role: player
+      name: Jose Altuve
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: MLM2-JC
+  uuid: 2ee236fa-cc00-4161-8c12-67a285a5a87a
+  subjects:
+  - entities:
+    - role: player
+      name: Junior Caminero
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: MLM2-JCA
+  uuid: d9c2471c-b9fa-4fa6-88c4-99a022913ae7
+  subjects:
+  - entities:
+    - role: player
+      name: Jac Caglianone
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: MLM2-JCH
+  uuid: 383aeeae-eabe-4635-bd64-edf6c2ca1db1
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Chourio
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: MLM2-JCJ
+  uuid: a84063c7-34a9-412b-857d-0fe529f055d8
+  subjects:
+  - entities:
+    - role: player
+      name: Jazz Chisholm Jr.
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: MLM2-JG
+  uuid: 9945e565-c305-4219-b3e1-749d245a5292
+  subjects:
+  - entities:
+    - role: player
+      name: Jhostynxon Garcia
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: MLM2-JM
+  uuid: 66c0b5e3-8ed9-4061-b018-34e7ba7a55fa
+  subjects:
+  - entities:
+    - role: player
+      name: Jakob Marsee
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: MLM2-JME
+  uuid: 889ffde8-07ca-41e4-bc82-104183400ea6
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Merrill
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: MLM2-JMI
+  uuid: 633df889-ad8c-4b88-a43b-d6bb8c82f571
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Misiorowski
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: MLM2-JR
+  uuid: 4973f423-3c7f-4a0f-ac80-4bf8731dee51
+  subjects:
+  - entities:
+    - role: player
+      name: Julio Rodríguez
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: MLM2-JRA
+  uuid: ce501535-7af4-4ae7-8d1b-0d8f51061f92
+  subjects:
+  - entities:
+    - role: player
+      name: José Ramírez
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: MLM2-JT
+  uuid: 2f57a84d-0571-436f-8bd1-06dbb5bd08a7
+  subjects:
+  - entities:
+    - role: player
+      name: Jonah Tong
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: MLM2-JTR
+  uuid: acb867ed-6b9e-4d54-a1e4-844718fe40ef
+  subjects:
+  - entities:
+    - role: player
+      name: J.T. Realmuto
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: MLM2-JW
+  uuid: 0b6c226e-00dc-41a0-86ef-e64ae24d0ac7
+  subjects:
+  - entities:
+    - role: player
+      name: Jordan Westburg
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: MLM2-JWI
+  uuid: a84e1bc6-981e-4b14-a592-51126725c10f
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Wilson
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: MLM2-JWO
+  uuid: 0a049dde-a763-4605-b09a-17737ca1a549
+  subjects:
+  - entities:
+    - role: player
+      name: James Wood
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: MLM2-KT
+  uuid: 12c47e42-27fc-471d-90e3-3406f3aaed33
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Teel
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: MLM2-KTU
+  uuid: 8f8991a9-21ba-4df8-b660-f01156e8f562
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Tucker
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: MLM2-LK
+  uuid: 50ad5547-c425-4a66-a830-f59e80acaedf
+  subjects:
+  - entities:
+    - role: player
+      name: Luke Keaschall
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: MLM2-LN
+  uuid: d282cfa0-0e36-4f8a-b422-c0a1f380db90
+  subjects:
+  - entities:
+    - role: player
+      name: Lars Nootbaar
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: MLM2-MC
+  uuid: bedee54e-0871-4c74-84d6-2d19bdb1888d
+  subjects:
+  - entities:
+    - role: player
+      name: Matt Chapman
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: MLM2-MM
+  uuid: f4c14dbe-5f6c-4c59-b0e5-9d57912ffe4a
+  subjects:
+  - entities:
+    - role: player
+      name: Manny Machado
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: MLM2-MT
+  uuid: e89338a5-cb8a-4ef3-b8f6-df136cde1aac
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Trout
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: MLM2-MW
+  uuid: f3373a12-b983-4232-8f95-1880f15e1f47
+  subjects:
+  - entities:
+    - role: player
+      name: Masyn Winn
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: MLM2-NA
+  uuid: 1188a187-42c8-46e9-aee2-28e1983a31f0
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan Arenado
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: MLM2-NH
+  uuid: 989a8f2a-da3f-4600-bf37-355043883c63
+  subjects:
+  - entities:
+    - role: player
+      name: Nico Hoerner
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: MLM2-NK
+  uuid: 514effcd-0e8a-4842-8666-01f03139cda3
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Kurtz
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: MLM2-NM
+  uuid: 5c862955-64a2-4283-869d-429b556319cb
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan McLean
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: MLM2-OA
+  uuid: 841afcda-8ad5-4fcd-a04a-f916ea76089a
+  subjects:
+  - entities:
+    - role: player
+      name: Ozzie Albies
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: MLM2-OC
+  uuid: bc54e912-e470-44be-8fe4-548fb4182d99
+  subjects:
+  - entities:
+    - role: player
+      name: Oneil Cruz
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: MLM2-OCA
+  uuid: 6329479a-fb89-4662-b64c-5f71eca924f1
+  subjects:
+  - entities:
+    - role: player
+      name: Owen Caissie
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: MLM2-PA
+  uuid: 99edb309-a19c-4b06-9d42-fe6fac26d29d
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Alonso
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: MLM2-PC
+  uuid: f6733b47-a876-4692-a232-f75e184f3dc1
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Crow-Armstrong
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: MLM2-PS
+  uuid: 9cb25883-94f3-48dd-9df3-de39075f2ece
+  subjects:
+  - entities:
+    - role: player
+      name: Paul Skenes
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: MLM2-PT
+  uuid: cc4246a7-a38e-4992-ba8d-2c9a9eab32c3
+  subjects:
+  - entities:
+    - role: player
+      name: Payton Tolle
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: MLM2-RA
+  uuid: 49309a3d-007b-4941-80ee-40edc565e2cb
+  subjects:
+  - entities:
+    - role: player
+      name: Roman Anthony
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: MLM2-RAJ
+  uuid: 60a85c78-ebca-4ea0-81d7-d8f92f427f42
+  subjects:
+  - entities:
+    - role: player
+      name: Ronald Acuña Jr.
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: MLM2-RD
+  uuid: b58b1de8-0d51-4b5f-95fe-da93602ae602
+  subjects:
+  - entities:
+    - role: player
+      name: Rafael Devers
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: MLM2-RG
+  uuid: f03c834b-a39e-4fc7-bc39-9850dd4cd48d
+  subjects:
+  - entities:
+    - role: player
+      name: Riley Greene
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: MLM2-RR
+  uuid: 4bf535b2-db9d-453b-93fb-47106e893f45
+  subjects:
+  - entities:
+    - role: player
+      name: Ryan Ritter
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: MLM2-RS
+  uuid: 7a48a8cc-0f82-4dd4-b0a8-dfce385d6958
+  subjects:
+  - entities:
+    - role: player
+      name: Roki Sasaki
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: MLM2-SB
+  uuid: ef40f1f9-cec8-4079-86ad-28030a98b043
+  subjects:
+  - entities:
+    - role: player
+      name: Samuel Basallo
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: MLM2-SS
+  uuid: 1184ce00-9fdd-4d45-ad43-d69ab5295002
+  subjects:
+  - entities:
+    - role: player
+      name: Sal Stewart
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: MLM2-SSC
+  uuid: c57a4ecf-28a0-4592-b4d1-a95276e219d7
+  subjects:
+  - entities:
+    - role: player
+      name: Spencer Schwellenbach
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: MLM2-SST
+  uuid: 387fa74b-bf7b-42fe-8c52-c694449cbc06
+  subjects:
+  - entities:
+    - role: player
+      name: Spencer Strider
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: MLM2-SSU
+  uuid: 62e96c80-8cde-43ca-b466-888d9e12af48
+  subjects:
+  - entities:
+    - role: player
+      name: Seiya Suzuki
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: MLM2-TS
+  uuid: e83c156e-977f-44b3-974a-6e873fa8b7ae
+  subjects:
+  - entities:
+    - role: player
+      name: Tarik Skubal
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: MLM2-TSO
+  uuid: 21a5cbbb-8600-4c23-ad67-664793185d80
+  subjects:
+  - entities:
+    - role: player
+      name: Tyler Soderstrom
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: MLM2-TT
+  uuid: 6f916e89-78d3-433e-8e98-9393026af267
+  subjects:
+  - entities:
+    - role: player
+      name: Trea Turner
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: MLM2-TY
+  uuid: c01c57ca-c880-4f32-8fee-4a5fd870de78
+  subjects:
+  - entities:
+    - role: player
+      name: Trey Yesavage
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: MLM2-VG
+  uuid: 0ab0d5c1-661d-4a69-bca3-361051dba031
+  subjects:
+  - entities:
+    - role: player
+      name: Vladimir Guerrero
+      ref: 
+    - role: team
+      name: Montréal Expos
+      ref: 
+- number: MLM2-VGJ
+  uuid: eedee827-cd0e-45dd-9715-b0bb84e3d382
+  subjects:
+  - entities:
+    - role: player
+      name: Vladimir Guerrero Jr.
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: MLM2-VP
+  uuid: 35d5cd5e-a0f1-4dec-b93a-79330de1abcc
+  subjects:
+  - entities:
+    - role: player
+      name: Vinnie Pasquantino
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: MLM2-WL
+  uuid: 285d4236-4689-4a4e-8493-4fa5b8d6e5a1
+  subjects:
+  - entities:
+    - role: player
+      name: Wyatt Langford
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: MLM2-WS
+  uuid: 543e9af3-0b6b-4a32-9fbb-caabc659314a
+  subjects:
+  - entities:
+    - role: player
+      name: Will Smith
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: MLM2-YA
+  uuid: 730a9f9c-1c00-4dbd-ae37-68b79a91239f
+  subjects:
+  - entities:
+    - role: player
+      name: Yordan Alvarez
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: MLM2-YY
+  uuid: 486160eb-820e-4d69-af1d-c1d91e59600a
+  subjects:
+  - entities:
+    - role: player
+      name: Yoshinobu Yamamoto
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 

--- a/data/baseball/2026-topps-series-2/checklists/major-league-materials-autographs.yaml
+++ b/data/baseball/2026-topps-series-2/checklists/major-league-materials-autographs.yaml
@@ -1,0 +1,650 @@
+- number: MLM2-AF
+  uuid: f05a5172-35a3-4408-abef-66960dc469b1
+  subjects:
+  - entities:
+    - role: player
+      name: Alex Freeland
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: MLM2-AG
+  uuid: 6eb3ccc5-bac0-426c-97f4-628f5b21fe56
+  subjects:
+  - entities:
+    - role: player
+      name: Adolis García
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: MLM2-AM
+  uuid: d93ef5d9-5b4e-4c8c-adea-f0c679151e8f
+  subjects:
+  - entities:
+    - role: player
+      name: Andrew McCutchen
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: MLM2-BC
+  uuid: eec91c30-d2e3-4947-b492-39d7c15ef511
+  subjects:
+  - entities:
+    - role: player
+      name: Bubba Chandler
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: MLM2-BHO
+  uuid: 17299231-bf51-40c3-bd30-e76b2fd37ec5
+  subjects:
+  - entities:
+    - role: player
+      name: Brady House
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: MLM2-BL
+  uuid: 4ca7ff93-f5e1-49f2-8114-bc0b2e44cd5b
+  subjects:
+  - entities:
+    - role: player
+      name: Barry Larkin
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: MLM2-BM
+  uuid: 51fd2efd-b76a-4429-96ad-2317067f22f6
+  subjects:
+  - entities:
+    - role: player
+      name: Brice Matthews
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: MLM2-BW
+  uuid: 8bb48876-f53a-49cf-9251-fd96a72b2181
+  subjects:
+  - entities:
+    - role: player
+      name: Bryan Woo
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: MLM2-CA
+  uuid: f03d1515-4cc0-4342-baf3-348689792930
+  subjects:
+  - entities:
+    - role: player
+      name: CJ Abrams
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: MLM2-CB
+  uuid: dd347e3d-8253-4df7-863a-44810fc5b4c0
+  subjects:
+  - entities:
+    - role: player
+      name: Chase Burns
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: MLM2-CCA
+  uuid: e3c60038-3389-4ce9-9145-be9eab6b061d
+  subjects:
+  - entities:
+    - role: player
+      name: Corbin Carroll
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: MLM2-CCS
+  uuid: f4647c62-b64c-4365-b4e2-4b9a966306b1
+  subjects:
+  - entities:
+    - role: player
+      name: CC Sabathia
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: MLM2-CD
+  uuid: '0449aadb-43cc-4f00-9f7b-756c2ff27cea'
+  subjects:
+  - entities:
+    - role: player
+      name: Chase DeLauter
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: MLM2-CH
+  uuid: 9fb0dfe7-6a36-44ad-954a-ca1abd2d6aa8
+  subjects:
+  - entities:
+    - role: player
+      name: Cade Horton
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: MLM2-CJ
+  uuid: 78056593-1729-4e77-b43b-e24728f8a793
+  subjects:
+  - entities:
+    - role: player
+      name: Carter Jensen
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: MLM2-CK
+  uuid: 7be0ea98-f9ab-4c8f-9dcb-98ccaa6f8d3c
+  subjects:
+  - entities:
+    - role: player
+      name: C.J. Kayfus
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: MLM2-CM
+  uuid: 368e75b8-90f1-4398-b8f4-15d25d195b5f
+  subjects:
+  - entities:
+    - role: player
+      name: Colson Montgomery
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: MLM2-CR
+  uuid: 9046742d-d8e1-49df-8f08-f41826cea63f
+  subjects:
+  - entities:
+    - role: player
+      name: Ceddanne Rafaela
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: MLM2-CRJ
+  uuid: 532c50e0-cc06-4312-90d6-2e1b0c706afe
+  subjects:
+  - entities:
+    - role: player
+      name: Cal Ripken Jr.
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: MLM2-CS
+  uuid: 5c07cb8d-99ac-414a-bb7d-68d2f1d3e310
+  subjects:
+  - entities:
+    - role: player
+      name: Chris Sale
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: MLM2-CSC
+  uuid: eb574474-813f-45c1-a4c1-f25715ee83b6
+  subjects:
+  - entities:
+    - role: player
+      name: Cam Schlittler
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: MLM2-CT
+  uuid: afb157cb-02be-4f3f-a1c7-b5d18c68725a
+  subjects:
+  - entities:
+    - role: player
+      name: Colby Thomas
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: MLM2-CW
+  uuid: 8c40358e-196c-4b1a-a80a-558ce5cf829e
+  subjects:
+  - entities:
+    - role: player
+      name: Carson Williams
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: MLM2-CY
+  uuid: 601e6c48-2da5-401e-991a-c6ff59330527
+  subjects:
+  - entities:
+    - role: player
+      name: Christian Yelich
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: MLM2-DB
+  uuid: d3e5d154-f32a-47fe-ac73-b92847cb9142
+  subjects:
+  - entities:
+    - role: player
+      name: Drake Baldwin
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: MLM2-DC
+  uuid: 19113015-61ac-4f37-91af-5eb6ada32335
+  subjects:
+  - entities:
+    - role: player
+      name: Dylan Crews
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: MLM2-DO
+  uuid: 98fcd32a-02c7-493e-b778-dc67e5306b1f
+  subjects:
+  - entities:
+    - role: player
+      name: David Ortiz
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: MLM2-DS
+  uuid: c71f0bb0-d387-4c40-a516-f10ff151494e
+  subjects:
+  - entities:
+    - role: player
+      name: Dansby Swanson
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: MLM2-FT
+  uuid: b94d7111-7215-42c1-8123-d8eeff0ed858
+  subjects:
+  - entities:
+    - role: player
+      name: Frank Thomas
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: MLM2-JC
+  uuid: a40d52d5-3c18-4e5c-a588-0fc6c3bb1dcd
+  subjects:
+  - entities:
+    - role: player
+      name: Junior Caminero
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: MLM2-JCA
+  uuid: 7f0b58f0-1d62-4714-8a73-a6a141c8b661
+  subjects:
+  - entities:
+    - role: player
+      name: Jac Caglianone
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: MLM2-JCJ
+  uuid: 4b728a95-43c3-4606-9835-d4c219d97790
+  subjects:
+  - entities:
+    - role: player
+      name: Jazz Chisholm Jr.
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: MLM2-JM
+  uuid: fbe3db8a-1a50-473a-b915-6dd9853848e0
+  subjects:
+  - entities:
+    - role: player
+      name: Jakob Marsee
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: MLM2-JMI
+  uuid: 7b95bc7d-55d2-449c-8ff5-1fd5ad4d7c38
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Misiorowski
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: MLM2-JRA
+  uuid: eb8c42f8-c534-412f-83b4-2f3f68dbde7b
+  subjects:
+  - entities:
+    - role: player
+      name: José Ramírez
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: MLM2-JT
+  uuid: 47987e2f-882d-43b1-a294-e016d5537262
+  subjects:
+  - entities:
+    - role: player
+      name: Jonah Tong
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: MLM2-JWO
+  uuid: 8f3df35b-1974-4649-88f1-dbcd7ad3c61e
+  subjects:
+  - entities:
+    - role: player
+      name: James Wood
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: MLM2-KT
+  uuid: cfd53acb-f7fa-47b4-9a4c-b0b5ba4deb88
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Teel
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: MLM2-KTU
+  uuid: f17251b6-b2e3-43b7-a777-dd265a621f88
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Tucker
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: MLM2-LK
+  uuid: 5f93b5e8-980c-4c6d-baa7-36dd0a6970f9
+  subjects:
+  - entities:
+    - role: player
+      name: Luke Keaschall
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: MLM2-MC
+  uuid: ffa0f038-9702-4c1e-a4f4-5a8fbf110146
+  subjects:
+  - entities:
+    - role: player
+      name: Matt Chapman
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: MLM2-MT
+  uuid: a042821f-1e52-4a65-b4e6-b12ef31b1b56
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Trout
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: MLM2-MW
+  uuid: 3e505d27-ef37-42a4-ac4f-c815bc6d5418
+  subjects:
+  - entities:
+    - role: player
+      name: Masyn Winn
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: MLM2-NH
+  uuid: fb5c1621-2136-4fc3-8bb4-bc7076338fc9
+  subjects:
+  - entities:
+    - role: player
+      name: Nico Hoerner
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: MLM2-NK
+  uuid: 6dfb7efa-fb9d-4609-a161-55cedb7c0a8a
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Kurtz
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: MLM2-NM
+  uuid: 12cf9438-4e4f-4db4-964f-dd2bce061cf1
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan McLean
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: MLM2-PT
+  uuid: 16936770-6827-4d62-a326-1bf7f0a49a61
+  subjects:
+  - entities:
+    - role: player
+      name: Payton Tolle
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: MLM2-RAJ
+  uuid: 2e738c2e-7688-4158-8877-1f117df3b808
+  subjects:
+  - entities:
+    - role: player
+      name: Ronald Acuña Jr.
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: MLM2-RS
+  uuid: d5f35d97-cc8a-4d53-9119-b33fb838f7b5
+  subjects:
+  - entities:
+    - role: player
+      name: Roki Sasaki
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: MLM2-SB
+  uuid: 200756d3-3d55-40a7-bc16-74065cb51827
+  subjects:
+  - entities:
+    - role: player
+      name: Samuel Basallo
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: MLM2-SS
+  uuid: 630106f0-9a9d-4f05-99a6-12b2f8c420ae
+  subjects:
+  - entities:
+    - role: player
+      name: Sal Stewart
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: MLM2-SSC
+  uuid: 42c5ed30-2aa2-4dc7-9a10-1ab6de2652cc
+  subjects:
+  - entities:
+    - role: player
+      name: Spencer Schwellenbach
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: MLM2-SST
+  uuid: ae9e45a7-3095-4cc7-8656-45eacccd955f
+  subjects:
+  - entities:
+    - role: player
+      name: Spencer Strider
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: MLM2-TSO
+  uuid: 350362ed-ce24-40ad-9814-97ec45c4c3ac
+  subjects:
+  - entities:
+    - role: player
+      name: Tyler Soderstrom
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: MLM2-TT
+  uuid: 590abbce-f469-42ac-8981-971286b56cfc
+  subjects:
+  - entities:
+    - role: player
+      name: Trea Turner
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: MLM2-VG
+  uuid: f82a677d-43be-454a-a6d8-9dd978629b11
+  subjects:
+  - entities:
+    - role: player
+      name: Vladimir Guerrero
+      ref: 
+    - role: team
+      name: Montréal Expos
+      ref: 
+- number: MLM2-VP
+  uuid: fe48cff1-0820-4620-bcfa-0eebff7c31d6
+  subjects:
+  - entities:
+    - role: player
+      name: Vinnie Pasquantino
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: MLM2-WL
+  uuid: fac0cf07-2631-4a0b-915b-11e49153fe12
+  subjects:
+  - entities:
+    - role: player
+      name: Wyatt Langford
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: MLM2-WS
+  uuid: 4cf3b46f-bf5a-445d-9c67-3354ceaed800
+  subjects:
+  - entities:
+    - role: player
+      name: Will Smith
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: MLM2-YY
+  uuid: d378df2c-9935-4437-92a3-7193a85a9141
+  subjects:
+  - entities:
+    - role: player
+      name: Yoshinobu Yamamoto
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: MLMA-CM
+  uuid: c326b5ee-51c5-4e0f-bed4-9727572b6ab2
+  subjects:
+  - entities:
+    - role: player
+      name: Christian Moore
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: MLMA-ED
+  uuid: b0b26b7e-6d86-4bd7-8d3f-23231462fd73
+  subjects:
+  - entities:
+    - role: player
+      name: Elly De La Cruz
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: MLMA-JS
+  uuid: 91ecad36-0412-4fe0-8d5c-9c9816522b65
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: MLMA-JWI
+  uuid: aaffcbbf-19d4-43fe-b304-c3c5abb7c22c
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Wilson
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: MLMA-MO
+  uuid: 70d5218e-c5bd-4ae8-94a2-bcd7aaf1c4d5
+  subjects:
+  - entities:
+    - role: player
+      name: Matt Olson
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 

--- a/data/baseball/2026-topps-series-2/checklists/major-legaue-materials-dual-autographs.yaml
+++ b/data/baseball/2026-topps-series-2/checklists/major-legaue-materials-dual-autographs.yaml
@@ -1,0 +1,68 @@
+- number: MLMDA-AJA
+  uuid: 7c726c03-22e0-4285-a034-b344cd38f915
+  subjects:
+  - entities:
+    - role: player
+      name: Ozzie Albies
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+  - entities:
+    - role: player
+      name: Ronald Acuña Jr.
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: MLMDA-CW
+  uuid: fc5715cf-5232-46e2-a9b6-f3ab9ed7f969
+  subjects:
+  - entities:
+    - role: player
+      name: James Wood
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+  - entities:
+    - role: player
+      name: Dylan Crews
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: MLMDA-HSW
+  uuid: e2117e54-20ba-4722-8d9b-92dfdcfa2a21
+  subjects:
+  - entities:
+    - role: player
+      name: Dansby Swanson
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+  - entities:
+    - role: player
+      name: Nico Hoerner
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: MLMDA-OLH
+  uuid: 7cbd9f3e-3870-424b-8540-fd6ee33920a7
+  subjects:
+  - entities:
+    - role: player
+      name: Michael Harris II
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+  - entities:
+    - role: player
+      name: Matt Olson
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 

--- a/data/baseball/2026-topps-series-2/checklists/oversized-1991-topps-baseball.yaml
+++ b/data/baseball/2026-topps-series-2/checklists/oversized-1991-topps-baseball.yaml
@@ -1,0 +1,160 @@
+- number: 91O-1
+  uuid: 49b1c423-aca7-4907-a031-ac7fa9370bf1
+  subjects:
+  - entities:
+    - role: player
+      name: Shohei Ohtani
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: 91O-2
+  uuid: 157066f7-5624-4fe0-a44f-43477859a966
+  subjects:
+  - entities:
+    - role: player
+      name: Aaron Judge
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: 91O-3
+  uuid: b386909c-759e-4d99-a0c1-0ad1598e5b57
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Trout
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: 91O-4
+  uuid: 85edcc08-26bb-4194-b796-56108a3c9810
+  subjects:
+  - entities:
+    - role: player
+      name: Ken Griffey Jr.
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: 91O-5
+  uuid: 77307e4f-cd6b-450f-8714-194024beb1c4
+  subjects:
+  - entities:
+    - role: player
+      name: Ronald Acuña Jr.
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: 91O-6
+  uuid: dc1bc3dc-d7fa-4ab5-b48a-e8cdcea60a25
+  subjects:
+  - entities:
+    - role: player
+      name: Bobby Witt Jr.
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: 91O-7
+  uuid: 40d09c3b-747c-4c99-ac1d-05008dce8006
+  subjects:
+  - entities:
+    - role: player
+      name: Munetaka Murakami
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: 91O-8
+  uuid: 8d68e20d-8e9f-4f0e-9dcf-d7cc010abbcd
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Crow-Armstrong
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: 91O-9
+  uuid: 71451320-3b8e-43a5-9b97-30c6eb9ea625
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: 91O-10
+  uuid: 037a15fd-bd78-4277-9ca5-9c46ec49a06c
+  subjects:
+  - entities:
+    - role: player
+      name: Gunnar Henderson
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: 91O-11
+  uuid: cdfee425-e1c1-4cf3-8e35-725b6482ed2d
+  subjects:
+  - entities:
+    - role: player
+      name: Elly De La Cruz
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: 91O-12
+  uuid: d845caa4-5a6e-4496-91a7-7373cf47328b
+  subjects:
+  - entities:
+    - role: player
+      name: Fernando Tatis Jr.
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: 91O-13
+  uuid: bc2543d1-7f6b-48ad-8c75-0f32a7d1ebb5
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Harper
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: 91O-14
+  uuid: 4e8b31ce-6823-41e0-badf-ed5fda5603cc
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Kurtz
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: 91O-15
+  uuid: 5e5babf0-696a-4c22-a269-a4b7904e078b
+  subjects:
+  - entities:
+    - role: player
+      name: Jac Caglianone
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: 91O-16
+  uuid: e2bc0adb-9029-4a3d-a0f7-1e90b81779f3
+  subjects:
+  - entities:
+    - role: player
+      name: Roman Anthony
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 

--- a/data/baseball/2026-topps-series-2/checklists/oversized-2026-topps-baseball.yaml
+++ b/data/baseball/2026-topps-series-2/checklists/oversized-2026-topps-baseball.yaml
@@ -1,0 +1,160 @@
+- number: '368'
+  uuid: 9e9eb65a-fbf1-454b-8f35-8ed6806c6c7c
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Tucker
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '372'
+  uuid: c5c5ccef-4956-4d56-b759-fd49cb9171b6
+  subjects:
+  - entities:
+    - role: player
+      name: Sal Stewart
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '400'
+  uuid: 9e7371ff-b934-4d28-a068-c4a3964a74db
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Alonso
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '406'
+  uuid: 603af0f5-64a6-48eb-8692-4c0fa071909b
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Eldridge
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '448'
+  uuid: cd049ad8-bb08-4b45-b9b4-b37333df6df4
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Chourio
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: '458'
+  uuid: e511d110-5d59-4c71-8f53-ed1b72fdcf7d
+  subjects:
+  - entities:
+    - role: player
+      name: Chase DeLauter
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '468'
+  uuid: e3e844ff-796c-4b8d-87fd-4f140a767c40
+  subjects:
+  - entities:
+    - role: player
+      name: Yordan Alvarez
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '473'
+  uuid: dfdefc1d-52e9-4b76-baf8-51d4a41c6de2
+  subjects:
+  - entities:
+    - role: player
+      name: Bo Bichette
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '500'
+  uuid: 63a54735-c0b7-4bfe-8cf2-baa514523522
+  subjects:
+  - entities:
+    - role: player
+      name: Shohei Ohtani
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '503'
+  uuid: 1c7a8ced-bb59-434f-97b6-5904ca48e7e3
+  subjects:
+  - entities:
+    - role: player
+      name: Munetaka Murakami
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: '530'
+  uuid: 419e2b0f-5896-4e4b-b99e-5b9adbec8c51
+  subjects:
+  - entities:
+    - role: player
+      name: Carter Jensen
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: '560'
+  uuid: e9317249-a91b-4cf6-a3fc-13f302fa5a6e
+  subjects:
+  - entities:
+    - role: player
+      name: Jarren Duran
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '600'
+  uuid: f1c14a95-3484-41a6-9a44-4620c37126b2
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '620'
+  uuid: 46c356a5-493a-49a5-b7d3-17f3a0c53d78
+  subjects:
+  - entities:
+    - role: player
+      name: Trey Yesavage
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '650'
+  uuid: 6619532c-6610-4c30-8dd1-d0787d14064f
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Schwarber
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: '685'
+  uuid: f880dd3f-6886-4746-8d2e-2b91c952461a
+  subjects:
+  - entities:
+    - role: player
+      name: Seiya Suzuki
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 

--- a/data/baseball/2026-topps-series-2/checklists/player-number-variations.yaml
+++ b/data/baseball/2026-topps-series-2/checklists/player-number-variations.yaml
@@ -1,0 +1,250 @@
+- number: '358'
+  uuid: f42c3673-aafa-40da-ac1c-f91d5272e7d7
+  subjects:
+  - entities:
+    - role: player
+      name: Adley Rutschman
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '372'
+  uuid: f3cda8cd-7a2a-451e-b67f-8f10b5c9af7c
+  subjects:
+  - entities:
+    - role: player
+      name: Sal Stewart
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '398'
+  uuid: bb200128-774f-40a6-8ab5-9a796d470906
+  subjects:
+  - entities:
+    - role: player
+      name: Hunter Barco
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '400'
+  uuid: e8024982-e89f-44a1-b384-cbb7e4927412
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Alonso
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '406'
+  uuid: 3f9eff0b-3a57-4832-ad18-8466325e8bed
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Eldridge
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '415'
+  uuid: 0f637de5-e204-4189-b5d6-c7458501e246
+  subjects:
+  - entities:
+    - role: player
+      name: Justin Verlander
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '448'
+  uuid: fc3bd5c8-7c23-496f-9ffe-f2cc2f1f2c2f
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Chourio
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: '450'
+  uuid: 42939b20-9aac-436d-a75a-12013ef77ffa
+  subjects:
+  - entities:
+    - role: player
+      name: Gerrit Cole
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '458'
+  uuid: 6ac522d1-7eed-4fee-bd96-2c5fc7e5494b
+  subjects:
+  - entities:
+    - role: player
+      name: Chase DeLauter
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '459'
+  uuid: ce10dd79-990e-4602-904a-322cae4afd07
+  subjects:
+  - entities:
+    - role: player
+      name: Ketel Marte
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: '468'
+  uuid: aafda479-1a4b-4cba-a2f0-f282cb353089
+  subjects:
+  - entities:
+    - role: player
+      name: Yordan Alvarez
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '473'
+  uuid: d2a98f5d-7920-4d5a-a68c-a00862954657
+  subjects:
+  - entities:
+    - role: player
+      name: Bo Bichette
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '500'
+  uuid: e6d8025f-22f2-4035-adf9-fd1eaf30992a
+  subjects:
+  - entities:
+    - role: player
+      name: Shohei Ohtani
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '503'
+  uuid: dac3ee60-fecb-4fd1-9821-1ced8a2b4acd
+  subjects:
+  - entities:
+    - role: player
+      name: Munetaka Murakami
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: '530'
+  uuid: 0c1ca4b5-21d3-4e58-bcaa-3526e2d0f2c4
+  subjects:
+  - entities:
+    - role: player
+      name: Carter Jensen
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: '534'
+  uuid: 602c5a80-f192-4946-b480-39f145b75189
+  subjects:
+  - entities:
+    - role: player
+      name: Brandon Sproat
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: '561'
+  uuid: 356d4d61-4cc7-4c94-bf1b-db5c773d12b4
+  subjects:
+  - entities:
+    - role: player
+      name: Matt Chapman
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '568'
+  uuid: fc8e1b28-1d2e-494f-ac28-91257d97ef07
+  subjects:
+  - entities:
+    - role: player
+      name: Ozzie Albies
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: '600'
+  uuid: 0aaf0283-7160-4c50-be6a-dce9d1d4cf60
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '614'
+  uuid: fa4c5394-860b-4c74-8cfa-a4925e63a7e2
+  subjects:
+  - entities:
+    - role: player
+      name: Manny Machado
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: '620'
+  uuid: 2aef1477-20f4-4195-8fe0-11b7e0a7b057
+  subjects:
+  - entities:
+    - role: player
+      name: Trey Yesavage
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '632'
+  uuid: cd53469b-9db5-49e0-ae89-5f895e4cfaf1
+  subjects:
+  - entities:
+    - role: player
+      name: Cade Horton
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '650'
+  uuid: accf6654-fd8d-4eb5-8099-04c3081a78df
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Schwarber
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: '659'
+  uuid: 25c8723a-6cba-4586-ac1e-3348ac3ff4d9
+  subjects:
+  - entities:
+    - role: player
+      name: Harry Ford
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: '700'
+  uuid: 7acb2b7b-41c7-456d-86e4-e985fa6d2590
+  subjects:
+  - entities:
+    - role: player
+      name: Freddie Freeman
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 

--- a/data/baseball/2026-topps-series-2/checklists/postseason-performance-autographs.yaml
+++ b/data/baseball/2026-topps-series-2/checklists/postseason-performance-autographs.yaml
@@ -1,0 +1,330 @@
+- number: PPA-ABR
+  uuid: c8c292ae-5943-4bda-a74d-767d51f0ca4b
+  subjects:
+  - entities:
+    - role: player
+      name: Alex Bregman
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: PPA-AG
+  uuid: 3ccc9102-1536-4214-9ece-9aeb925d4f35
+  subjects:
+  - entities:
+    - role: player
+      name: Andrés Giménez
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: PPA-AV
+  uuid: 51d21358-3a7a-4569-a212-e480c7cf689f
+  subjects:
+  - entities:
+    - role: player
+      name: Anthony Volpe
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: PPA-BR
+  uuid: b40d4166-85b7-47a3-82c2-988726ceeaf3
+  subjects:
+  - entities:
+    - role: player
+      name: Ben Rice
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: PPA-BT
+  uuid: fe24eb05-704b-452f-8929-2f5867a9ea6f
+  subjects:
+  - entities:
+    - role: player
+      name: Brice Turang
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: PPA-CD
+  uuid: 37990e67-c239-49ec-8f72-08e2317fc04a
+  subjects:
+  - entities:
+    - role: player
+      name: Caleb Durbin
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: PPA-CS
+  uuid: e3663e50-377e-4a10-9d24-5178a9025233
+  subjects:
+  - entities:
+    - role: player
+      name: Cam Schlittler
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: PPA-CY
+  uuid: ab916db4-7284-4112-be71-a2f7b0fc7a8c
+  subjects:
+  - entities:
+    - role: player
+      name: Christian Yelich
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: PPA-ED
+  uuid: 00121dcf-c184-473f-88cc-901332d73c5e
+  subjects:
+  - entities:
+    - role: player
+      name: Elly De La Cruz
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: PPA-FP
+  uuid: b0b8834a-1cbc-4383-8146-a0d73fda2dff
+  subjects:
+  - entities:
+    - role: player
+      name: Freddy Peralta
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: PPA-GK
+  uuid: c5bf13ca-6e3f-4fa0-8788-254d5bb0891d
+  subjects:
+  - entities:
+    - role: player
+      name: George Kirby
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: PPA-GSP
+  uuid: e54d8cc0-5408-46df-8d50-8d3cac37939b
+  subjects:
+  - entities:
+    - role: player
+      name: George Springer
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: PPA-JC
+  uuid: ea70739e-6980-4395-8914-6a72f7d0c528
+  subjects:
+  - entities:
+    - role: player
+      name: Jazz Chisholm Jr.
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: PPA-JD
+  uuid: fcf28faf-f91e-46a3-ad22-9a9cd36a12fc
+  subjects:
+  - entities:
+    - role: player
+      name: Jhoan Duran
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: PPA-JM
+  uuid: 17342616-c764-4cd5-92bd-59ba9cf31f25
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Merrill
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: PPA-JMI
+  uuid: 3ce6cf42-5a43-4d05-b18f-a2cf21b5d4de
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Misiorowski
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: PPA-JRA
+  uuid: 3c5e7d61-0f9e-494f-a23a-e745c6e19066
+  subjects:
+  - entities:
+    - role: player
+      name: José Ramírez
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: PPA-JTR
+  uuid: 0c101979-3371-44e8-8264-9eed4c336a69
+  subjects:
+  - entities:
+    - role: player
+      name: J.T. Realmuto
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: PPA-KC
+  uuid: 93b2de76-aa0c-4649-8f75-2b227f25b816
+  subjects:
+  - entities:
+    - role: player
+      name: Kerry Carpenter
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: PPA-LC
+  uuid: ac71f8d2-1fa9-4a67-b953-6ab77e5403b9
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Castillo
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: PPA-MBU
+  uuid: 427341cd-5be8-4d1a-b1d5-eaf4f14eb650
+  subjects:
+  - entities:
+    - role: player
+      name: Michael Busch
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: PPA-MM
+  uuid: 77b947c9-94fb-462f-9a4e-ee9b7f127c12
+  subjects:
+  - entities:
+    - role: player
+      name: Manny Machado
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: PPA-MY
+  uuid: 6c0426ce-da6e-4890-a95f-ac9dd5013006
+  subjects:
+  - entities:
+    - role: player
+      name: Masataka Yoshida
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: PPA-NH
+  uuid: ef3eb6b9-3435-4600-80e8-288b60cb9f96
+  subjects:
+  - entities:
+    - role: player
+      name: Nico Hoerner
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: PPA-RG
+  uuid: a599698c-e3eb-4859-862a-0a287635f877
+  subjects:
+  - entities:
+    - role: player
+      name: Riley Greene
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: PPA-SF
+  uuid: 24f80a4a-3f86-4184-be5b-de71e09774b2
+  subjects:
+  - entities:
+    - role: player
+      name: Sal Frelick
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: PPA-SK
+  uuid: dcb6105d-0a2d-40a2-b0fe-aa1c68be2fa4
+  subjects:
+  - entities:
+    - role: player
+      name: Steven Kwan
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: PPA-SST
+  uuid: cb42b154-8769-4c05-81be-8bd79415f147
+  subjects:
+  - entities:
+    - role: player
+      name: Sal Stewart
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: PPA-SSU
+  uuid: a275800c-0edc-413f-bdfc-e19d667c2698
+  subjects:
+  - entities:
+    - role: player
+      name: Seiya Suzuki
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: PPA-TS
+  uuid: 63550c33-72cf-4a0b-9971-653bbbd50b59
+  subjects:
+  - entities:
+    - role: player
+      name: Tarik Skubal
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: PPA-TT
+  uuid: 5342d6f8-8c69-4288-a800-86289638d1cb
+  subjects:
+  - entities:
+    - role: player
+      name: Trea Turner
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: PPA-TY
+  uuid: 35fa8ccc-b612-4056-b110-4cde96558d7a
+  subjects:
+  - entities:
+    - role: player
+      name: Trey Yesavage
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: PPA-VG
+  uuid: 2458e6b0-38fc-462a-953c-3bc997de5647
+  subjects:
+  - entities:
+    - role: player
+      name: Vladimir Guerrero Jr.
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 

--- a/data/baseball/2026-topps-series-2/checklists/real-one-relics.yaml
+++ b/data/baseball/2026-topps-series-2/checklists/real-one-relics.yaml
@@ -1,0 +1,450 @@
+- number: '352'
+  uuid: d3a789ca-041b-40b5-8bd4-80d08da3f2d4
+  subjects:
+  - entities:
+    - role: player
+      name: Spencer Torkelson
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '358'
+  uuid: a9b002e3-aed6-4593-82c3-2c4da0666205
+  subjects:
+  - entities:
+    - role: player
+      name: Adley Rutschman
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '363'
+  uuid: e0aa18f8-6ff8-41f8-8779-7a10818c34ed
+  subjects:
+  - entities:
+    - role: player
+      name: J.T. Realmuto
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: '368'
+  uuid: 4ed02102-d182-4e66-9d4b-6fc082d2babf
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Tucker
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '371'
+  uuid: ab55b784-e862-4a95-a653-f11e6c9a338a
+  subjects:
+  - entities:
+    - role: player
+      name: Brent Rooker
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: '372'
+  uuid: 35052f32-d13c-4f22-ad7e-57e37b638a71
+  subjects:
+  - entities:
+    - role: player
+      name: Sal Stewart
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '382'
+  uuid: 9a6110b1-2a8b-421a-a0f7-e45b6e1b74d3
+  subjects:
+  - entities:
+    - role: player
+      name: Hunter Greene
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '383'
+  uuid: 6d20e182-84d0-4875-826e-7b37d185ddd1
+  subjects:
+  - entities:
+    - role: player
+      name: Wyatt Langford
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: '393'
+  uuid: b3e3bfb2-7dc4-45f7-9f3b-39937e9fa005
+  subjects:
+  - entities:
+    - role: player
+      name: Jazz Chisholm Jr.
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '400'
+  uuid: b4c2526f-6eb4-435e-9123-fa4e72b9660b
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Alonso
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '415'
+  uuid: 0217526e-1f34-43f1-a8c2-ea03174915fd
+  subjects:
+  - entities:
+    - role: player
+      name: Justin Verlander
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '423'
+  uuid: 2452b050-b52a-4963-8217-f7f36c8111eb
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Robert Jr.
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '427'
+  uuid: 7752e121-4315-4ee1-9221-e3c3cf57c6b4
+  subjects:
+  - entities:
+    - role: player
+      name: Chris Sale
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: '431'
+  uuid: 9f33ba96-d601-4e90-9682-9be7b66d8ce8
+  subjects:
+  - entities:
+    - role: player
+      name: Randy Arozarena
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: '441'
+  uuid: e81d5ccb-cafd-421c-bbb3-a20a0ffb193d
+  subjects:
+  - entities:
+    - role: player
+      name: Lars Nootbaar
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: '448'
+  uuid: 703513c3-3ec9-412d-9cae-b305777c9073
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Chourio
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: '450'
+  uuid: 6fe66068-0e30-4d02-9a2a-dbf5eae53dc4
+  subjects:
+  - entities:
+    - role: player
+      name: Gerrit Cole
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '455'
+  uuid: 74d0452e-7860-4c3d-ad5b-3d433dcf9e27
+  subjects:
+  - entities:
+    - role: player
+      name: George Springer
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '459'
+  uuid: c3235ad2-6b41-4484-96ec-119f3aee9b50
+  subjects:
+  - entities:
+    - role: player
+      name: Ketel Marte
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: '468'
+  uuid: 8031c333-2050-4713-9285-e94db37be1d4
+  subjects:
+  - entities:
+    - role: player
+      name: Yordan Alvarez
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '471'
+  uuid: 8c65b58a-0aee-4cc0-9534-981315111c52
+  subjects:
+  - entities:
+    - role: player
+      name: J.P. Crawford
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: '473'
+  uuid: 483599af-6098-49ba-8d21-4391a169d67b
+  subjects:
+  - entities:
+    - role: player
+      name: Bo Bichette
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '500'
+  uuid: 1a4a4d21-c985-499c-88b3-a422bcfa55b4
+  subjects:
+  - entities:
+    - role: player
+      name: Shohei Ohtani
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '526'
+  uuid: 9a71d60c-f27b-4272-ab69-6d94ac5099da
+  subjects:
+  - entities:
+    - role: player
+      name: Masyn Winn
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: '533'
+  uuid: 2df799de-d038-48bc-b043-5f72b5c209db
+  subjects:
+  - entities:
+    - role: player
+      name: Jasson Domínguez
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '536'
+  uuid: 60056f4e-74c7-4758-8a2f-55c0eed195b3
+  subjects:
+  - entities:
+    - role: player
+      name: Trevor Story
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '541'
+  uuid: ed0eccbb-9760-427b-a4b5-fbcc00e1e94a
+  subjects:
+  - entities:
+    - role: player
+      name: Jung Hoo Lee
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '550'
+  uuid: 3a700364-194a-4575-9c26-b1df06fb0169
+  subjects:
+  - entities:
+    - role: player
+      name: Dansby Swanson
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '560'
+  uuid: 0571c9f0-51f1-4250-915a-35d2a7de2a0c
+  subjects:
+  - entities:
+    - role: player
+      name: Jarren Duran
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '561'
+  uuid: bfba9cad-57ce-48e7-9a37-bb2ebfe6185d
+  subjects:
+  - entities:
+    - role: player
+      name: Matt Chapman
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '568'
+  uuid: e71825f0-9167-4b57-b7cc-ce4f77ab53ab
+  subjects:
+  - entities:
+    - role: player
+      name: Ozzie Albies
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: '569'
+  uuid: 413cef50-6755-461f-b485-4a42c2789322
+  subjects:
+  - entities:
+    - role: player
+      name: Max Scherzer
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '600'
+  uuid: 69ddf340-158b-43d7-b849-33628b606560
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '607'
+  uuid: f3e6e132-c7bf-4b83-b2e7-eecdb337f81d
+  subjects:
+  - entities:
+    - role: player
+      name: Cody Bellinger
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '614'
+  uuid: ef19a894-f73c-4ae3-a129-eca201255e55
+  subjects:
+  - entities:
+    - role: player
+      name: Manny Machado
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: '629'
+  uuid: 83734e8b-f149-4f8c-817c-89c44bd28fda
+  subjects:
+  - entities:
+    - role: player
+      name: Tyler Glasnow
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '631'
+  uuid: a0ced625-2aa0-47d1-b35f-ef695daea215
+  subjects:
+  - entities:
+    - role: player
+      name: Will Smith
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '632'
+  uuid: 55c96093-128b-4c50-b0d8-2357be219dd6
+  subjects:
+  - entities:
+    - role: player
+      name: Cade Horton
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '633'
+  uuid: 802ec530-e9ff-45c6-8b1d-6f1c19029a6d
+  subjects:
+  - entities:
+    - role: player
+      name: Salvador Perez
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: '650'
+  uuid: f902d052-ca00-451d-bd01-eeb002a39b67
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Schwarber
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: '675'
+  uuid: 91b9770b-3f87-4ca0-bbe6-77dab4948d8a
+  subjects:
+  - entities:
+    - role: player
+      name: Steven Kwan
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '680'
+  uuid: 8fda854c-0084-47ba-94ce-2bc0f891da8c
+  subjects:
+  - entities:
+    - role: player
+      name: Carlos Correa
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '685'
+  uuid: a9ddde9d-ffa6-47cf-afdf-8793cf8277e9
+  subjects:
+  - entities:
+    - role: player
+      name: Seiya Suzuki
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '692'
+  uuid: 4a2b3f38-5836-414b-a351-eb90a87abe7d
+  subjects:
+  - entities:
+    - role: player
+      name: Drake Baldwin
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: '700'
+  uuid: 0b3909de-fdf7-4168-b6b9-860937a5022a
+  subjects:
+  - entities:
+    - role: player
+      name: Freddie Freeman
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 

--- a/data/baseball/2026-topps-series-2/checklists/rounding-the-bases-autographs.yaml
+++ b/data/baseball/2026-topps-series-2/checklists/rounding-the-bases-autographs.yaml
@@ -1,0 +1,610 @@
+- number: RTB-AB
+  uuid: e5c9fb5a-4d73-4c80-9f09-53762e4f1ac0
+  subjects:
+  - entities:
+    - role: player
+      name: Alex Bregman
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: RTB-AJ
+  uuid: 48a98f7d-67e2-4531-b87b-c0d80344b994
+  subjects:
+  - entities:
+    - role: player
+      name: Aaron Judge
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: RTB-AJU
+  uuid: bb3ddf27-f04a-4170-9bce-8e9cdedf6231
+  subjects:
+  - entities:
+    - role: player
+      name: Aaron Judge
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: RTB-AM
+  uuid: 150cbcaf-8db7-443c-b9ab-ab585816c79b
+  subjects:
+  - entities:
+    - role: player
+      name: Andrew McCutchen
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: RTB-AV
+  uuid: af436808-9789-4c04-8721-381e43dfe621
+  subjects:
+  - entities:
+    - role: player
+      name: Anthony Volpe
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: RTB-BL
+  uuid: 35cee88a-c24a-4a07-aa4d-f349a6bb9e2d
+  subjects:
+  - entities:
+    - role: player
+      name: Brooks Lee
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: RTB-BR
+  uuid: 3c135043-081f-4297-9440-65dfde2f76d2
+  subjects:
+  - entities:
+    - role: player
+      name: Brent Rooker
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: RTB-BWJ
+  uuid: 5c48cd7a-df6e-4358-84dd-97fd77192068
+  subjects:
+  - entities:
+    - role: player
+      name: Bobby Witt Jr.
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: RTB-CA
+  uuid: 4113254e-6ff4-40ef-bed5-78fb50dc8092
+  subjects:
+  - entities:
+    - role: player
+      name: CJ Abrams
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: RTB-CB
+  uuid: 6bc9e215-7716-42d0-8e93-e1ec60d06b7c
+  subjects:
+  - entities:
+    - role: player
+      name: Cody Bellinger
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: RTB-CF
+  uuid: 0e7edc24-73fd-45f4-b7ae-1c41b10124cd
+  subjects:
+  - entities:
+    - role: player
+      name: Cody Freeman
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: RTB-CM
+  uuid: 1e50efa4-2191-4a88-a376-439829046334
+  subjects:
+  - entities:
+    - role: player
+      name: Coby Mayo
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: RTB-CN
+  uuid: 8de73578-6ef0-4a82-8bf8-7bb587568996
+  subjects:
+  - entities:
+    - role: player
+      name: Carlos Narváez
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: RTB-CR
+  uuid: f58fb2fb-a81a-407d-aac3-398455b2ce8a
+  subjects:
+  - entities:
+    - role: player
+      name: Cal Raleigh
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: RTB-CS
+  uuid: 6da1c96c-4a4b-4416-a480-728b24dd10ed
+  subjects:
+  - entities:
+    - role: player
+      name: Corey Seager
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: RTB-CY
+  uuid: 31023669-02ad-4935-b8a1-44d1eae51f0e
+  subjects:
+  - entities:
+    - role: player
+      name: Christian Yelich
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: RTB-DC
+  uuid: aa7f6c1b-184e-497e-8f53-c6f66b2033ad
+  subjects:
+  - entities:
+    - role: player
+      name: Dylan Crews
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: RTB-DS
+  uuid: 2f998d15-dfe0-44d6-a9c0-a3bf38ec0f6a
+  subjects:
+  - entities:
+    - role: player
+      name: Dansby Swanson
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: RTB-ED
+  uuid: 10f73ceb-0924-4e73-92da-6bfd339ab6b7
+  subjects:
+  - entities:
+    - role: player
+      name: Elly De La Cruz
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: RTB-FL
+  uuid: 415e0a6c-83fc-449b-ba6f-f9ec4c04bc51
+  subjects:
+  - entities:
+    - role: player
+      name: Francisco Lindor
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: RTB-FT
+  uuid: aac309bc-34d8-40e6-88a6-175462d8fa42
+  subjects:
+  - entities:
+    - role: player
+      name: Fernando Tatis Jr.
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: RTB-GS
+  uuid: d65012dd-be3e-4b29-9f5d-6e1add07bd77
+  subjects:
+  - entities:
+    - role: player
+      name: George Springer
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: RTB-GV
+  uuid: 901bd2f5-4c53-4449-8979-a1101d7c0984
+  subjects:
+  - entities:
+    - role: player
+      name: George Valera
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: RTB-IH
+  uuid: 23cf1c0b-32da-4b5d-a8ee-03367d4a4c89
+  subjects:
+  - entities:
+    - role: player
+      name: Ian Happ
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: RTB-JA
+  uuid: a43d26f8-f115-47e7-a41b-475c0a34a1ab
+  subjects:
+  - entities:
+    - role: player
+      name: Jonathan Aranda
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: RTB-JC
+  uuid: 8d14e6a8-6435-4819-9e2f-fcea19d56b85
+  subjects:
+  - entities:
+    - role: player
+      name: Jazz Chisholm Jr.
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: RTB-JCA
+  uuid: 3efc48b7-4f5e-42bb-8500-ddf61a341b6b
+  subjects:
+  - entities:
+    - role: player
+      name: Junior Caminero
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: RTB-JCH
+  uuid: 32ea2fe6-ef74-4d12-831f-d8d93bc10ed8
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Chourio
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: RTB-JD
+  uuid: f0e5dc03-d386-40f8-a676-04984aebba0d
+  subjects:
+  - entities:
+    - role: player
+      name: Jarren Duran
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: RTB-JH
+  uuid: 4b73cf07-d130-4c65-b27f-a0573a3e657b
+  subjects:
+  - entities:
+    - role: player
+      name: Jung Hoo Lee
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: RTB-JJ
+  uuid: 3f6a4d29-669d-4b83-b64e-479bb9ac1240
+  subjects:
+  - entities:
+    - role: player
+      name: Josh Jung
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: RTB-JM
+  uuid: b6e870cf-601c-4723-9fb6-3156cc218f92
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Merrill
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: RTB-JR
+  uuid: ccf13241-a681-4d4f-a6f5-f9b79fd93f0e
+  subjects:
+  - entities:
+    - role: player
+      name: J.T. Realmuto
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: RTB-JRA
+  uuid: 9f1ff99e-bff3-4dfa-ba69-4834c8751266
+  subjects:
+  - entities:
+    - role: player
+      name: José Ramírez
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: RTB-JRO
+  uuid: fce9bb35-5eb3-4cdc-97d4-818ace26b613
+  subjects:
+  - entities:
+    - role: player
+      name: Julio Rodríguez
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: RTB-JRZ
+  uuid: a2fbcde1-0df1-46d7-bbce-d6e7602973a2
+  subjects:
+  - entities:
+    - role: player
+      name: José Ramírez
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: RTB-JS
+  uuid: 791cb2ea-5f3c-494a-b026-a15fc8830324
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: RTB-JW
+  uuid: 8af90fe7-90fa-4f6c-8a73-63f58de7aa8b
+  subjects:
+  - entities:
+    - role: player
+      name: Jordan Westburg
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: RTB-JWI
+  uuid: eb0726d8-a2e3-4605-a122-929b2766c1b5
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Wilson
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: RTB-KC
+  uuid: afa72e00-85a6-490b-b54d-a74301942241
+  subjects:
+  - entities:
+    - role: player
+      name: Kerry Carpenter
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: RTB-KM
+  uuid: 4bb6f8ad-8599-4545-94ce-f72b00bb8140
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Manzardo
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: RTB-KT
+  uuid: 9b3ec95d-79e4-4fdf-9a59-6658bebe23d3
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Tucker
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: RTB-KTE
+  uuid: ef5cc916-b665-4352-b37d-0c6370834a77
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Teel
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: RTB-MO
+  uuid: 64aa92d6-f5b0-44ae-862a-efde7b53caa5
+  subjects:
+  - entities:
+    - role: player
+      name: Matt Olson
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: RTB-MS
+  uuid: a18ff2c2-0cf2-4d17-abc6-7c6d754940a0
+  subjects:
+  - entities:
+    - role: player
+      name: Matt Shaw
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: RTB-MSE
+  uuid: b1c65853-db55-4163-bd35-d065880b4af4
+  subjects:
+  - entities:
+    - role: player
+      name: Marcus Semien
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: RTB-NA
+  uuid: ad28bb1f-7dfa-43be-9b5a-2bcd60ea81bf
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan Arenado
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: RTB-NC
+  uuid: 4c3eaefa-780a-4e3d-ab85-2b17dc81e719
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Castellanos
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: RTB-NK
+  uuid: 475fef2c-7ea1-48ad-99e9-0794bf37403f
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Kurtz
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: RTB-OC
+  uuid: b998d3f4-1f0c-44f2-ab44-ce52a4313b03
+  subjects:
+  - entities:
+    - role: player
+      name: Owen Caissie
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: RTB-PA
+  uuid: 4f828f21-3c32-4923-8126-df7311a911d2
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Alonso
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: RTB-PG
+  uuid: 30d37990-9e12-4428-903a-e6a9b21a527a
+  subjects:
+  - entities:
+    - role: player
+      name: Paul Goldschmidt
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: RTB-RA
+  uuid: c096b22f-7651-47c2-8c1c-a5e9981450bd
+  subjects:
+  - entities:
+    - role: player
+      name: Ronald Acuña Jr.
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: RTB-RG
+  uuid: 868bae90-3a00-419c-84e0-d773070d684a
+  subjects:
+  - entities:
+    - role: player
+      name: Riley Greene
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: RTB-SK
+  uuid: b5d7f22e-574e-4964-a2ee-2c8e9b7fb724
+  subjects:
+  - entities:
+    - role: player
+      name: Steven Kwan
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: RTB-SO
+  uuid: 6dc12462-7eea-4b92-84e3-084134d3b9a0
+  subjects:
+  - entities:
+    - role: player
+      name: Shohei Ohtani
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: RTB-SOTO
+  uuid: cce6b530-9619-4a91-9aec-1c4f8d5d7843
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: RTB-SS
+  uuid: ccff1abb-41b3-423b-ac47-5b7bbe12fd51
+  subjects:
+  - entities:
+    - role: player
+      name: Seiya Suzuki
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: RTB-VG
+  uuid: c5bf8d0c-6e7a-4dcd-a7cb-fbc1d712d6c6
+  subjects:
+  - entities:
+    - role: player
+      name: Vladimir Guerrero Jr.
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: RTB-WC
+  uuid: b5367f2b-2956-4bf3-b7ae-755e1580c7be
+  subjects:
+  - entities:
+    - role: player
+      name: William Contreras
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: RTB-ZV
+  uuid: 95bb61a6-b3b7-45c8-a4e5-95be7b6a9d78
+  subjects:
+  - entities:
+    - role: player
+      name: Zac Veen
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 

--- a/data/baseball/2026-topps-series-2/checklists/rounding-the-bases-relics.yaml
+++ b/data/baseball/2026-topps-series-2/checklists/rounding-the-bases-relics.yaml
@@ -1,0 +1,790 @@
+- number: RTB-AB
+  uuid: faf46e14-ec14-44d1-813f-f302a883aa11
+  subjects:
+  - entities:
+    - role: player
+      name: Alex Bregman
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: RTB-AJ
+  uuid: f1bae025-4793-44dc-92da-93feaf75f938
+  subjects:
+  - entities:
+    - role: player
+      name: Aaron Judge
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: RTB-AJU
+  uuid: 1a1805fb-29e0-4214-a6a8-a319cf2b54e2
+  subjects:
+  - entities:
+    - role: player
+      name: Aaron Judge
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: RTB-AM
+  uuid: 8e69e1a0-aa6b-49fb-8386-e4ab14b03b85
+  subjects:
+  - entities:
+    - role: player
+      name: Andrew McCutchen
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: RTB-AV
+  uuid: '08ad87bf-5248-4e6e-adaa-9bc727eb90b5'
+  subjects:
+  - entities:
+    - role: player
+      name: Anthony Volpe
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: RTB-BB
+  uuid: f10172dd-32ad-4602-9480-be9414fc7a11
+  subjects:
+  - entities:
+    - role: player
+      name: Bo Bichette
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: RTB-BHA
+  uuid: 7a7aa248-07ea-4a31-8d80-ba96d31205ea
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Harper
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: RTB-BHR
+  uuid: 5dec117b-bd85-4dc8-8ab6-6b8a10fcda56
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Harper
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: RTB-BL
+  uuid: 95edb94a-91bc-4f88-9d20-164d2a274d4f
+  subjects:
+  - entities:
+    - role: player
+      name: Brooks Lee
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: RTB-BR
+  uuid: 633df84a-c41d-423f-8c2a-45244ee06d69
+  subjects:
+  - entities:
+    - role: player
+      name: Brent Rooker
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: RTB-BW
+  uuid: 46096d32-d214-435b-93de-bc7af6b13add
+  subjects:
+  - entities:
+    - role: player
+      name: Bobby Witt Jr.
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: RTB-BWJ
+  uuid: cacb94d3-299d-4aea-a091-83c4cb916b90
+  subjects:
+  - entities:
+    - role: player
+      name: Bobby Witt Jr.
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: RTB-CA
+  uuid: b3cdb990-f041-4712-b724-4ee290200c84
+  subjects:
+  - entities:
+    - role: player
+      name: CJ Abrams
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: RTB-CB
+  uuid: 65090107-6064-46d1-b6c1-4af0a1b8af85
+  subjects:
+  - entities:
+    - role: player
+      name: Cody Bellinger
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: RTB-CC
+  uuid: 5ce43b6c-a008-4dc3-bc50-233bb10f8270
+  subjects:
+  - entities:
+    - role: player
+      name: Carlos Correa
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: RTB-CF
+  uuid: 606ca41b-7b28-4a2f-8ada-d1ec4eb866f4
+  subjects:
+  - entities:
+    - role: player
+      name: Cody Freeman
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: RTB-CM
+  uuid: a5d51e2a-0c13-46db-9bf3-2e1341890be3
+  subjects:
+  - entities:
+    - role: player
+      name: Coby Mayo
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: RTB-CN
+  uuid: 5ae24805-c662-449a-8f5e-7d7209c290d2
+  subjects:
+  - entities:
+    - role: player
+      name: Carlos Narváez
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: RTB-CR
+  uuid: bcbd990f-d104-44fe-94a5-1baabcffb260
+  subjects:
+  - entities:
+    - role: player
+      name: Cal Raleigh
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: RTB-CRA
+  uuid: 349d8a1e-9a45-4aa2-b8f5-ad49c6dc517b
+  subjects:
+  - entities:
+    - role: player
+      name: Cal Raleigh
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: RTB-CS
+  uuid: 3306c883-b83f-47cc-9958-48900b29f73d
+  subjects:
+  - entities:
+    - role: player
+      name: Corey Seager
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: RTB-CY
+  uuid: bdd09fb1-cd41-4406-b8da-cccd00654ea5
+  subjects:
+  - entities:
+    - role: player
+      name: Christian Yelich
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: RTB-DC
+  uuid: eb4f546a-75fe-421f-a20e-8d8d1920f6cc
+  subjects:
+  - entities:
+    - role: player
+      name: Dylan Crews
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: RTB-DS
+  uuid: 5b94a645-4b4f-403e-a63d-a438db5829c1
+  subjects:
+  - entities:
+    - role: player
+      name: Dansby Swanson
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: RTB-ED
+  uuid: bc9a0518-fc30-4105-920c-2516cba13ba3
+  subjects:
+  - entities:
+    - role: player
+      name: Elly De La Cruz
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: RTB-FL
+  uuid: 8e3ac865-de9f-4b35-9219-62d3279138d0
+  subjects:
+  - entities:
+    - role: player
+      name: Francisco Lindor
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: RTB-FT
+  uuid: fe07819f-2fa0-483b-8db8-d5c27d7a4149
+  subjects:
+  - entities:
+    - role: player
+      name: Fernando Tatis Jr.
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: RTB-GH
+  uuid: b5873166-fa65-4998-8610-0dfdbadda38b
+  subjects:
+  - entities:
+    - role: player
+      name: Gunnar Henderson
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: RTB-GS
+  uuid: 7a4a1adf-5e42-4f58-91de-78c70be1bbd0
+  subjects:
+  - entities:
+    - role: player
+      name: George Springer
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: RTB-GV
+  uuid: d652daa9-b0bc-4892-9151-8fe8509dc961
+  subjects:
+  - entities:
+    - role: player
+      name: George Valera
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: RTB-IH
+  uuid: 8fd82299-73cf-40f3-82c1-818068e56b5b
+  subjects:
+  - entities:
+    - role: player
+      name: Ian Happ
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: RTB-JA
+  uuid: b6e032d3-315b-4a77-8c96-c3845c57d041
+  subjects:
+  - entities:
+    - role: player
+      name: Jonathan Aranda
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: RTB-JC
+  uuid: f80a7c7d-ff0b-48e0-836e-7e4adae68a81
+  subjects:
+  - entities:
+    - role: player
+      name: Jazz Chisholm Jr.
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: RTB-JCA
+  uuid: a4b54e7e-91b8-4236-8d67-b580d782009f
+  subjects:
+  - entities:
+    - role: player
+      name: Junior Caminero
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: RTB-JCH
+  uuid: 306d28c3-da15-4f61-ab83-ff86e201ce0e
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Chourio
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: RTB-JD
+  uuid: 10b981f1-c9c1-459b-bb6e-3729ad94df76
+  subjects:
+  - entities:
+    - role: player
+      name: Jarren Duran
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: RTB-JH
+  uuid: b2f35302-ddfc-4f97-8b89-c43055384f95
+  subjects:
+  - entities:
+    - role: player
+      name: Jung Hoo Lee
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: RTB-JJ
+  uuid: e4112f1e-e7f4-4896-b5b0-8a16540b8096
+  subjects:
+  - entities:
+    - role: player
+      name: Josh Jung
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: RTB-JM
+  uuid: 27323783-4031-4a2d-97ec-c87233d9b970
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Merrill
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: RTB-JP
+  uuid: 2ea9b761-ef4f-4942-81af-675d9fb62a16
+  subjects:
+  - entities:
+    - role: player
+      name: Jeremy Peña
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: RTB-JR
+  uuid: 9134ad1b-48ae-49e4-b4d0-fad8439f94e1
+  subjects:
+  - entities:
+    - role: player
+      name: J.T. Realmuto
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: RTB-JRA
+  uuid: 7ffb4b65-3046-4de5-a3dc-55287c517c3e
+  subjects:
+  - entities:
+    - role: player
+      name: José Ramírez
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: RTB-JRO
+  uuid: 24f44a55-dd6c-439b-be4b-a89ea2b3ce12
+  subjects:
+  - entities:
+    - role: player
+      name: Julio Rodríguez
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: RTB-JRZ
+  uuid: 23a291f4-4a82-4a7f-a063-e83875f5d498
+  subjects:
+  - entities:
+    - role: player
+      name: José Ramírez
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: RTB-JS
+  uuid: 7e396b7a-d266-4930-ad38-b7b4cb503cb7
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: RTB-JSO
+  uuid: fc9524ce-a375-4489-8185-66bc2c0ddc1f
+  subjects:
+  - entities:
+    - role: player
+      name: Jorge Soler
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: RTB-JW
+  uuid: de6ad1f9-96dc-49f5-9ab8-695c42ab751b
+  subjects:
+  - entities:
+    - role: player
+      name: Jordan Westburg
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: RTB-JWI
+  uuid: fc85fc8b-f967-4cdf-825d-cae7b2a02a36
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Wilson
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: RTB-KC
+  uuid: 3b71b529-89e4-43e4-95bf-b65c40ec0b70
+  subjects:
+  - entities:
+    - role: player
+      name: Kerry Carpenter
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: RTB-KM
+  uuid: 72235abe-1116-44a6-94aa-cf15ec7b7d66
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Manzardo
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: RTB-KS
+  uuid: b3d2be2a-1f43-41b5-bb89-abd3cb4602ba
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Schwarber
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: RTB-KSC
+  uuid: d9a936f5-d067-4bac-8db6-aac85ba884d8
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Schwarber
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: RTB-KT
+  uuid: 3c49f3cc-53bb-43f4-8087-a714edf6da6e
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Tucker
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: RTB-KTE
+  uuid: 5eca9e78-d4bd-413b-a721-01243ce8133b
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Teel
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: RTB-MO
+  uuid: 2610dff1-1810-4b3c-885f-b53aa98ebe6a
+  subjects:
+  - entities:
+    - role: player
+      name: Matt Olson
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: RTB-MS
+  uuid: 65ea48ff-b2e7-4606-81d8-55f84980e6d0
+  subjects:
+  - entities:
+    - role: player
+      name: Matt Shaw
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: RTB-MSE
+  uuid: 83812631-484f-492b-9edb-145d1e70728c
+  subjects:
+  - entities:
+    - role: player
+      name: Marcus Semien
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: RTB-NA
+  uuid: 193611e3-9863-4ffb-b13a-4fee740ffbc9
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan Arenado
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: RTB-NC
+  uuid: 74c1ebdc-5a6c-49fb-a920-bb9d4bc0db0a
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Castellanos
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: RTB-NK
+  uuid: 29c4a014-28dd-4d6b-bed1-48da4f3398e9
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Kurtz
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: RTB-OA
+  uuid: a3ee515c-120e-4ade-9c06-705a88882811
+  subjects:
+  - entities:
+    - role: player
+      name: Ozzie Albies
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: RTB-OC
+  uuid: a5b225d2-60ad-4750-bc3b-8614897be3f4
+  subjects:
+  - entities:
+    - role: player
+      name: Owen Caissie
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: RTB-PA
+  uuid: 13469a54-40c7-4120-a3af-0e428b7c1167
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Alonso
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: RTB-PC
+  uuid: fae55d8c-3e0e-4552-88cc-942959eacd20
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Crow-Armstrong
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: RTB-PCA
+  uuid: 12cabfd7-b523-416d-b01a-91dc77549165
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Crow-Armstrong
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: RTB-PG
+  uuid: afec85cc-5aed-4f20-9d5c-1225dcb6fd9c
+  subjects:
+  - entities:
+    - role: player
+      name: Paul Goldschmidt
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: RTB-RA
+  uuid: 17277cf2-07bc-4374-a516-252a3f90c00a
+  subjects:
+  - entities:
+    - role: player
+      name: Ronald Acuña Jr.
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: RTB-RG
+  uuid: 8a5d7d5d-0f49-4fa2-a5db-25f01cb527d7
+  subjects:
+  - entities:
+    - role: player
+      name: Riley Greene
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: RTB-SK
+  uuid: 392c9707-e255-4e36-ab85-f3cfb857d95f
+  subjects:
+  - entities:
+    - role: player
+      name: Steven Kwan
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: RTB-SM
+  uuid: d56e8471-cd08-4b1d-b725-0a8a392dacad
+  subjects:
+  - entities:
+    - role: player
+      name: Starling Marte
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: RTB-SO
+  uuid: 1ae5be07-a610-4541-bd60-41648981aca1
+  subjects:
+  - entities:
+    - role: player
+      name: Shohei Ohtani
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: RTB-SOTO
+  uuid: 1d9ed7ff-8de1-4bf8-a033-8148bb178a9e
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: RTB-SP
+  uuid: 00574c81-ee38-4349-b028-509e74a50b32
+  subjects:
+  - entities:
+    - role: player
+      name: Salvador Perez
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: RTB-SS
+  uuid: 4d6a145d-377b-4db2-9d34-25fe21e6d764
+  subjects:
+  - entities:
+    - role: player
+      name: Seiya Suzuki
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: RTB-TS
+  uuid: 17e541e8-cd70-4ebc-916e-d8585fa6e9b2
+  subjects:
+  - entities:
+    - role: player
+      name: Trevor Story
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: RTB-VG
+  uuid: 965725d9-9447-42eb-8bf1-750d2a06661f
+  subjects:
+  - entities:
+    - role: player
+      name: Vladimir Guerrero Jr.
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: RTB-WC
+  uuid: 6fed5912-2213-44f9-ba38-9860a593c7dc
+  subjects:
+  - entities:
+    - role: player
+      name: William Contreras
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: RTB-WF
+  uuid: 0eadc5ca-e91f-46a5-9e07-9e01e0d5b19e
+  subjects:
+  - entities:
+    - role: player
+      name: Wilmer Flores
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: RTB-ZV
+  uuid: d0ea4baa-d360-46f0-bed7-460ebd369163
+  subjects:
+  - entities:
+    - role: player
+      name: Zac Veen
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 

--- a/data/baseball/2026-topps-series-2/checklists/signature-tunes-dual-aurographs.yaml
+++ b/data/baseball/2026-topps-series-2/checklists/signature-tunes-dual-aurographs.yaml
@@ -1,0 +1,34 @@
+- number: ST-AS
+  uuid: 0a3d7b65-13d7-47e1-9b67-ff487d894d0e
+  subjects:
+  - entities:
+    - role: player
+      name: Skeme
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+  - entities:
+    - role: player
+      name: CJ Abrams
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: ST-TY
+  uuid: 93156989-66da-4712-ac05-c9c0e1368030
+  subjects:
+  - entities:
+    - role: player
+      name: Yandel
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+  - entities:
+    - role: player
+      name: Fernando Tatis Jr.
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 

--- a/data/baseball/2026-topps-series-2/checklists/stars-of-mlb.yaml
+++ b/data/baseball/2026-topps-series-2/checklists/stars-of-mlb.yaml
@@ -1,0 +1,300 @@
+- number: SMLB-31
+  uuid: 16a2a084-1509-4cb8-a53a-465c5764c208
+  subjects:
+  - entities:
+    - role: player
+      name: Christian Moore
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: SMLB-32
+  uuid: 516f39ef-a262-4236-ab0b-77ae49e52263
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Kurtz
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: SMLB-33
+  uuid: 016cde22-e5d5-4aec-b987-416d899387a1
+  subjects:
+  - entities:
+    - role: player
+      name: Dylan Beavers
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: SMLB-34
+  uuid: 7d8b9109-03e3-45e5-aead-60d567e57059
+  subjects:
+  - entities:
+    - role: player
+      name: Payton Tolle
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: SMLB-35
+  uuid: 7f19c394-536b-45a3-882f-673f96e707fb
+  subjects:
+  - entities:
+    - role: player
+      name: Jarren Duran
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: SMLB-36
+  uuid: a2d39347-185b-4547-b5a2-4f51af7f9b0d
+  subjects:
+  - entities:
+    - role: player
+      name: Owen Caissie
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: SMLB-37
+  uuid: 7cbbc458-a649-4813-b099-1c6184e8bbf0
+  subjects:
+  - entities:
+    - role: player
+      name: Colson Montgomery
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: SMLB-38
+  uuid: da51111e-fd6c-4ac8-b858-d6b8670115b5
+  subjects:
+  - entities:
+    - role: player
+      name: Sal Stewart
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: SMLB-39
+  uuid: b8cff45e-5ae9-4a6f-b039-b22749a6ae32
+  subjects:
+  - entities:
+    - role: player
+      name: Chase DeLauter
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: SMLB-40
+  uuid: c0058a45-234a-471f-b7bb-3ea6679b4816
+  subjects:
+  - entities:
+    - role: player
+      name: Riley Greene
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: SMLB-41
+  uuid: 8f4a0afb-c1a6-4a24-978c-c6962241e8f2
+  subjects:
+  - entities:
+    - role: player
+      name: Brice Matthews
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: SMLB-42
+  uuid: 9bff38cf-6502-479f-a8c8-ec9d541350dd
+  subjects:
+  - entities:
+    - role: player
+      name: Freddie Freeman
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: SMLB-43
+  uuid: bc2c3b07-628e-4c2d-85e6-559241b84e4f
+  subjects:
+  - entities:
+    - role: player
+      name: Yoshinobu Yamamoto
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: SMLB-44
+  uuid: e59e0dde-dd28-4a5f-bcd5-9969cefa810c
+  subjects:
+  - entities:
+    - role: player
+      name: Alex Freeland
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: SMLB-45
+  uuid: 4ac8fc00-1f5f-462e-a165-d6d20bb861a2
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Chourio
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: SMLB-46
+  uuid: efb5c496-d796-452a-8df3-42157118b1c2
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan McLean
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: SMLB-47
+  uuid: 64d65bf8-a4f1-4104-a474-779f857d8176
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Alonso
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: SMLB-48
+  uuid: 2b39277c-d38b-498d-8946-4ca6de7c136b
+  subjects:
+  - entities:
+    - role: player
+      name: Cam Schlittler
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: SMLB-49
+  uuid: a6a0af59-f6a0-45ea-a526-19bd63642978
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Schwarber
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: SMLB-50
+  uuid: 44878ad9-7042-4607-81cf-387e1ce2ac6f
+  subjects:
+  - entities:
+    - role: player
+      name: Bubba Chandler
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: SMLB-51
+  uuid: 8d922fd0-d95d-4c58-b1e3-732ec6e33736
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Merrill
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: SMLB-52
+  uuid: 21a27df2-a3d5-40bb-9633-49c1dd27de1c
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Eldridge
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: SMLB-53
+  uuid: db5009e6-ec39-4379-ab19-6bd137ea2ef6
+  subjects:
+  - entities:
+    - role: player
+      name: Cole Young
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: SMLB-54
+  uuid: c3cc4667-375b-4feb-9ed5-b7d720c53ba6
+  subjects:
+  - entities:
+    - role: player
+      name: Cal Raleigh
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: SMLB-55
+  uuid: 62098d2c-8ef8-4121-a23b-d46770da1fe1
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan Arenado
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: SMLB-56
+  uuid: aaffc2e0-aa03-4797-80cf-5bb991e46117
+  subjects:
+  - entities:
+    - role: player
+      name: Munetaka Murakami
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: SMLB-57
+  uuid: 66fed8f0-de51-4e5c-a1ca-5f767504efe7
+  subjects:
+  - entities:
+    - role: player
+      name: Carson Williams
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: SMLB-58
+  uuid: e366978e-1485-424a-a16f-767ad72b326b
+  subjects:
+  - entities:
+    - role: player
+      name: Wyatt Langford
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: SMLB-59
+  uuid: 18b5c25e-9429-4dc3-90dc-e85625ac825b
+  subjects:
+  - entities:
+    - role: player
+      name: Trey Yesavage
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: SMLB-60
+  uuid: 0c592af8-cc09-409c-9852-366bc8143921
+  subjects:
+  - entities:
+    - role: player
+      name: Brady House
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 

--- a/data/baseball/2026-topps-series-2/checklists/swinging-with-the-stars.yaml
+++ b/data/baseball/2026-topps-series-2/checklists/swinging-with-the-stars.yaml
@@ -1,0 +1,250 @@
+- number: SWS-1
+  uuid: 3743b49a-0048-4389-b1d0-b0cbd6f4f187
+  subjects:
+  - entities:
+    - role: player
+      name: Shohei Ohtani
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: SWS-2
+  uuid: 18e1fa4f-925c-4dc4-b784-058bfd729fed
+  subjects:
+  - entities:
+    - role: player
+      name: Aaron Judge
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: SWS-3
+  uuid: d314756e-fb27-486a-9bc1-2bca497a7e51
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: SWS-4
+  uuid: f9c62e0b-96c6-4af6-becc-28790785c7e6
+  subjects:
+  - entities:
+    - role: player
+      name: Vladimir Guerrero Jr.
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: SWS-5
+  uuid: 4094e72d-b88c-47f2-b5e8-1daa142162ae
+  subjects:
+  - entities:
+    - role: player
+      name: Julio Rodríguez
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: SWS-6
+  uuid: ab58eda0-23c6-44ac-ab45-732e77389c2b
+  subjects:
+  - entities:
+    - role: player
+      name: Ronald Acuña Jr.
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: SWS-7
+  uuid: 74d2823e-2669-4d05-9e30-97420865a5b4
+  subjects:
+  - entities:
+    - role: player
+      name: Bobby Witt Jr.
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: SWS-8
+  uuid: 7d6a1b7f-948a-4f49-87b5-4ce621a36fb1
+  subjects:
+  - entities:
+    - role: player
+      name: Elly De La Cruz
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: SWS-9
+  uuid: 40248b6d-b288-455e-81b6-3176cf81551d
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Trout
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: SWS-10
+  uuid: a6816efe-4a88-4db6-94bb-b114bb686685
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Harper
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: SWS-11
+  uuid: b1fcc778-fc21-4c6d-b694-22fc6d42016f
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Crow-Armstrong
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: SWS-12
+  uuid: 1b248264-3cd6-4e0a-aa29-f075091769d8
+  subjects:
+  - entities:
+    - role: player
+      name: Cal Raleigh
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: SWS-13
+  uuid: 4c670fe5-eb6b-492a-8fc0-e5486fd73695
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Kurtz
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: SWS-14
+  uuid: 390f6b9c-3cf3-47f5-a19d-bba457453166
+  subjects:
+  - entities:
+    - role: player
+      name: Jac Caglianone
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: SWS-15
+  uuid: 785b3d83-320e-428b-9443-7720f96bdccc
+  subjects:
+  - entities:
+    - role: player
+      name: Roman Anthony
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: SWS-16
+  uuid: e9034eec-1a48-409b-90dd-7f97406197fb
+  subjects:
+  - entities:
+    - role: player
+      name: Samuel Basallo
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: SWS-17
+  uuid: bd520b6c-d4a2-4737-925f-11e00787fc11
+  subjects:
+  - entities:
+    - role: player
+      name: Colson Montgomery
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: SWS-18
+  uuid: c4ceb65c-feb7-4696-8d33-a4c646612949
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Eldridge
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: SWS-19
+  uuid: 35ae0ab4-77ca-4584-9949-67106f0817ef
+  subjects:
+  - entities:
+    - role: player
+      name: Carson Williams
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: SWS-20
+  uuid: 7a593546-199a-4a5d-8a24-fa290bdfcde5
+  subjects:
+  - entities:
+    - role: player
+      name: Gunnar Henderson
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: SWS-21
+  uuid: a01f899f-eccf-4aba-9eaa-64778b0ba994
+  subjects:
+  - entities:
+    - role: player
+      name: Ken Griffey Jr.
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: SWS-22
+  uuid: 90fd7f65-77fb-4475-af90-b6eb8ded3579
+  subjects:
+  - entities:
+    - role: player
+      name: Willie Mays
+      ref: 
+    - role: team
+      name: New York Giants
+      ref: 
+- number: SWS-23
+  uuid: 5b7ce0e4-8262-4c39-9971-f8163b8d122b
+  subjects:
+  - entities:
+    - role: player
+      name: Derek Jeter
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: SWS-24
+  uuid: 8c671097-4286-4333-a21c-542bfbfa9728
+  subjects:
+  - entities:
+    - role: player
+      name: Mickey Mantle
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: SWS-25
+  uuid: 6b8109c7-268a-4d0b-972e-e7878451e0e8
+  subjects:
+  - entities:
+    - role: player
+      name: Jackie Robinson
+      ref: 
+    - role: team
+      name: Brooklyn Dodgers
+      ref: 

--- a/data/baseball/2026-topps-series-2/checklists/team-color-border-variations.yaml
+++ b/data/baseball/2026-topps-series-2/checklists/team-color-border-variations.yaml
@@ -1,0 +1,1000 @@
+- number: '352'
+  uuid: 2016dc23-3fe8-45db-8a99-864ee7de0442
+  subjects:
+  - entities:
+    - role: player
+      name: Spencer Torkelson
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '355'
+  uuid: 54423c2a-ae92-4b4b-821d-7868dafea36a
+  subjects:
+  - entities:
+    - role: player
+      name: Nathan Eovaldi
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: '358'
+  uuid: 178ec5bb-9d24-49a3-9a49-f97eb2aef455
+  subjects:
+  - entities:
+    - role: player
+      name: Adley Rutschman
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '363'
+  uuid: 5dccb2f8-0d31-43ac-8f3e-fd05d1f82fc9
+  subjects:
+  - entities:
+    - role: player
+      name: J.T. Realmuto
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: '365'
+  uuid: 958cf98e-3b59-48bf-af7d-dda1276f13f8
+  subjects:
+  - entities:
+    - role: player
+      name: Spencer Steer
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '367'
+  uuid: 67b371bd-5e52-4eac-a54a-d64c210c81cc
+  subjects:
+  - entities:
+    - role: player
+      name: Robbie Ray
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '368'
+  uuid: e1e3d026-9882-44cc-a3cd-b2500c26970b
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Tucker
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '371'
+  uuid: 0c1af1c1-5548-4714-9776-c2c00401961c
+  subjects:
+  - entities:
+    - role: player
+      name: Brent Rooker
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: '372'
+  uuid: 74ee9cdf-c867-43c4-a392-9ccb2f179572
+  subjects:
+  - entities:
+    - role: player
+      name: Sal Stewart
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '382'
+  uuid: 5fe9ba6b-e378-4764-af58-941011a88cbe
+  subjects:
+  - entities:
+    - role: player
+      name: Hunter Greene
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '383'
+  uuid: 59160490-0e18-4a62-8899-df30dbb3a31e
+  subjects:
+  - entities:
+    - role: player
+      name: Wyatt Langford
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: '386'
+  uuid: 6421ddd5-5ded-4dd3-86f3-78b0f1064063
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Curvelo
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: '387'
+  uuid: 97d7d1d8-0fa9-4514-8287-ed3f9a777cd3
+  subjects:
+  - entities:
+    - role: player
+      name: Drew Sommers
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '393'
+  uuid: 9b2d11a9-4803-4061-916d-3a4437ceaf0f
+  subjects:
+  - entities:
+    - role: player
+      name: Jazz Chisholm Jr.
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '395'
+  uuid: 79d97e4e-f7ca-4ab2-b68f-7630955ae9cc
+  subjects:
+  - entities:
+    - role: player
+      name: Josh Naylor
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: '398'
+  uuid: 0ecd59df-5e61-4811-aad7-a8ec5619bdf6
+  subjects:
+  - entities:
+    - role: player
+      name: Hunter Barco
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '400'
+  uuid: 27098e13-ebc5-4fda-9ed0-d89710d2e99e
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Alonso
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '406'
+  uuid: f99a2b93-b9b2-473c-8619-3f285c7937c6
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Eldridge
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '410'
+  uuid: 25965b04-a55b-4cc4-b682-c2ff323555e3
+  subjects:
+  - entities:
+    - role: player
+      name: Hayden Harris
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: '415'
+  uuid: 6d862510-ccfe-4731-8847-3e48291b2b04
+  subjects:
+  - entities:
+    - role: player
+      name: Justin Verlander
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '422'
+  uuid: 2e9bb534-542e-4e10-875c-5dd9e7011ab8
+  subjects:
+  - entities:
+    - role: player
+      name: Shane Bieber
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '423'
+  uuid: 21627e55-18f5-41e8-b011-5b947da6a190
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Robert Jr.
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '425'
+  uuid: bded815b-b1ce-497e-a319-70e534bcafc7
+  subjects:
+  - entities:
+    - role: player
+      name: Trent Grisham
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '427'
+  uuid: 307263a3-b435-4985-8f52-cc463f1630a3
+  subjects:
+  - entities:
+    - role: player
+      name: Chris Sale
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: '431'
+  uuid: 3f25bc6b-acf4-492b-87b7-c077f01d9317
+  subjects:
+  - entities:
+    - role: player
+      name: Randy Arozarena
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: '435'
+  uuid: 5713ed58-f7d7-465a-bc69-d2362ff9ed64
+  subjects:
+  - entities:
+    - role: player
+      name: Denzer Guzman
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: '439'
+  uuid: c33f3f08-8427-4d67-992e-86c215005bd3
+  subjects:
+  - entities:
+    - role: player
+      name: Gleyber Torres
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '441'
+  uuid: e8189c3b-1801-42bf-9bf3-b5b302918001
+  subjects:
+  - entities:
+    - role: player
+      name: Lars Nootbaar
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: '446'
+  uuid: 92143a65-225d-42ae-9fec-b932d788df19
+  subjects:
+  - entities:
+    - role: player
+      name: Eugenio Suárez
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '448'
+  uuid: a5e947c1-2e44-4288-b4a5-5eb17118419a
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Chourio
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: '450'
+  uuid: 635eaab9-b415-4c59-8727-6c8a29fb82bb
+  subjects:
+  - entities:
+    - role: player
+      name: Gerrit Cole
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '455'
+  uuid: 0f338819-705c-4cfe-8c44-11d89e920e90
+  subjects:
+  - entities:
+    - role: player
+      name: George Springer
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '458'
+  uuid: 9b5d7182-6251-4eae-b6dd-07e5ac5497ec
+  subjects:
+  - entities:
+    - role: player
+      name: Chase DeLauter
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '459'
+  uuid: 337eab88-bb78-44d1-aefd-257dc406e342
+  subjects:
+  - entities:
+    - role: player
+      name: Ketel Marte
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: '463'
+  uuid: 8bb1d0cc-5238-4258-9da4-29d4185d912c
+  subjects:
+  - entities:
+    - role: player
+      name: Aaron Nola
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: '468'
+  uuid: e48df9df-8045-4a54-9af4-e327ef512e49
+  subjects:
+  - entities:
+    - role: player
+      name: Yordan Alvarez
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '470'
+  uuid: d54abf22-ef02-48f0-8394-7074fb986fb6
+  subjects:
+  - entities:
+    - role: player
+      name: Brandon Nimmo
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: '471'
+  uuid: 74000238-912d-447a-afa5-928b26bc617f
+  subjects:
+  - entities:
+    - role: player
+      name: J.P. Crawford
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: '473'
+  uuid: 74a372e4-484b-4e20-bf78-48340c094034
+  subjects:
+  - entities:
+    - role: player
+      name: Bo Bichette
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '483'
+  uuid: 7975c995-dcb9-46d2-8acb-8c5b473e0366
+  subjects:
+  - entities:
+    - role: player
+      name: Logan O'Hoppe
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: '493'
+  uuid: 59c2f147-45fa-4a29-baab-9056c2f3f610
+  subjects:
+  - entities:
+    - role: player
+      name: George Kirby
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: '500'
+  uuid: e861efac-2bfb-4a6d-8bf9-29212cd6915b
+  subjects:
+  - entities:
+    - role: player
+      name: Shohei Ohtani
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '501'
+  uuid: bfac2524-7832-499d-a626-729e1e8cf01e
+  subjects:
+  - entities:
+    - role: player
+      name: Connelly Early
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '503'
+  uuid: 8cdfba4e-a428-406b-857f-452e8f031fef
+  subjects:
+  - entities:
+    - role: player
+      name: Munetaka Murakami
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: '507'
+  uuid: 24eb73de-4b58-4e30-963a-4583f4412f0c
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Castillo
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: '510'
+  uuid: ba68365a-52de-454c-86a7-20afe696531c
+  subjects:
+  - entities:
+    - role: player
+      name: Philip Abner
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: '520'
+  uuid: fcbe39a0-fcd8-4bde-b155-4cfa79dccb31
+  subjects:
+  - entities:
+    - role: player
+      name: Andrew Alvarez
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: '526'
+  uuid: fbd734f9-d314-4cc1-b4e1-58afa257f0e1
+  subjects:
+  - entities:
+    - role: player
+      name: Masyn Winn
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: '530'
+  uuid: 551f63b9-95f9-46ce-938e-550144d2c406
+  subjects:
+  - entities:
+    - role: player
+      name: Carter Jensen
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: '533'
+  uuid: f2545659-3069-4203-80fa-37b6491ecfbe
+  subjects:
+  - entities:
+    - role: player
+      name: Jasson Domínguez
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '534'
+  uuid: 6f1cf16f-b3b1-4127-a136-92f95f1b8088
+  subjects:
+  - entities:
+    - role: player
+      name: Brandon Sproat
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: '536'
+  uuid: 053de29e-db60-46ff-9ead-fe6560673450
+  subjects:
+  - entities:
+    - role: player
+      name: Trevor Story
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '541'
+  uuid: 679926f1-afcd-462e-9323-2e66e33293ae
+  subjects:
+  - entities:
+    - role: player
+      name: Jung Hoo Lee
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '547'
+  uuid: 5adffa88-8abc-4f36-810c-db55d538f050
+  subjects:
+  - entities:
+    - role: player
+      name: Dylan Cease
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '550'
+  uuid: 8fa6bb51-832a-4f2a-a7db-eac741447acd
+  subjects:
+  - entities:
+    - role: player
+      name: Dansby Swanson
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '551'
+  uuid: 070de9c0-d250-44ea-83ad-1d6440fd3c82
+  subjects:
+  - entities:
+    - role: player
+      name: Taylor Ward
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '560'
+  uuid: 2f895a49-0878-4163-9de1-815cc6fe5b8b
+  subjects:
+  - entities:
+    - role: player
+      name: Jarren Duran
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '561'
+  uuid: 8394fa68-7ce0-4e0c-949d-c5eed93c7038
+  subjects:
+  - entities:
+    - role: player
+      name: Matt Chapman
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '562'
+  uuid: 47311a56-db01-4af1-9ed9-c501389ba1c7
+  subjects:
+  - entities:
+    - role: player
+      name: Bryson Stott
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: '564'
+  uuid: dc6405dc-ec93-4c58-9180-8b7e95163be8
+  subjects:
+  - entities:
+    - role: player
+      name: Tyler Soderstrom
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: '568'
+  uuid: 4de71c4e-6000-4ddc-ad7e-d77f7277f6c1
+  subjects:
+  - entities:
+    - role: player
+      name: Ozzie Albies
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: '569'
+  uuid: c781de6e-2d34-4683-afd8-419da9445ac8
+  subjects:
+  - entities:
+    - role: player
+      name: Max Scherzer
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '570'
+  uuid: 28420ef3-6e16-4fff-a39a-daa59bf107fd
+  subjects:
+  - entities:
+    - role: player
+      name: Rolddy Muñoz
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: '578'
+  uuid: a8ed7206-fd1d-4609-aa3a-bc3ddc209974
+  subjects:
+  - entities:
+    - role: player
+      name: Heriberto Hernández
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: '585'
+  uuid: 90d4b540-d665-4e22-a563-a5569cbd0f80
+  subjects:
+  - entities:
+    - role: player
+      name: Ian Happ
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '586'
+  uuid: 07436db8-4d9f-41ff-80b3-a9cd679de8ae
+  subjects:
+  - entities:
+    - role: player
+      name: Marcus Semien
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '594'
+  uuid: 67408388-707a-47e4-828d-1c922629bdea
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Gil
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '597'
+  uuid: a506dc9f-2f47-4f0e-8193-34fb25d94abf
+  subjects:
+  - entities:
+    - role: player
+      name: Paul Goldschmidt
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '598'
+  uuid: 27ce15ed-7acd-485b-bff8-55d954e3f663
+  subjects:
+  - entities:
+    - role: player
+      name: Jack Winkler
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '600'
+  uuid: '09ce3007-0a9b-4c87-915b-1261d6f5d79d'
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '601'
+  uuid: 9b33ad76-d978-41df-b8dd-83f78a348825
+  subjects:
+  - entities:
+    - role: player
+      name: Zach Cole
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '603'
+  uuid: 36431400-0ace-4ad3-9761-233b6e17fee1
+  subjects:
+  - entities:
+    - role: player
+      name: George Valera
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '607'
+  uuid: abde79b4-bb94-4f1b-ba0d-0cd32624f1c5
+  subjects:
+  - entities:
+    - role: player
+      name: Cody Bellinger
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '611'
+  uuid: 0bab82bd-8a87-43c2-be26-894d7a6e05a1
+  subjects:
+  - entities:
+    - role: player
+      name: Paul Gervase
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '613'
+  uuid: b43039c8-fc6f-4a97-ab33-8c0948596b31
+  subjects:
+  - entities:
+    - role: player
+      name: Jordan Westburg
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '614'
+  uuid: 03e49f18-7fdc-4374-b9cb-ee6b5f345bc4
+  subjects:
+  - entities:
+    - role: player
+      name: Manny Machado
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: '618'
+  uuid: c96918d2-0a8e-4390-a60a-9d32a03b016a
+  subjects:
+  - entities:
+    - role: player
+      name: Tanner Bibee
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '620'
+  uuid: 78bfc56b-c425-4998-8ce0-94089c8d3893
+  subjects:
+  - entities:
+    - role: player
+      name: Trey Yesavage
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '623'
+  uuid: 63519afe-7ed7-4ed0-a1d8-d5330a1f1b82
+  subjects:
+  - entities:
+    - role: player
+      name: Rafael Flores
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '629'
+  uuid: d9dcb872-3443-4a37-9bfb-5c5d4b628a0b
+  subjects:
+  - entities:
+    - role: player
+      name: Tyler Glasnow
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '631'
+  uuid: d5946ca6-55d0-4760-b24f-3b0c7a21eebe
+  subjects:
+  - entities:
+    - role: player
+      name: Will Smith
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '632'
+  uuid: c4b487ac-368e-46b4-b93a-d6da51bd59dd
+  subjects:
+  - entities:
+    - role: player
+      name: Cade Horton
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '633'
+  uuid: a26b7ab2-2eae-4df4-8052-7c1b7da4965e
+  subjects:
+  - entities:
+    - role: player
+      name: Salvador Perez
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: '643'
+  uuid: c22af383-2bc9-4efc-88d7-08b6ba0aa4b0
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Lodolo
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '646'
+  uuid: e3974502-fecc-44d9-b6e2-e2b296fbc453
+  subjects:
+  - entities:
+    - role: player
+      name: Mark Vientos
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '650'
+  uuid: bb55d140-c266-4fd7-a2c1-7a4ac4029dff
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Schwarber
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: '656'
+  uuid: 362c699f-2fa7-4cc5-b1e5-eac4e5bd7d27
+  subjects:
+  - entities:
+    - role: player
+      name: Aroldis Chapman
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '658'
+  uuid: 959c8b9d-a86e-4e7b-aa68-a3df5c1d5c00
+  subjects:
+  - entities:
+    - role: player
+      name: Jack Flaherty
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '659'
+  uuid: a3b06b4b-3b6d-4795-9fd3-bb09462773af
+  subjects:
+  - entities:
+    - role: player
+      name: Harry Ford
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: '665'
+  uuid: 50c02579-a66f-4779-837e-6b2da21e25f6
+  subjects:
+  - entities:
+    - role: player
+      name: Jose Corniell
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: '667'
+  uuid: 31cc373d-2021-4752-b2f0-75b71308560d
+  subjects:
+  - entities:
+    - role: player
+      name: Kodai Senga
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '668'
+  uuid: b039545b-a32b-425b-958a-f05357e406cf
+  subjects:
+  - entities:
+    - role: player
+      name: Petey Halpin
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '674'
+  uuid: b8385868-05c5-481b-97f0-826dc97387be
+  subjects:
+  - entities:
+    - role: player
+      name: Andre Granillo
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: '675'
+  uuid: f55e8d22-f8fc-45ed-8b78-bcc1ef832f26
+  subjects:
+  - entities:
+    - role: player
+      name: Steven Kwan
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '677'
+  uuid: ebf887ee-4e55-4075-981c-1e6eb4db8a95
+  subjects:
+  - entities:
+    - role: player
+      name: Wilyer Abreu
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '680'
+  uuid: 79bd491c-2806-4711-bf74-d6f5d65da543
+  subjects:
+  - entities:
+    - role: player
+      name: Carlos Correa
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '685'
+  uuid: e25c97d9-bb2f-42bc-885d-597cbbc6d4d9
+  subjects:
+  - entities:
+    - role: player
+      name: Seiya Suzuki
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '692'
+  uuid: ed3a1d76-d1b7-48e4-b62a-46296218ce76
+  subjects:
+  - entities:
+    - role: player
+      name: Drake Baldwin
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: '697'
+  uuid: ee36e452-dc9b-4301-89b2-87e5dd757481
+  subjects:
+  - entities:
+    - role: player
+      name: Bryan Reynolds
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '700'
+  uuid: 5ca57385-bab1-48d7-a858-56f8b04c80a4
+  subjects:
+  - entities:
+    - role: player
+      name: Freddie Freeman
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 

--- a/data/baseball/2026-topps-series-2/checklists/the-flagship-collection-chrome-autographs.yaml
+++ b/data/baseball/2026-topps-series-2/checklists/the-flagship-collection-chrome-autographs.yaml
@@ -1,0 +1,630 @@
+- number: '2'
+  uuid: 52ba6d19-a01f-4b41-8a0d-60d58980301a
+  subjects:
+  - entities:
+    - role: player
+      name: Dylan Beavers
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '4'
+  uuid: a1aa8e2f-42d9-4d5c-b54d-bde454e11a45
+  subjects:
+  - entities:
+    - role: player
+      name: Jose Altuve
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '6'
+  uuid: 9f9a9764-f128-437a-8f3b-5ac9a3ee823b
+  subjects:
+  - entities:
+    - role: player
+      name: Elly De La Cruz
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '8'
+  uuid: 80cb796d-e939-4a9d-a28d-745057f4b39d
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Teel
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: '9'
+  uuid: 86829174-0f03-4066-a311-56629646dfd5
+  subjects:
+  - entities:
+    - role: player
+      name: Jazz Chisholm Jr.
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '11'
+  uuid: 0fcc048e-5be4-48e7-9106-21c38071a748
+  subjects:
+  - entities:
+    - role: player
+      name: George Springer
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '12'
+  uuid: 4b389f9c-a2a8-4125-97d7-51ecba8b6609
+  subjects:
+  - entities:
+    - role: player
+      name: Chase DeLauter
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '13'
+  uuid: d66fb801-709b-4d0b-9ac2-d654cb1cb9b3
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Alonso
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '14'
+  uuid: ac1af42b-6fde-463c-8425-e1d36035bd8e
+  subjects:
+  - entities:
+    - role: player
+      name: Manny Machado
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: '16'
+  uuid: ad91b3e8-f15d-4301-9fcc-80f71355438c
+  subjects:
+  - entities:
+    - role: player
+      name: James Wood
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: '17'
+  uuid: 5ad44d5d-477c-4dac-9d55-52f5e9a14056
+  subjects:
+  - entities:
+    - role: player
+      name: Chase Burns
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '18'
+  uuid: 1758e594-5693-4695-bbbe-759113bfb351
+  subjects:
+  - entities:
+    - role: player
+      name: Francisco Lindor
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '19'
+  uuid: 4d13eb5a-d50b-411d-b428-6f39d117b508
+  subjects:
+  - entities:
+    - role: player
+      name: Owen Caissie
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: '21'
+  uuid: 5bf66536-de33-4578-8f4f-6c72f9b674b5
+  subjects:
+  - entities:
+    - role: player
+      name: Zach Neto
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: '22'
+  uuid: 00e134e5-4e33-4a3e-aaeb-4c8799926e78
+  subjects:
+  - entities:
+    - role: player
+      name: Riley Greene
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '23'
+  uuid: e1047fe7-dff4-4646-af15-d3a3ef5cafc4
+  subjects:
+  - entities:
+    - role: player
+      name: Brice Matthews
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '24'
+  uuid: 9e8e806d-4f2c-4926-993a-6cc6011e9db4
+  subjects:
+  - entities:
+    - role: player
+      name: Junior Caminero
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: '25'
+  uuid: 5a638457-debb-4b0b-b567-7e9f3432f481
+  subjects:
+  - entities:
+    - role: player
+      name: Garrett Crochet
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '26'
+  uuid: 62c430fe-9214-4dbb-bfee-8a25c0e046b1
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Tucker
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '27'
+  uuid: 61943219-131a-4f36-9a54-dbd662bd8692
+  subjects:
+  - entities:
+    - role: player
+      name: Colby Thomas
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: '29'
+  uuid: 38abb255-6a08-401c-b21d-531e70526aaa
+  subjects:
+  - entities:
+    - role: player
+      name: Jonah Tong
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '30'
+  uuid: cf78fa40-24f7-4d01-bf91-67e507ddd618
+  subjects:
+  - entities:
+    - role: player
+      name: Freddie Freeman
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '31'
+  uuid: ac276f60-b5a8-45eb-8b27-80c13d186f4b
+  subjects:
+  - entities:
+    - role: player
+      name: Colson Montgomery
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: '32'
+  uuid: bf3de4c0-f48c-4948-ac4d-618b09e38ad1
+  subjects:
+  - entities:
+    - role: player
+      name: Drew Gilbert
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '33'
+  uuid: 3186c3ef-e9ee-468f-a15c-49de6fd772bf
+  subjects:
+  - entities:
+    - role: player
+      name: Shota Imanaga
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '34'
+  uuid: 65c4d375-97ec-43c7-b37b-23bd1d21acc8
+  subjects:
+  - entities:
+    - role: player
+      name: Carter Jensen
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: '36'
+  uuid: 3e189d94-fa2d-4a01-a14e-ae8d3075a898
+  subjects:
+  - entities:
+    - role: player
+      name: Cam Schlittler
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '38'
+  uuid: 7be82782-edb8-4509-8791-3e9d6d01f1e1
+  subjects:
+  - entities:
+    - role: player
+      name: Harry Ford
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: '40'
+  uuid: 742689c9-da28-430b-9d77-77de5dd71580
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Kurtz
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: '41'
+  uuid: 495d39e5-b8f6-4a4b-a2e9-fdab06fcc505
+  subjects:
+  - entities:
+    - role: player
+      name: Payton Tolle
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '42'
+  uuid: 9c32dc5a-31fa-41f9-a475-77410e90aff3
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Melton
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: '43'
+  uuid: 7812fce2-249c-4c1a-9950-7e10053d4f8e
+  subjects:
+  - entities:
+    - role: player
+      name: Cal Raleigh
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: '44'
+  uuid: 4b7ae830-2fba-4076-ae2f-1c05dfa9bfb2
+  subjects:
+  - entities:
+    - role: player
+      name: Bubba Chandler
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '48'
+  uuid: 2b1a0be8-353d-470c-8f7d-63866d29f75a
+  subjects:
+  - entities:
+    - role: player
+      name: Ronald Acuña Jr.
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: '49'
+  uuid: e07231fa-a8b2-4ba9-8bed-c8995481be55
+  subjects:
+  - entities:
+    - role: player
+      name: Sonny Gray
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '50'
+  uuid: 59a98a7f-6fea-411f-8c1a-dd6447188aa9
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Trout
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: '52'
+  uuid: bf91c066-470b-42a5-8368-9558aa5d532b
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan McLean
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '53'
+  uuid: b2e481e4-5000-4077-9ce3-e8ca538a2c1b
+  subjects:
+  - entities:
+    - role: player
+      name: Carson Williams
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: '54'
+  uuid: a6e50b63-b367-4e06-8c88-bebce5d38bf3
+  subjects:
+  - entities:
+    - role: player
+      name: Yoshinobu Yamamoto
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '55'
+  uuid: 9c9d88e3-2544-43bf-bbd8-291e479ae31d
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '56'
+  uuid: 04dabe7c-84c6-4bb6-9b88-b21bc8e03bae
+  subjects:
+  - entities:
+    - role: player
+      name: C.J. Kayfus
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '59'
+  uuid: 62748a09-3c07-4dbb-9c59-a130d6cc1ab6
+  subjects:
+  - entities:
+    - role: player
+      name: Corbin Carroll
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: '60'
+  uuid: 44de508d-082a-450f-bbdb-b5e2ba13f72a
+  subjects:
+  - entities:
+    - role: player
+      name: Alex Freeland
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '61'
+  uuid: 7bca046e-cfa7-42bb-a74c-ffa298af68c9
+  subjects:
+  - entities:
+    - role: player
+      name: Paul Skenes
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '64'
+  uuid: 0cddac1d-e8f9-4894-a0f9-a645d2e1d46a
+  subjects:
+  - entities:
+    - role: player
+      name: Vladimir Guerrero Jr.
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '65'
+  uuid: a38c3808-07f2-4089-8a4b-94c8194028a3
+  subjects:
+  - entities:
+    - role: player
+      name: Christian Moore
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: '68'
+  uuid: 3eb02b6b-8a4d-43d2-a1cb-e7d94456e173
+  subjects:
+  - entities:
+    - role: player
+      name: Corey Seager
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: '69'
+  uuid: d2475289-37ba-401c-8f95-f477ad60129b
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan Arenado
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: '70'
+  uuid: 7b1146ab-10fd-4f4b-9c38-e5ede95c1720
+  subjects:
+  - entities:
+    - role: player
+      name: Austin Riley
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: '71'
+  uuid: e02c6285-d234-4b32-81c7-e50b85ed4666
+  subjects:
+  - entities:
+    - role: player
+      name: Alex Bregman
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '72'
+  uuid: d120c6dd-0bc8-4a2c-8a2b-d6247d08a047
+  subjects:
+  - entities:
+    - role: player
+      name: Sal Stewart
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '73'
+  uuid: b8ed26e2-bdd2-4d3a-b707-952fe4899d7c
+  subjects:
+  - entities:
+    - role: player
+      name: Fernando Tatis Jr.
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: '75'
+  uuid: 75fc33d1-3063-460f-88a9-cf7251bfce5f
+  subjects:
+  - entities:
+    - role: player
+      name: Adley Rutschman
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '77'
+  uuid: 135a1311-14bd-4823-8a8d-38989525a102
+  subjects:
+  - entities:
+    - role: player
+      name: Jarren Duran
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '80'
+  uuid: eab81d3f-8eb7-4f09-8afe-07eb642a6ce4
+  subjects:
+  - entities:
+    - role: player
+      name: Brady House
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: '82'
+  uuid: 680719ec-b6d7-412e-8a3a-5b66b47df185
+  subjects:
+  - entities:
+    - role: player
+      name: Jac Caglianone
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: '83'
+  uuid: 3db76b97-b643-4d7c-a275-f1e1decf90a4
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Chourio
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: '84'
+  uuid: 10eb2830-44d2-4e17-829b-6007d56f718e
+  subjects:
+  - entities:
+    - role: player
+      name: Andrew McCutchen
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '85'
+  uuid: a45a06b3-650f-437f-99ae-6f7048fb5b96
+  subjects:
+  - entities:
+    - role: player
+      name: Julio Rodríguez
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: '86'
+  uuid: 01b8cbe1-e46b-491a-8132-61cd824a439d
+  subjects:
+  - entities:
+    - role: player
+      name: Jhostynxon Garcia
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '88'
+  uuid: 934aa7f3-e520-4005-904f-c7cc3f654154
+  subjects:
+  - entities:
+    - role: player
+      name: Trea Turner
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: '89'
+  uuid: 630ac0f5-4fe2-418c-b172-7f4fe274cbca
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Wilson
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: '90'
+  uuid: 00aae341-f39e-4197-a07c-9da01acf22e6
+  subjects:
+  - entities:
+    - role: player
+      name: Christian Yelich
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 

--- a/data/baseball/2026-topps-series-2/checklists/the-flagship-collection-chrome.yaml
+++ b/data/baseball/2026-topps-series-2/checklists/the-flagship-collection-chrome.yaml
@@ -1,0 +1,900 @@
+- number: '1'
+  uuid: 1522805a-2362-4451-b7b9-d3f05f6b975e
+  subjects:
+  - entities:
+    - role: player
+      name: Shohei Ohtani
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '2'
+  uuid: 24718001-574f-4e18-9294-815fa32e205b
+  subjects:
+  - entities:
+    - role: player
+      name: Dylan Beavers
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '3'
+  uuid: 14471852-b133-49ce-a077-b0dba7f3186d
+  subjects:
+  - entities:
+    - role: player
+      name: Justin Verlander
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '4'
+  uuid: 4e3515dc-9b64-41ab-9aa7-bfa8c7fc8cb0
+  subjects:
+  - entities:
+    - role: player
+      name: Jose Altuve
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '5'
+  uuid: 348c7b1a-bd3d-4b84-b637-f6adef41b8cb
+  subjects:
+  - entities:
+    - role: player
+      name: Max Scherzer
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '6'
+  uuid: 2fbc6491-4529-4d13-99a5-98887d68d952
+  subjects:
+  - entities:
+    - role: player
+      name: Elly De La Cruz
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '7'
+  uuid: 861717e6-57dc-47d7-abc5-87068f0d4883
+  subjects:
+  - entities:
+    - role: player
+      name: Aaron Judge
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '8'
+  uuid: f1ea1699-919f-426d-a46c-9a26fb192a15
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Teel
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: '9'
+  uuid: 56e6692a-b99a-4267-b602-379ef084b3f2
+  subjects:
+  - entities:
+    - role: player
+      name: Jazz Chisholm Jr.
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '10'
+  uuid: 47a05e29-f165-4732-82a5-4e5f2436288e
+  subjects:
+  - entities:
+    - role: player
+      name: Dansby Swanson
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '11'
+  uuid: 3009ecbf-47c8-43f0-b4c0-05ab39f68d0d
+  subjects:
+  - entities:
+    - role: player
+      name: George Springer
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '12'
+  uuid: 39bcd2ab-36f6-4894-921b-8bb8a21d38fe
+  subjects:
+  - entities:
+    - role: player
+      name: Chase DeLauter
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '13'
+  uuid: d356dfc1-0d00-4b63-aff7-65ba4c9d09b7
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Alonso
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '14'
+  uuid: cca5fdc1-255a-4475-aaa4-6075b0b889d2
+  subjects:
+  - entities:
+    - role: player
+      name: Manny Machado
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: '15'
+  uuid: 3e131cc9-aa62-4f22-be31-ceabd16401ed
+  subjects:
+  - entities:
+    - role: player
+      name: Cole Young
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: '16'
+  uuid: 79836c25-09dd-475a-a339-1d1a6af022a8
+  subjects:
+  - entities:
+    - role: player
+      name: James Wood
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: '17'
+  uuid: be3eeda7-a6d4-4a91-9bd5-21df68a57c79
+  subjects:
+  - entities:
+    - role: player
+      name: Chase Burns
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '18'
+  uuid: e466f8b8-c397-4a6e-b3f0-6377cd748b4a
+  subjects:
+  - entities:
+    - role: player
+      name: Francisco Lindor
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '19'
+  uuid: ae9531bd-41e9-452d-bd20-e8d3a77d5911
+  subjects:
+  - entities:
+    - role: player
+      name: Owen Caissie
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: '20'
+  uuid: dbf1611a-d6be-4fcf-bbbb-36e8987a7665
+  subjects:
+  - entities:
+    - role: player
+      name: Trey Yesavage
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '21'
+  uuid: b29e1ce2-d5d4-4fa5-90ac-cb914729b336
+  subjects:
+  - entities:
+    - role: player
+      name: Zach Neto
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: '22'
+  uuid: 3864711b-45fc-403a-b04d-6297f121b895
+  subjects:
+  - entities:
+    - role: player
+      name: Riley Greene
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '23'
+  uuid: 6a0b8016-836b-4fc5-ae9d-49a791f858d3
+  subjects:
+  - entities:
+    - role: player
+      name: Brice Matthews
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '24'
+  uuid: 888a2003-3855-49d8-a567-3f11cca2b380
+  subjects:
+  - entities:
+    - role: player
+      name: Junior Caminero
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: '25'
+  uuid: 68fa3e0c-5fae-4b1c-a8e4-ba1d485d9632
+  subjects:
+  - entities:
+    - role: player
+      name: Garrett Crochet
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '26'
+  uuid: 35f851bf-07ee-4ffd-a8b6-65e942d0389a
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Tucker
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '27'
+  uuid: 9d5f49f5-6c97-46f6-b872-4434bb50d39c
+  subjects:
+  - entities:
+    - role: player
+      name: Colby Thomas
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: '28'
+  uuid: 0c06a497-6df8-4848-a99d-cbc4db22a89b
+  subjects:
+  - entities:
+    - role: player
+      name: Clayton Kershaw
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '29'
+  uuid: 641d5d04-28c0-40e1-b2d5-07a16ca595ba
+  subjects:
+  - entities:
+    - role: player
+      name: Jonah Tong
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '30'
+  uuid: 1eb1d008-e198-4459-8e31-4a4ec66668f3
+  subjects:
+  - entities:
+    - role: player
+      name: Freddie Freeman
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '31'
+  uuid: 64a083fe-e680-4552-8579-a98f2365e800
+  subjects:
+  - entities:
+    - role: player
+      name: Colson Montgomery
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: '32'
+  uuid: 61f25d60-abf1-4466-b8c1-e445b2900587
+  subjects:
+  - entities:
+    - role: player
+      name: Drew Gilbert
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '33'
+  uuid: ca9a8581-940f-4706-9839-ec91f4d1b82c
+  subjects:
+  - entities:
+    - role: player
+      name: Shota Imanaga
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '34'
+  uuid: c83096b9-0f76-4462-93bd-4decd3d5732d
+  subjects:
+  - entities:
+    - role: player
+      name: Carter Jensen
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: '35'
+  uuid: 961ce78b-eef9-4f48-8605-f01bf67e55fe
+  subjects:
+  - entities:
+    - role: player
+      name: Mookie Betts
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '36'
+  uuid: cfda77a9-d290-46e7-8026-5b365b8b0956
+  subjects:
+  - entities:
+    - role: player
+      name: Cam Schlittler
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '37'
+  uuid: 431e15c4-0405-47ce-a234-b78be0643d96
+  subjects:
+  - entities:
+    - role: player
+      name: Munetaka Murakami
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: '38'
+  uuid: d15c3364-c3c2-4347-b612-32457d246a35
+  subjects:
+  - entities:
+    - role: player
+      name: Harry Ford
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: '39'
+  uuid: 46f95755-5a44-4c78-9b55-cf1c967e034d
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Misiorowski
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: '40'
+  uuid: 31746c88-6112-480a-9dc3-1a2dfd608da9
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Kurtz
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: '41'
+  uuid: 221da517-5d6c-4f75-b333-4a87ef3961d3
+  subjects:
+  - entities:
+    - role: player
+      name: Payton Tolle
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '42'
+  uuid: 22b95d6e-9a55-45ce-952f-bce19d2a5f34
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Melton
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: '43'
+  uuid: 5b848beb-34d8-463f-b793-9916df23cb3f
+  subjects:
+  - entities:
+    - role: player
+      name: Cal Raleigh
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: '44'
+  uuid: 76faea54-2931-4e5d-90a9-edca6d77649b
+  subjects:
+  - entities:
+    - role: player
+      name: Bubba Chandler
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '45'
+  uuid: b554ce00-fbae-46e7-a688-31e73a270d2a
+  subjects:
+  - entities:
+    - role: player
+      name: Roki Sasaki
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '46'
+  uuid: 8d50ac81-640a-41af-a217-e707327f2d4e
+  subjects:
+  - entities:
+    - role: player
+      name: Jakob Marsee
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: '47'
+  uuid: 108d23cb-5167-473c-a4d2-215b82b92feb
+  subjects:
+  - entities:
+    - role: player
+      name: Yordan Alvarez
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '48'
+  uuid: a3b08d67-6703-4b79-9635-475661fb5920
+  subjects:
+  - entities:
+    - role: player
+      name: Ronald Acuña Jr.
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: '49'
+  uuid: ed16edd3-0ffc-4605-bacb-e4171095d05d
+  subjects:
+  - entities:
+    - role: player
+      name: Sonny Gray
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '50'
+  uuid: 7c3bf4d4-6319-4fb5-bef8-c41270ccf485
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Trout
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: '51'
+  uuid: 5bbfb0e8-88c9-4c67-b00c-44adb6c5722a
+  subjects:
+  - entities:
+    - role: player
+      name: Gunnar Henderson
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '52'
+  uuid: e467680c-ddbf-4c9f-9071-42e689d249e4
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan McLean
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '53'
+  uuid: 69d440db-8585-4656-84d4-7bf7edf10f9d
+  subjects:
+  - entities:
+    - role: player
+      name: Carson Williams
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: '54'
+  uuid: fe9304d3-f3a9-4302-9ea9-f109b2baee2e
+  subjects:
+  - entities:
+    - role: player
+      name: Yoshinobu Yamamoto
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '55'
+  uuid: 4699a9fc-5b9a-4996-beec-feccf63acca5
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '56'
+  uuid: e4bac890-b114-4763-8097-a69211f07c98
+  subjects:
+  - entities:
+    - role: player
+      name: C.J. Kayfus
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '57'
+  uuid: e554fc39-d39b-4d4d-bb2a-23b29a296ef6
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Harper
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: '58'
+  uuid: bb8364e0-28bd-43b6-8cc8-37ead252698d
+  subjects:
+  - entities:
+    - role: player
+      name: Roman Anthony
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '59'
+  uuid: 6d2af6ee-aa63-4d35-a002-c50ddb4d154c
+  subjects:
+  - entities:
+    - role: player
+      name: Corbin Carroll
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: '60'
+  uuid: 606bdc3f-0972-4962-b5b7-e846166ae10b
+  subjects:
+  - entities:
+    - role: player
+      name: Alex Freeland
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '61'
+  uuid: 6d67cc75-b56a-42a7-9b62-f7130e9b9d8b
+  subjects:
+  - entities:
+    - role: player
+      name: Paul Skenes
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '62'
+  uuid: 732d139d-b2a9-4183-85dc-b2fdcf78fc4f
+  subjects:
+  - entities:
+    - role: player
+      name: Max Muncy
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '63'
+  uuid: 3b27cb9c-fbb3-46b9-ae47-d8ed21bcc6b2
+  subjects:
+  - entities:
+    - role: player
+      name: Bo Bichette
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '64'
+  uuid: 2cc35356-5357-4c6d-890b-064d39d8bf11
+  subjects:
+  - entities:
+    - role: player
+      name: Vladimir Guerrero Jr.
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '65'
+  uuid: '04502977-d15c-4ec9-b2c6-a5e77a2dde2e'
+  subjects:
+  - entities:
+    - role: player
+      name: Christian Moore
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: '66'
+  uuid: 23351ec7-88bc-439c-babe-8bc87bc908f8
+  subjects:
+  - entities:
+    - role: player
+      name: Samuel Basallo
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '67'
+  uuid: 44b05250-f4ba-4b17-a9b8-7b57521d5686
+  subjects:
+  - entities:
+    - role: player
+      name: Ketel Marte
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: '68'
+  uuid: 7a7440fd-f8b1-4c7c-bfbf-36ac210f579a
+  subjects:
+  - entities:
+    - role: player
+      name: Corey Seager
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: '69'
+  uuid: abf62068-4b54-4172-a72a-9733b9b93ff8
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan Arenado
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: '70'
+  uuid: f28233b8-5e6e-4b66-84fc-ebd238adbcc6
+  subjects:
+  - entities:
+    - role: player
+      name: Austin Riley
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: '71'
+  uuid: 28ac8e35-1195-44b8-bcf1-20866a734894
+  subjects:
+  - entities:
+    - role: player
+      name: Alex Bregman
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '72'
+  uuid: 6fa82213-3d17-4952-90dc-dc52f54f518c
+  subjects:
+  - entities:
+    - role: player
+      name: Sal Stewart
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '73'
+  uuid: 153e9a57-1f4d-44c9-980b-612f691c89d3
+  subjects:
+  - entities:
+    - role: player
+      name: Fernando Tatis Jr.
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: '74'
+  uuid: 0ba889d9-030e-4ccd-92a5-d7eb8278ed58
+  subjects:
+  - entities:
+    - role: player
+      name: Bobby Witt Jr.
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: '75'
+  uuid: 95127573-f5a5-4fd8-8b7e-9d93a14ce2ed
+  subjects:
+  - entities:
+    - role: player
+      name: Adley Rutschman
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '76'
+  uuid: 0dd6e713-c788-4171-af92-e72cdb479862
+  subjects:
+  - entities:
+    - role: player
+      name: Tarik Skubal
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '77'
+  uuid: b421ab06-eeb0-4892-a296-658b8c7b415f
+  subjects:
+  - entities:
+    - role: player
+      name: Jarren Duran
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '78'
+  uuid: '0296e4c3-f828-44b9-b620-30b8954e34d9'
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Crow-Armstrong
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '79'
+  uuid: 8646042f-39ff-4e11-99a1-6f3843b0513a
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Eldridge
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '80'
+  uuid: 4079f848-3058-41fe-9413-1a619b6c318c
+  subjects:
+  - entities:
+    - role: player
+      name: Brady House
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: '81'
+  uuid: 69a6d69b-b106-48ed-9455-8eeca4266cd9
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Schwarber
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: '82'
+  uuid: f6aba64a-2443-4573-9e87-4cc99e4739fa
+  subjects:
+  - entities:
+    - role: player
+      name: Jac Caglianone
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: '83'
+  uuid: 9ccec179-d4ac-4e8e-a5e8-2ae5b908c04e
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Chourio
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: '84'
+  uuid: cab9c8ee-0937-4f1d-9ef1-0df12baf1152
+  subjects:
+  - entities:
+    - role: player
+      name: Andrew McCutchen
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '85'
+  uuid: 3385d7f1-d9da-430a-a580-fae47228d7b4
+  subjects:
+  - entities:
+    - role: player
+      name: Julio Rodríguez
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: '86'
+  uuid: f7127acf-d721-449f-a63d-ea415b297803
+  subjects:
+  - entities:
+    - role: player
+      name: Jhostynxon Garcia
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '87'
+  uuid: dcbef953-5127-4289-88e9-0510833bd08a
+  subjects:
+  - entities:
+    - role: player
+      name: Seiya Suzuki
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '88'
+  uuid: 68ec0860-d8cd-458b-a543-2d9d741057b5
+  subjects:
+  - entities:
+    - role: player
+      name: Trea Turner
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: '89'
+  uuid: 6a2f0ce3-d539-4ac7-8edd-125d530e8d07
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Wilson
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: '90'
+  uuid: 9333907e-8a94-4e85-944e-d216e473dbbd
+  subjects:
+  - entities:
+    - role: player
+      name: Christian Yelich
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 

--- a/data/baseball/2026-topps-series-2/checklists/the-flagship-collection.yaml
+++ b/data/baseball/2026-topps-series-2/checklists/the-flagship-collection.yaml
@@ -1,0 +1,900 @@
+- number: '1'
+  uuid: 7e96afbc-ac19-48f9-856d-c6b1a23e8e0d
+  subjects:
+  - entities:
+    - role: player
+      name: Shohei Ohtani
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '2'
+  uuid: 047a8727-88ae-412a-a996-56f03c754ea4
+  subjects:
+  - entities:
+    - role: player
+      name: Dylan Beavers
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '3'
+  uuid: 00666766-08ad-4155-9793-c84a4190ee85
+  subjects:
+  - entities:
+    - role: player
+      name: Justin Verlander
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '4'
+  uuid: 1edd0f61-03b8-40a7-bb03-cc4060435395
+  subjects:
+  - entities:
+    - role: player
+      name: Jose Altuve
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '5'
+  uuid: 7ca3cdd0-4fa6-4d95-9bd2-5b4cf78dc042
+  subjects:
+  - entities:
+    - role: player
+      name: Max Scherzer
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '6'
+  uuid: a006eec3-4e51-4376-b89d-44afc4062747
+  subjects:
+  - entities:
+    - role: player
+      name: Elly De La Cruz
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '7'
+  uuid: aefbb9fe-a644-44ba-b6f2-27e449b55833
+  subjects:
+  - entities:
+    - role: player
+      name: Aaron Judge
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '8'
+  uuid: 769b685b-c81b-4630-b364-9097eecc83d8
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Teel
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: '9'
+  uuid: 88379dea-be91-4388-8fa9-961b1687de43
+  subjects:
+  - entities:
+    - role: player
+      name: Jazz Chisholm Jr.
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '10'
+  uuid: 6dbc95fa-ff4b-468c-9e30-f4636667831b
+  subjects:
+  - entities:
+    - role: player
+      name: Dansby Swanson
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '11'
+  uuid: '0383e40c-da7f-4886-afd0-7f0627a79e4f'
+  subjects:
+  - entities:
+    - role: player
+      name: George Springer
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '12'
+  uuid: 86e30123-74f4-4acc-ae9a-93e29087526e
+  subjects:
+  - entities:
+    - role: player
+      name: Chase DeLauter
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '13'
+  uuid: f2c75f15-f9eb-4fbb-80af-a6a8a12ef5a0
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Alonso
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '14'
+  uuid: 2ba04cd7-620c-44a4-96e7-ba850e2e3d2a
+  subjects:
+  - entities:
+    - role: player
+      name: Manny Machado
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: '15'
+  uuid: 294448a4-d68c-4c99-ab32-ea248233fecc
+  subjects:
+  - entities:
+    - role: player
+      name: Cole Young
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: '16'
+  uuid: bd612ab1-e447-4b94-9649-058ebdba0324
+  subjects:
+  - entities:
+    - role: player
+      name: James Wood
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: '17'
+  uuid: bc33103e-8c4c-43a2-afd9-820de392b8d7
+  subjects:
+  - entities:
+    - role: player
+      name: Chase Burns
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '18'
+  uuid: 9a63c4d4-9f12-41fd-a66c-20b803ede607
+  subjects:
+  - entities:
+    - role: player
+      name: Francisco Lindor
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '19'
+  uuid: 39d2f87f-e238-4807-97bb-1aeede3944a2
+  subjects:
+  - entities:
+    - role: player
+      name: Owen Caissie
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: '20'
+  uuid: 8f9d281a-57a5-4b2c-bcb0-f365e9486b67
+  subjects:
+  - entities:
+    - role: player
+      name: Trey Yesavage
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '21'
+  uuid: 606d50bb-739e-4224-974b-ce75a66fbb79
+  subjects:
+  - entities:
+    - role: player
+      name: Zach Neto
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: '22'
+  uuid: a2f021b6-3538-4c75-9728-21d46e6a3ef1
+  subjects:
+  - entities:
+    - role: player
+      name: Riley Greene
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '23'
+  uuid: b43599cb-e505-4720-beef-cb329abfe675
+  subjects:
+  - entities:
+    - role: player
+      name: Brice Matthews
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '24'
+  uuid: 4da7dafe-e111-4bde-b5a4-df7cc251cd18
+  subjects:
+  - entities:
+    - role: player
+      name: Junior Caminero
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: '25'
+  uuid: 7575ae67-682b-4dcd-8c46-5ed927718c9c
+  subjects:
+  - entities:
+    - role: player
+      name: Garrett Crochet
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '26'
+  uuid: e59da792-7ee2-485d-a41e-2787452f686d
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Tucker
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '27'
+  uuid: '081bddc7-5e47-46d4-ba74-504037084715'
+  subjects:
+  - entities:
+    - role: player
+      name: Colby Thomas
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: '28'
+  uuid: c6618e73-99b1-4f6e-9847-5225340543a3
+  subjects:
+  - entities:
+    - role: player
+      name: Clayton Kershaw
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '29'
+  uuid: eb5d136a-df8e-4261-923d-9b8e760ab8b6
+  subjects:
+  - entities:
+    - role: player
+      name: Jonah Tong
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '30'
+  uuid: 66434846-4b8a-448a-9f8f-c553149b3ae0
+  subjects:
+  - entities:
+    - role: player
+      name: Freddie Freeman
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '31'
+  uuid: 13fc85cc-3cdd-4f27-b120-6547651936ea
+  subjects:
+  - entities:
+    - role: player
+      name: Colson Montgomery
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: '32'
+  uuid: 9f66a049-f667-4d40-ae7b-861d09c8fe0a
+  subjects:
+  - entities:
+    - role: player
+      name: Drew Gilbert
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '33'
+  uuid: fa20e310-dee9-412a-8150-a668276f30d7
+  subjects:
+  - entities:
+    - role: player
+      name: Shota Imanaga
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '34'
+  uuid: de4a1c36-94f6-4680-b997-aa5dc9520e55
+  subjects:
+  - entities:
+    - role: player
+      name: Carter Jensen
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: '35'
+  uuid: f7bdb41a-cbd8-4e6a-9516-922fe5cb4be6
+  subjects:
+  - entities:
+    - role: player
+      name: Mookie Betts
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '36'
+  uuid: d23a1b82-c358-47d1-b20b-5881a6bf1ee3
+  subjects:
+  - entities:
+    - role: player
+      name: Cam Schlittler
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '37'
+  uuid: 578a6c07-8364-4673-bc9c-829d20303a47
+  subjects:
+  - entities:
+    - role: player
+      name: Munetaka Murakami
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: '38'
+  uuid: bc6be718-eb00-4670-b1ac-712257a62127
+  subjects:
+  - entities:
+    - role: player
+      name: Harry Ford
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: '39'
+  uuid: de3348cb-5602-4995-be02-7125fde5ea46
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Misiorowski
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: '40'
+  uuid: 17b13c1e-67bf-472d-8e0c-fd16402b00ad
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Kurtz
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: '41'
+  uuid: f0ebd67d-25c1-4a42-a1c7-d98da1e7c378
+  subjects:
+  - entities:
+    - role: player
+      name: Payton Tolle
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '42'
+  uuid: 53c7b65c-bc8a-4029-ac8c-8d346142b3a0
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Melton
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: '43'
+  uuid: 47954038-5674-4f07-b9ed-521e5de17722
+  subjects:
+  - entities:
+    - role: player
+      name: Cal Raleigh
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: '44'
+  uuid: cd9446d6-cfb3-4713-a28f-6a3ac8baeb9c
+  subjects:
+  - entities:
+    - role: player
+      name: Bubba Chandler
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '45'
+  uuid: 2b324844-0cbd-4ba5-848c-2e9a1e4eca95
+  subjects:
+  - entities:
+    - role: player
+      name: Roki Sasaki
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '46'
+  uuid: 16d75619-148b-4028-8eb4-710ad0c5e8b3
+  subjects:
+  - entities:
+    - role: player
+      name: Jakob Marsee
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: '47'
+  uuid: 91756e17-ca88-425c-a87a-73c8875f95ba
+  subjects:
+  - entities:
+    - role: player
+      name: Yordan Alvarez
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '48'
+  uuid: cfdf9719-06eb-48f5-b6f4-2fe01330dd9b
+  subjects:
+  - entities:
+    - role: player
+      name: Ronald Acuña Jr.
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: '49'
+  uuid: f243e282-bc02-43cc-9f77-b31e385a3f9e
+  subjects:
+  - entities:
+    - role: player
+      name: Sonny Gray
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '50'
+  uuid: c4a8b46b-57e9-4e63-b804-66307249bced
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Trout
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: '51'
+  uuid: 2871f3b0-8e94-4614-b019-5d9507110eae
+  subjects:
+  - entities:
+    - role: player
+      name: Gunnar Henderson
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '52'
+  uuid: c21e3556-b837-4d24-bdee-3f5e15085ec1
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan McLean
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '53'
+  uuid: 777c51fe-d9f8-4136-bd15-5ba497dc6a12
+  subjects:
+  - entities:
+    - role: player
+      name: Carson Williams
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: '54'
+  uuid: 2500fb4b-27dc-482f-82ec-96afd888def1
+  subjects:
+  - entities:
+    - role: player
+      name: Yoshinobu Yamamoto
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '55'
+  uuid: 2adaef4b-98cb-4770-a710-677ed5efdae6
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '56'
+  uuid: 81293a33-08cf-4eb6-9c61-cb8df5b300ae
+  subjects:
+  - entities:
+    - role: player
+      name: C.J. Kayfus
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '57'
+  uuid: 2e30c6d1-9d7d-4715-859c-e99ff224037b
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Harper
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: '58'
+  uuid: 11ac7d7c-63e5-4e71-95f6-833bf40c3856
+  subjects:
+  - entities:
+    - role: player
+      name: Roman Anthony
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '59'
+  uuid: 76ad1666-2e63-4a97-ab66-c73b55436441
+  subjects:
+  - entities:
+    - role: player
+      name: Corbin Carroll
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: '60'
+  uuid: 7ecb002f-481a-4f95-be3d-0d559a2088ae
+  subjects:
+  - entities:
+    - role: player
+      name: Alex Freeland
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '61'
+  uuid: 10cfbff3-3ca8-4f8a-87a1-84e8a078a1ff
+  subjects:
+  - entities:
+    - role: player
+      name: Paul Skenes
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '62'
+  uuid: fc3e8a1d-44e5-4e85-904a-8bb97d978122
+  subjects:
+  - entities:
+    - role: player
+      name: Max Muncy
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '63'
+  uuid: '0359dc3b-f3aa-47f3-8c77-1bd80bcc056c'
+  subjects:
+  - entities:
+    - role: player
+      name: Bo Bichette
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '64'
+  uuid: 97bb03f5-4f8a-4cb5-badb-baa7d492bd50
+  subjects:
+  - entities:
+    - role: player
+      name: Vladimir Guerrero Jr.
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '65'
+  uuid: 83654b9b-6776-4355-a05b-b489bf96286a
+  subjects:
+  - entities:
+    - role: player
+      name: Christian Moore
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: '66'
+  uuid: a91bed39-ed21-4ca4-b17e-0d911a4a816c
+  subjects:
+  - entities:
+    - role: player
+      name: Samuel Basallo
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '67'
+  uuid: 59f2185c-b28d-4e1b-8e71-7aa6d2d85cc4
+  subjects:
+  - entities:
+    - role: player
+      name: Ketel Marte
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: '68'
+  uuid: 36321052-48ff-422c-97c2-119ddd3a8505
+  subjects:
+  - entities:
+    - role: player
+      name: Corey Seager
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: '69'
+  uuid: ad295cb8-a865-4b06-909e-855aea1d420b
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan Arenado
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: '70'
+  uuid: 1d5809ee-001b-428e-8129-46d067b5bc85
+  subjects:
+  - entities:
+    - role: player
+      name: Austin Riley
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: '71'
+  uuid: de07a103-020b-4959-ba49-55e55641ad73
+  subjects:
+  - entities:
+    - role: player
+      name: Alex Bregman
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '72'
+  uuid: eebfb955-3e4e-4217-90cc-15d4ed1657ba
+  subjects:
+  - entities:
+    - role: player
+      name: Sal Stewart
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '73'
+  uuid: 921e4847-9229-4bd7-a1fa-cee13cbf2c5f
+  subjects:
+  - entities:
+    - role: player
+      name: Fernando Tatis Jr.
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: '74'
+  uuid: df66ce1b-4d7e-4d1e-88c7-04050d834c0e
+  subjects:
+  - entities:
+    - role: player
+      name: Bobby Witt Jr.
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: '75'
+  uuid: 9170339e-4cc3-4c21-a394-1f3e704b4803
+  subjects:
+  - entities:
+    - role: player
+      name: Adley Rutschman
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '76'
+  uuid: b1c3e1e1-044b-49ea-b8d3-3460dfad0a5e
+  subjects:
+  - entities:
+    - role: player
+      name: Tarik Skubal
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '77'
+  uuid: 969f23a7-16b1-49cc-8eae-505acea57a5e
+  subjects:
+  - entities:
+    - role: player
+      name: Jarren Duran
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '78'
+  uuid: 9c895878-2131-4f80-a58e-5f0ae6d9ce4e
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Crow-Armstrong
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '79'
+  uuid: d2de7b7b-f98a-47ee-a4b7-1aad8f76eaf5
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Eldridge
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '80'
+  uuid: '059e4f2b-05a7-4447-89c6-c3a1374deee7'
+  subjects:
+  - entities:
+    - role: player
+      name: Brady House
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: '81'
+  uuid: 53550075-e70f-4ede-b582-e787deda2602
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Schwarber
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: '82'
+  uuid: 4d7aa579-49e1-4f05-aee3-bf87c6541bc5
+  subjects:
+  - entities:
+    - role: player
+      name: Jac Caglianone
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: '83'
+  uuid: 73a7ee1a-35cf-4b60-bb4f-7c360393b65f
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Chourio
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: '84'
+  uuid: '08747f5b-8467-4f61-924b-0173384c84f9'
+  subjects:
+  - entities:
+    - role: player
+      name: Andrew McCutchen
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '85'
+  uuid: '09d2d3a7-e7f5-420e-9a9f-ff03f19abc83'
+  subjects:
+  - entities:
+    - role: player
+      name: Julio Rodríguez
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: '86'
+  uuid: 24a20bc8-3d73-4e24-b9c4-095f017157ff
+  subjects:
+  - entities:
+    - role: player
+      name: Jhostynxon Garcia
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '87'
+  uuid: e5337bd0-f75a-4785-9b62-de76061e115b
+  subjects:
+  - entities:
+    - role: player
+      name: Seiya Suzuki
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '88'
+  uuid: 40692170-4306-4dc4-857e-b33f2f818f82
+  subjects:
+  - entities:
+    - role: player
+      name: Trea Turner
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: '89'
+  uuid: 2d059816-c7df-49ca-9214-673efbcdb79c
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Wilson
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: '90'
+  uuid: b7dcad1d-db06-46e7-af7f-82f0ff4492ed
+  subjects:
+  - entities:
+    - role: player
+      name: Christian Yelich
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 

--- a/data/baseball/2026-topps-series-2/checklists/through-the-years-golden-mirror-rookie-cards.yaml
+++ b/data/baseball/2026-topps-series-2/checklists/through-the-years-golden-mirror-rookie-cards.yaml
@@ -1,0 +1,50 @@
+- number: '98'
+  uuid: a933d508-a8d8-4ffa-bda3-eb2199dbc565
+  subjects:
+  - entities:
+    - role: player
+      name: Derek Jeter
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '164'
+  uuid: e56522bd-7d15-4e52-8fb8-9f91f60b9e89
+  subjects:
+  - entities:
+    - role: player
+      name: Roberto Clemente
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '312'
+  uuid: 2f7106fa-d5cf-4460-8fe2-82520062fb0e
+  subjects:
+  - entities:
+    - role: player
+      name: Jackie Robinson
+      ref: 
+    - role: team
+      name: Brooklyn Dodgers
+      ref: 
+- number: '482'
+  uuid: c5eab479-d71c-40cd-80a7-e21d8747bcb9
+  subjects:
+  - entities:
+    - role: player
+      name: Rickey Henderson
+      ref: 
+    - role: team
+      name: Oakland Athletics
+      ref: 
+- number: US175
+  uuid: 4af2720b-505a-4785-988a-6e8bfcb5465f
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Trout
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 

--- a/data/baseball/2026-topps-series-2/checklists/titans-of-the-game.yaml
+++ b/data/baseball/2026-topps-series-2/checklists/titans-of-the-game.yaml
@@ -1,0 +1,200 @@
+- number: TOG-21
+  uuid: 7a835874-1450-48e8-a48e-fbfe094da4d9
+  subjects:
+  - entities:
+    - role: player
+      name: Christian Moore
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: TOG-22
+  uuid: 238a9733-b8fb-4f57-b8e8-0921358b4bde
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Kurtz
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: TOG-23
+  uuid: a562dbbe-d3bf-4484-92db-aa04e7248c2c
+  subjects:
+  - entities:
+    - role: player
+      name: Seiya Suzuki
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: TOG-24
+  uuid: '087c26a7-60b4-4c32-9d72-17f4cfb9edfa'
+  subjects:
+  - entities:
+    - role: player
+      name: Colson Montgomery
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: TOG-25
+  uuid: 4e06a7f6-1f3a-4be7-a99b-2e1495fce19e
+  subjects:
+  - entities:
+    - role: player
+      name: Chase Burns
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: TOG-26
+  uuid: 3614c753-1fa9-4352-9858-d5b82f3abb2d
+  subjects:
+  - entities:
+    - role: player
+      name: José Ramírez
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: TOG-27
+  uuid: febad243-f118-486b-8865-ceedf4eba166
+  subjects:
+  - entities:
+    - role: player
+      name: Tarik Skubal
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: TOG-28
+  uuid: 96929fca-e15f-45f3-b58d-45730deab89e
+  subjects:
+  - entities:
+    - role: player
+      name: Munetaka Murakami
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: TOG-29
+  uuid: 3d7144fa-4ae8-4411-8341-24cfd0f7ef75
+  subjects:
+  - entities:
+    - role: player
+      name: Freddie Freeman
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: TOG-30
+  uuid: 0e124fc7-a762-402e-b3e3-4c687a2381b2
+  subjects:
+  - entities:
+    - role: player
+      name: Alex Freeland
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: TOG-31
+  uuid: 297791b3-a3e7-43b2-8151-c4f1645a74ad
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Chourio
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: TOG-32
+  uuid: f5788672-a918-4a4e-bcb0-1dbf79692b48
+  subjects:
+  - entities:
+    - role: player
+      name: Francisco Lindor
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: TOG-33
+  uuid: 4f3adff3-9bb6-45b0-8dcf-d7770b3872f9
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan McLean
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: TOG-34
+  uuid: 7a021382-0c45-4db2-8c83-2371624644c2
+  subjects:
+  - entities:
+    - role: player
+      name: Cam Schlittler
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: TOG-35
+  uuid: 1ad06797-b3fd-4c9a-8c85-a86a67d79e8f
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Schwarber
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: TOG-36
+  uuid: 954c104e-8f17-4428-b2a5-00c2c9ce0ee8
+  subjects:
+  - entities:
+    - role: player
+      name: Bubba Chandler
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: TOG-37
+  uuid: a98591c1-3c2d-471c-9c0b-c095b0eeb58c
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Merrill
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: TOG-38
+  uuid: d03a3426-292f-4618-8e3c-c36c7e8bbb97
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Eldridge
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: TOG-39
+  uuid: 2b08ec70-2149-4124-b0ea-29e0e8f54fca
+  subjects:
+  - entities:
+    - role: player
+      name: Cole Young
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: TOG-40
+  uuid: '0921bc67-651d-46c7-bf24-6d02e37cc936'
+  subjects:
+  - entities:
+    - role: player
+      name: Trey Yesavage
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 

--- a/data/baseball/2026-topps-series-2/checklists/topps-flagship-autograph-patches.yaml
+++ b/data/baseball/2026-topps-series-2/checklists/topps-flagship-autograph-patches.yaml
@@ -1,0 +1,510 @@
+- number: TFAP-ABO
+  uuid: '089c2098-dd6d-4feb-bb5f-60d9cd009d87'
+  subjects:
+  - entities:
+    - role: player
+      name: Alec Bohm
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: TFAP-AG
+  uuid: d4fe150e-b5f3-4989-9cd0-9af4374ed04a
+  subjects:
+  - entities:
+    - role: player
+      name: Adolis García
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: TFAP-AM
+  uuid: 396d0317-d971-4bf5-b347-9ee56e3b6487
+  subjects:
+  - entities:
+    - role: player
+      name: Andrew McCutchen
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: TFAP-ANO
+  uuid: 68972c08-ddb2-4ea9-8215-9e7636301e1f
+  subjects:
+  - entities:
+    - role: player
+      name: Aaron Nola
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: TFAP-AP
+  uuid: fa14f162-6618-40e0-a1d8-3fcc2672e27c
+  subjects:
+  - entities:
+    - role: player
+      name: Albert Pujols
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: TFAP-ARY
+  uuid: '07899bd1-8148-4705-b538-ffc0e703a7d4'
+  subjects:
+  - entities:
+    - role: player
+      name: Austin Riley
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: TFAP-BST
+  uuid: 1e787163-2625-4987-af4b-cf5bc7e7f377
+  subjects:
+  - entities:
+    - role: player
+      name: Bryson Stott
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: TFAP-CRA
+  uuid: 1f687fdf-3b1f-408a-9491-b63f06b2071d
+  subjects:
+  - entities:
+    - role: player
+      name: Ceddanne Rafaela
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: TFAP-DST
+  uuid: 10829d02-4119-43c8-b1ca-38966f0cac3e
+  subjects:
+  - entities:
+    - role: player
+      name: Darryl Strawberry
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: TFAP-EL
+  uuid: 4363b93a-7ffc-4932-b742-18ee4f4e7b40
+  subjects:
+  - entities:
+    - role: player
+      name: Evan Longoria
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: TFAP-EM
+  uuid: fab4dd41-ad91-4b69-8bee-7233203433d2
+  subjects:
+  - entities:
+    - role: player
+      name: Eddie Murray
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: TFAP-FP
+  uuid: eff82858-60fb-433e-9d9e-7bd59e75ae4b
+  subjects:
+  - entities:
+    - role: player
+      name: Freddy Peralta
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: TFAP-FTJ
+  uuid: cfbcee87-302f-4b0e-87d7-1e4cc39023d9
+  subjects:
+  - entities:
+    - role: player
+      name: Fernando Tatis Jr.
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: TFAP-GSH
+  uuid: 7d1483a7-f02b-4a82-afa2-71daf0906546
+  subjects:
+  - entities:
+    - role: player
+      name: Gary Sheffield
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: TFAP-JMA
+  uuid: 2e0b2c5d-773c-4f53-8484-af96ecb112ee
+  subjects:
+  - entities:
+    - role: player
+      name: Joe Mauer
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: TFAP-LC
+  uuid: 7ac14273-69ff-44fe-895e-f358bb7ee7a3
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Castillo
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: TFAP-MMU
+  uuid: 58eb8f04-193e-4506-b45a-f8a6d641f19b
+  subjects:
+  - entities:
+    - role: player
+      name: Max Muncy
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: TFAP-MOL
+  uuid: efe546ae-0754-4400-ac23-99fdd930bca3
+  subjects:
+  - entities:
+    - role: player
+      name: Matt Olson
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: TFAP-MTR
+  uuid: a0fb8e43-3818-434c-ae73-fe8c302c053a
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Trout
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: TFAP-PG
+  uuid: ee0c3127-fff5-4f22-962d-879c97472328
+  subjects:
+  - entities:
+    - role: player
+      name: Paul Goldschmidt
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: TFAP-SL
+  uuid: a8bc08bf-d8fb-49a0-b28b-fee817eaf158
+  subjects:
+  - entities:
+    - role: player
+      name: Shea Langeliers
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: TFAP-TIH
+  uuid: 709fa941-b9d3-4a89-aa5f-645172d88ec0
+  subjects:
+  - entities:
+    - role: player
+      name: Torii Hunter
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: TFAP-ZW
+  uuid: 0c004b32-124b-43f8-a53f-8a45b8a1c940
+  subjects:
+  - entities:
+    - role: player
+      name: Zack Wheeler
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: TFAP2-AB
+  uuid: 46010c09-49cc-427f-b11f-0e6b8319c007
+  subjects:
+  - entities:
+    - role: player
+      name: Alex Bregman
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: TFAP2-AJ
+  uuid: affcce1d-3052-49f4-83bf-7fd05579f1ca
+  subjects:
+  - entities:
+    - role: player
+      name: Aaron Judge
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: TFAP2-AM
+  uuid: dd64140d-0957-4ecb-8a06-95296854426b
+  subjects:
+  - entities:
+    - role: player
+      name: Andrew McCutchen
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: TFAP2-AR
+  uuid: 6e04a7ab-eb47-45b1-81c9-0c9af647afd9
+  subjects:
+  - entities:
+    - role: player
+      name: Austin Riley
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: TFAP2-AV
+  uuid: afbad0e5-7370-4bc8-9283-2be744227d9b
+  subjects:
+  - entities:
+    - role: player
+      name: Anthony Volpe
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: TFAP2-BC
+  uuid: 51ee12fe-6d98-4e3a-88ea-e5e08d030ec6
+  subjects:
+  - entities:
+    - role: player
+      name: Bubba Chandler
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: TFAP2-BH
+  uuid: 5b2550fa-9f9a-4d94-8f44-ff0c609d3000
+  subjects:
+  - entities:
+    - role: player
+      name: Brady House
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: TFAP2-BR
+  uuid: 5ee36e9f-fb9b-4a72-b4db-a0b846e4bf6b
+  subjects:
+  - entities:
+    - role: player
+      name: Brent Rooker
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: TFAP2-CB
+  uuid: b8b2abf1-3920-407c-b2bb-bf8a1184d0e3
+  subjects:
+  - entities:
+    - role: player
+      name: Chase Burns
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: TFAP2-CK
+  uuid: 00326ebb-8931-4ff8-a14a-5641f754c6d4
+  subjects:
+  - entities:
+    - role: player
+      name: C.J. Kayfus
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: TFAP2-CMO
+  uuid: e0b101dc-4cf9-486d-a4eb-2847673a55c7
+  subjects:
+  - entities:
+    - role: player
+      name: Christian Moore
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: TFAP2-CS
+  uuid: 40e0a0ab-e975-43aa-91d7-873108101651
+  subjects:
+  - entities:
+    - role: player
+      name: Chris Sale
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: TFAP2-CY
+  uuid: 4ed00b6c-af0b-4a05-abe3-0f61db1f4102
+  subjects:
+  - entities:
+    - role: player
+      name: Christian Yelich
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: TFAP2-DB
+  uuid: aa31777b-420b-425b-a95c-464766175739
+  subjects:
+  - entities:
+    - role: player
+      name: Drake Baldwin
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: TFAP2-DBE
+  uuid: d40e8dff-7167-4ddd-9fdf-a1efe29e200c
+  subjects:
+  - entities:
+    - role: player
+      name: Dylan Beavers
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: TFAP2-FL
+  uuid: 7e7873bd-9ff7-40b3-9b9c-b20d65a3d2a8
+  subjects:
+  - entities:
+    - role: player
+      name: Francisco Lindor
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: TFAP2-FP
+  uuid: e45e69a4-d5ab-49b0-a17e-8d94b3f3794a
+  subjects:
+  - entities:
+    - role: player
+      name: Freddy Peralta
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: TFAP2-JCA
+  uuid: 8da000e0-062a-4257-aebc-ce6b4be07215
+  subjects:
+  - entities:
+    - role: player
+      name: Jac Caglianone
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: TFAP2-JM
+  uuid: de11e2b1-661c-4f2f-aa45-1c7313f96679
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Melton
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: TFAP2-JP
+  uuid: 39286d04-81aa-4443-86d4-4329eccf9d01
+  subjects:
+  - entities:
+    - role: player
+      name: Jeremy Peña
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: TFAP2-JR
+  uuid: e2a69c2c-6d06-448f-b5a9-3dc5bdae252b
+  subjects:
+  - entities:
+    - role: player
+      name: José Ramírez
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: TFAP2-JWI
+  uuid: f82c57c6-88c6-43cb-bef0-9a5d323e5324
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Wilson
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: TFAP2-MF
+  uuid: 1dbb8c1e-88ba-40da-97cd-2350588eed25
+  subjects:
+  - entities:
+    - role: player
+      name: Max Fried
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: TFAP2-NC
+  uuid: ccdc7484-4500-41f7-8396-b7c1226dfe86
+  subjects:
+  - entities:
+    - role: player
+      name: Nathan Church
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: TFAP2-RAN
+  uuid: 4e6c3413-915f-46f3-b197-121818a187c9
+  subjects:
+  - entities:
+    - role: player
+      name: Roman Anthony
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: TFAP2-RG
+  uuid: 267a5e46-736e-4239-89bd-a73f5c66d2c5
+  subjects:
+  - entities:
+    - role: player
+      name: Riley Greene
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: TFAP2-WS
+  uuid: b2abda3c-b8e5-40e3-af79-5336ace37558
+  subjects:
+  - entities:
+    - role: player
+      name: Will Smith
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: TFAP2-YF
+  uuid: b7dbbc08-1f88-434b-a28c-a05b10bfa3cc
+  subjects:
+  - entities:
+    - role: player
+      name: Yanquiel Fernández
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 

--- a/data/baseball/2026-topps-series-2/checklists/true-photo-variations.yaml
+++ b/data/baseball/2026-topps-series-2/checklists/true-photo-variations.yaml
@@ -1,0 +1,1000 @@
+- number: '352'
+  uuid: 53c2cd5e-54b1-4727-8d46-81ad3c88d213
+  subjects:
+  - entities:
+    - role: player
+      name: Spencer Torkelson
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '355'
+  uuid: 10c53b22-9924-4f07-b620-236a86981a99
+  subjects:
+  - entities:
+    - role: player
+      name: Nathan Eovaldi
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: '358'
+  uuid: 8f6ace37-fe74-4f69-a845-2eb8a07ae260
+  subjects:
+  - entities:
+    - role: player
+      name: Adley Rutschman
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '363'
+  uuid: e09c39eb-4ae0-433d-9d6f-bdfbf8c96eb0
+  subjects:
+  - entities:
+    - role: player
+      name: J.T. Realmuto
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: '365'
+  uuid: a3d2cbc3-1734-498b-92db-e9b37507bf70
+  subjects:
+  - entities:
+    - role: player
+      name: Spencer Steer
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '367'
+  uuid: 357a020a-e6c4-483f-a4c4-790b2bbe2efe
+  subjects:
+  - entities:
+    - role: player
+      name: Robbie Ray
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '368'
+  uuid: 73d67b16-70f5-4164-89f9-30aa53b5d703
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Tucker
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '371'
+  uuid: 13242aa5-0f73-451a-9ca5-7d0e54a9e0fc
+  subjects:
+  - entities:
+    - role: player
+      name: Brent Rooker
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: '372'
+  uuid: b201a76f-fd02-4c77-9442-49cac61da3ee
+  subjects:
+  - entities:
+    - role: player
+      name: Sal Stewart
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '382'
+  uuid: 187ff967-1fb3-4dce-b8b7-ef2b6637eb6d
+  subjects:
+  - entities:
+    - role: player
+      name: Hunter Greene
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '383'
+  uuid: '08c39904-2d1e-43fb-9d21-3c6e89de9cc6'
+  subjects:
+  - entities:
+    - role: player
+      name: Wyatt Langford
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: '386'
+  uuid: 86c39433-840e-4c9e-b1ff-fd3efa33067d
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Curvelo
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: '387'
+  uuid: 531a6b46-1973-4132-9282-985907dee903
+  subjects:
+  - entities:
+    - role: player
+      name: Drew Sommers
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '393'
+  uuid: f75a7c66-a9cd-479b-8ec2-ab83541c4327
+  subjects:
+  - entities:
+    - role: player
+      name: Jazz Chisholm Jr.
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '395'
+  uuid: df6e1d10-76e2-4d24-ae1b-373849d38cde
+  subjects:
+  - entities:
+    - role: player
+      name: Josh Naylor
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: '398'
+  uuid: a4dc2a0a-1dc6-41bb-80c9-5b5ea781c012
+  subjects:
+  - entities:
+    - role: player
+      name: Hunter Barco
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '400'
+  uuid: d764225f-f962-434d-a7ed-3653dce9a1af
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Alonso
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '406'
+  uuid: 8f5d553e-f0a9-4cf7-a489-132e3cebe86b
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Eldridge
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '410'
+  uuid: d3275f2f-9317-480d-a667-be20d1e038e7
+  subjects:
+  - entities:
+    - role: player
+      name: Hayden Harris
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: '415'
+  uuid: 7f988422-2fd4-4287-b880-3e8d67a1b3a1
+  subjects:
+  - entities:
+    - role: player
+      name: Justin Verlander
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '422'
+  uuid: 74ad1b7a-dfd3-4ded-98ba-c9fc24ee71fa
+  subjects:
+  - entities:
+    - role: player
+      name: Shane Bieber
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '423'
+  uuid: e18a73d1-28d5-4dee-8b69-9f7ada2ed570
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Robert Jr.
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '425'
+  uuid: 3a953e80-8ff5-428c-8d08-85b8e9d91261
+  subjects:
+  - entities:
+    - role: player
+      name: Trent Grisham
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '427'
+  uuid: 0c08c26b-5872-4ff0-a8af-b7d6c0bf7ccf
+  subjects:
+  - entities:
+    - role: player
+      name: Chris Sale
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: '431'
+  uuid: 12c1b07a-d17a-455c-bbb9-f0ebb4f3f6ad
+  subjects:
+  - entities:
+    - role: player
+      name: Randy Arozarena
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: '435'
+  uuid: 1938059f-ca27-4f48-995d-e0124c91dc16
+  subjects:
+  - entities:
+    - role: player
+      name: Denzer Guzman
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: '439'
+  uuid: 4f752e1c-ce89-4d89-b792-82806be4e9ef
+  subjects:
+  - entities:
+    - role: player
+      name: Gleyber Torres
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '441'
+  uuid: bbfdd544-253c-4ae3-9cac-27901cba5a48
+  subjects:
+  - entities:
+    - role: player
+      name: Lars Nootbaar
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: '446'
+  uuid: 22aed917-bd6e-4af9-a33f-d41724589410
+  subjects:
+  - entities:
+    - role: player
+      name: Eugenio Suárez
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '448'
+  uuid: 801e3966-aacc-42c0-bed9-ff001b68f324
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Chourio
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: '450'
+  uuid: 50c2366d-e979-44f4-9120-e1bb2b14a304
+  subjects:
+  - entities:
+    - role: player
+      name: Gerrit Cole
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '455'
+  uuid: 33088093-5773-4e5a-9b74-c4e122f61572
+  subjects:
+  - entities:
+    - role: player
+      name: George Springer
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '458'
+  uuid: c2376d85-c95a-4ef7-bc8c-42a12aabb02f
+  subjects:
+  - entities:
+    - role: player
+      name: Chase DeLauter
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '459'
+  uuid: 2adc7c63-4caf-4c65-9655-dd185a9ccfc4
+  subjects:
+  - entities:
+    - role: player
+      name: Ketel Marte
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: '463'
+  uuid: 46b31ace-ad19-4584-b186-e82eca21c3f6
+  subjects:
+  - entities:
+    - role: player
+      name: Aaron Nola
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: '468'
+  uuid: d8753178-ecd1-46cb-b0f0-fe12140b4b9e
+  subjects:
+  - entities:
+    - role: player
+      name: Yordan Alvarez
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '470'
+  uuid: daa0ca71-5d13-4fcc-aabd-33a05587f27d
+  subjects:
+  - entities:
+    - role: player
+      name: Brandon Nimmo
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: '471'
+  uuid: db080699-0a90-4626-88a1-cbfc3524f472
+  subjects:
+  - entities:
+    - role: player
+      name: J.P. Crawford
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: '473'
+  uuid: d339b769-3525-4558-a3d2-2aa439185ce8
+  subjects:
+  - entities:
+    - role: player
+      name: Bo Bichette
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '483'
+  uuid: 970fec8a-3b67-4c38-a197-9d4c8130982b
+  subjects:
+  - entities:
+    - role: player
+      name: Logan O'Hoppe
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: '493'
+  uuid: d681e42e-c427-4fb6-ab89-a61f6b2f2725
+  subjects:
+  - entities:
+    - role: player
+      name: George Kirby
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: '500'
+  uuid: 854f0c32-8dbb-4809-b90b-19c8b9f04ded
+  subjects:
+  - entities:
+    - role: player
+      name: Shohei Ohtani
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '501'
+  uuid: 59f50810-7bc0-43c9-a511-66353d42d897
+  subjects:
+  - entities:
+    - role: player
+      name: Connelly Early
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '503'
+  uuid: e6670edf-ca78-4557-9748-91ae5f40f153
+  subjects:
+  - entities:
+    - role: player
+      name: Munetaka Murakami
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: '507'
+  uuid: 94c5aabb-c473-47fa-9a52-9fbb757ed201
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Castillo
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: '510'
+  uuid: ea0702c6-2710-4dc2-bc7e-69333b8ece89
+  subjects:
+  - entities:
+    - role: player
+      name: Philip Abner
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: '520'
+  uuid: 1d38d1c6-0eea-454a-84a9-304110f72c18
+  subjects:
+  - entities:
+    - role: player
+      name: Andrew Alvarez
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: '526'
+  uuid: 7ecf9b6a-36b2-4abd-a724-16dd2a703e3a
+  subjects:
+  - entities:
+    - role: player
+      name: Masyn Winn
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: '530'
+  uuid: 59b43e94-f084-4ee2-87df-3b24b1d69e49
+  subjects:
+  - entities:
+    - role: player
+      name: Carter Jensen
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: '533'
+  uuid: 243d7938-1ebe-43e3-8086-75018738439b
+  subjects:
+  - entities:
+    - role: player
+      name: Jasson Domínguez
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '534'
+  uuid: ad773fbb-39e1-429b-b8b2-cd044d213af1
+  subjects:
+  - entities:
+    - role: player
+      name: Brandon Sproat
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: '536'
+  uuid: 4d78eadc-307c-4408-9e5e-99d91de47e81
+  subjects:
+  - entities:
+    - role: player
+      name: Trevor Story
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '541'
+  uuid: 2fa920be-9a17-4790-a0dd-e21c61386f78
+  subjects:
+  - entities:
+    - role: player
+      name: Jung Hoo Lee
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '547'
+  uuid: 8881ff1a-2b3d-4ffd-b0d5-708fc1ab7819
+  subjects:
+  - entities:
+    - role: player
+      name: Dylan Cease
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '550'
+  uuid: 4e703c2b-b912-4a3e-a641-c32aad252cf5
+  subjects:
+  - entities:
+    - role: player
+      name: Dansby Swanson
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '551'
+  uuid: f66b9a88-2efb-46e9-89d4-71bed2d54570
+  subjects:
+  - entities:
+    - role: player
+      name: Taylor Ward
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '560'
+  uuid: 83833530-6c36-4477-a58d-428a8cdb72c3
+  subjects:
+  - entities:
+    - role: player
+      name: Jarren Duran
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '561'
+  uuid: 31f7a158-fa61-4a69-a387-fa96f898d00e
+  subjects:
+  - entities:
+    - role: player
+      name: Matt Chapman
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '562'
+  uuid: 8bc9167d-047d-4fec-a70b-b5f85323245c
+  subjects:
+  - entities:
+    - role: player
+      name: Bryson Stott
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: '564'
+  uuid: 803d9c9a-43d6-4be5-aba5-00cd65cb3d7d
+  subjects:
+  - entities:
+    - role: player
+      name: Tyler Soderstrom
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: '568'
+  uuid: b77ed3d4-606b-470c-825c-b06c7daefff5
+  subjects:
+  - entities:
+    - role: player
+      name: Ozzie Albies
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: '569'
+  uuid: ef0f7625-78a4-4707-b7e0-56d0323be86e
+  subjects:
+  - entities:
+    - role: player
+      name: Max Scherzer
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '570'
+  uuid: 139c8165-6854-4a8e-85be-5199cf954d58
+  subjects:
+  - entities:
+    - role: player
+      name: Rolddy Muñoz
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: '578'
+  uuid: e61a28b7-6f23-4cd6-84e9-1aa55a1c88fc
+  subjects:
+  - entities:
+    - role: player
+      name: Heriberto Hernández
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: '585'
+  uuid: 319c6a62-3f86-42f1-b364-b05fff769d06
+  subjects:
+  - entities:
+    - role: player
+      name: Ian Happ
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '586'
+  uuid: 1c0de130-ee77-478a-8b3b-c9f34447de49
+  subjects:
+  - entities:
+    - role: player
+      name: Marcus Semien
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '594'
+  uuid: 284264bc-22db-411f-a0b0-7e89efa7d3ab
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Gil
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '597'
+  uuid: 234d3793-2ca4-4d7b-a4e7-6309cff1e9f7
+  subjects:
+  - entities:
+    - role: player
+      name: Paul Goldschmidt
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '598'
+  uuid: 6bba7c4a-fd45-495e-b1eb-ef4394b1e125
+  subjects:
+  - entities:
+    - role: player
+      name: Jack Winkler
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '600'
+  uuid: 230a0251-2253-435e-a6c6-cd5128246b74
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '601'
+  uuid: 73f6a9a1-6e9a-4252-ace5-172d1991e2be
+  subjects:
+  - entities:
+    - role: player
+      name: Zach Cole
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '603'
+  uuid: caf956b2-c2b4-491a-affc-7a7a98d8f988
+  subjects:
+  - entities:
+    - role: player
+      name: George Valera
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '607'
+  uuid: 34fd812c-0de2-43bf-8ad4-d9d504fa934a
+  subjects:
+  - entities:
+    - role: player
+      name: Cody Bellinger
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '611'
+  uuid: 911f6e66-3127-4752-9e57-a81f2dfde4a0
+  subjects:
+  - entities:
+    - role: player
+      name: Paul Gervase
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '613'
+  uuid: b70bb84b-f1e8-4c58-a21f-fa826eae85b9
+  subjects:
+  - entities:
+    - role: player
+      name: Jordan Westburg
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '614'
+  uuid: 923b0b47-5800-4047-91be-3bd3db25baaa
+  subjects:
+  - entities:
+    - role: player
+      name: Manny Machado
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: '618'
+  uuid: 46755221-5c7f-4131-a27d-43da06b09d61
+  subjects:
+  - entities:
+    - role: player
+      name: Tanner Bibee
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '620'
+  uuid: 27c16627-a2c4-4803-b62e-ae11de3a3f4c
+  subjects:
+  - entities:
+    - role: player
+      name: Trey Yesavage
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '623'
+  uuid: 83a68822-7276-4b16-bdc5-5afc3cacea6b
+  subjects:
+  - entities:
+    - role: player
+      name: Rafael Flores
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '629'
+  uuid: 4cacfa61-7271-49a9-9299-58e18b36c839
+  subjects:
+  - entities:
+    - role: player
+      name: Tyler Glasnow
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '631'
+  uuid: ec71cda8-24c4-4c89-b2da-01485bce903f
+  subjects:
+  - entities:
+    - role: player
+      name: Will Smith
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '632'
+  uuid: d05c2e00-2a7f-4fd2-9b41-5f9da502e9a6
+  subjects:
+  - entities:
+    - role: player
+      name: Cade Horton
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '633'
+  uuid: f3a6a6b7-4c06-4baa-913b-cc9fa9b6e7ba
+  subjects:
+  - entities:
+    - role: player
+      name: Salvador Perez
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: '643'
+  uuid: 72a0b835-d98f-40cd-9bbf-006518800d38
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Lodolo
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '646'
+  uuid: a6b95b7d-17bf-458b-b4fa-162d14f1c9c4
+  subjects:
+  - entities:
+    - role: player
+      name: Mark Vientos
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '650'
+  uuid: 494b5958-e39d-466f-948f-604ca6442a43
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Schwarber
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: '656'
+  uuid: 8e1d8924-a4d5-4f99-880e-b113e55f2a97
+  subjects:
+  - entities:
+    - role: player
+      name: Aroldis Chapman
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '658'
+  uuid: 825b37e1-23af-430f-96a2-6ac20ce929a9
+  subjects:
+  - entities:
+    - role: player
+      name: Jack Flaherty
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '659'
+  uuid: 6a9cb446-6c34-4263-bd32-9f3166fe4718
+  subjects:
+  - entities:
+    - role: player
+      name: Harry Ford
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: '665'
+  uuid: 49cff9f5-9445-454e-86c9-797454de4721
+  subjects:
+  - entities:
+    - role: player
+      name: Jose Corniell
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: '667'
+  uuid: 6f507ba3-9033-4d79-916e-199e38c36c84
+  subjects:
+  - entities:
+    - role: player
+      name: Kodai Senga
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '668'
+  uuid: 75334904-6f38-4878-a5f1-06a81ef79cb5
+  subjects:
+  - entities:
+    - role: player
+      name: Petey Halpin
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '674'
+  uuid: 859ff02e-21ee-42d2-aae9-163176d94c59
+  subjects:
+  - entities:
+    - role: player
+      name: Andre Granillo
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: '675'
+  uuid: 64fcd227-a4e6-4937-a072-49869cbdb117
+  subjects:
+  - entities:
+    - role: player
+      name: Steven Kwan
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '677'
+  uuid: 751de7c4-5214-4d58-9a0b-35cab84d1277
+  subjects:
+  - entities:
+    - role: player
+      name: Wilyer Abreu
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '680'
+  uuid: 86465b80-4a4b-4ef5-8013-d689728943d2
+  subjects:
+  - entities:
+    - role: player
+      name: Carlos Correa
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '685'
+  uuid: f8f22a98-6bd8-46bc-a012-855bfc3d75cc
+  subjects:
+  - entities:
+    - role: player
+      name: Seiya Suzuki
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '692'
+  uuid: eb1b2ecf-0f31-4302-917c-975b3eac616d
+  subjects:
+  - entities:
+    - role: player
+      name: Drake Baldwin
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: '697'
+  uuid: 19f1d40b-72d4-4460-be05-b550a3c37994
+  subjects:
+  - entities:
+    - role: player
+      name: Bryan Reynolds
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '700'
+  uuid: 7df8295e-d958-49af-a6ee-c019e91be0ef
+  subjects:
+  - entities:
+    - role: player
+      name: Freddie Freeman
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 

--- a/data/baseball/2026-topps-series-2/checklists/vintage-stock-variations.yaml
+++ b/data/baseball/2026-topps-series-2/checklists/vintage-stock-variations.yaml
@@ -1,0 +1,1000 @@
+- number: '352'
+  uuid: 28c532bb-03b4-474a-8549-4401a8083fa6
+  subjects:
+  - entities:
+    - role: player
+      name: Spencer Torkelson
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '355'
+  uuid: a2d08e24-1535-47eb-8080-538690343b75
+  subjects:
+  - entities:
+    - role: player
+      name: Nathan Eovaldi
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: '358'
+  uuid: 11f38f79-d313-4b64-b883-a66c2591fe8f
+  subjects:
+  - entities:
+    - role: player
+      name: Adley Rutschman
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '363'
+  uuid: 58161381-2ed7-4848-9b26-e3d7eb262abf
+  subjects:
+  - entities:
+    - role: player
+      name: J.T. Realmuto
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: '365'
+  uuid: 636b3671-8b6e-44b1-88b3-abe93cd95aa1
+  subjects:
+  - entities:
+    - role: player
+      name: Spencer Steer
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '367'
+  uuid: '0759c269-b273-47ec-b399-0b65db5d3ba2'
+  subjects:
+  - entities:
+    - role: player
+      name: Robbie Ray
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '368'
+  uuid: cf5e9f26-3b2f-4758-8466-1772aa222d03
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Tucker
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '371'
+  uuid: 1755bae1-bcf3-4751-bb5c-0dc6cdc882bb
+  subjects:
+  - entities:
+    - role: player
+      name: Brent Rooker
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: '372'
+  uuid: fabdf902-1190-4a86-b068-2b06eb918fa7
+  subjects:
+  - entities:
+    - role: player
+      name: Sal Stewart
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '382'
+  uuid: ce0c4a6c-7be7-44b8-aaf6-9dabf19efb0b
+  subjects:
+  - entities:
+    - role: player
+      name: Hunter Greene
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '383'
+  uuid: 42c91552-c852-41e3-9f23-58701750e2f5
+  subjects:
+  - entities:
+    - role: player
+      name: Wyatt Langford
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: '386'
+  uuid: e316802b-1a43-42a7-8b89-9113c0f3c970
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Curvelo
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: '387'
+  uuid: 85483b83-7f6d-4fe4-85f6-7f8f819b90ec
+  subjects:
+  - entities:
+    - role: player
+      name: Drew Sommers
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '393'
+  uuid: 61835812-e0f7-4ce2-891c-80ebc600aaf2
+  subjects:
+  - entities:
+    - role: player
+      name: Jazz Chisholm Jr.
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '395'
+  uuid: f7a2ae7b-8116-494e-8516-a8744a367488
+  subjects:
+  - entities:
+    - role: player
+      name: Josh Naylor
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: '398'
+  uuid: 774331dd-6dbc-469d-a711-0c6522f31735
+  subjects:
+  - entities:
+    - role: player
+      name: Hunter Barco
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '400'
+  uuid: 72203e8f-fdee-40a8-a2d0-bec50e2c37b7
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Alonso
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '406'
+  uuid: 7180d19f-da7c-4add-957e-88c46e714a80
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Eldridge
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '410'
+  uuid: c6b7d9cf-3d46-435c-9eb4-30e4cfcbfbde
+  subjects:
+  - entities:
+    - role: player
+      name: Hayden Harris
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: '415'
+  uuid: 11c1680f-8216-48a5-8340-c13f3641a1d9
+  subjects:
+  - entities:
+    - role: player
+      name: Justin Verlander
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '422'
+  uuid: ebb43c41-bb84-477a-af5e-0092aaf980dc
+  subjects:
+  - entities:
+    - role: player
+      name: Shane Bieber
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '423'
+  uuid: 292d8249-c9c7-4521-b20a-27b4c316a7ea
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Robert Jr.
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '425'
+  uuid: 06fcd70f-7b9d-4504-abd6-bfccb18060e0
+  subjects:
+  - entities:
+    - role: player
+      name: Trent Grisham
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '427'
+  uuid: c4e55f05-5481-4175-9333-2f3e0b004f2a
+  subjects:
+  - entities:
+    - role: player
+      name: Chris Sale
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: '431'
+  uuid: f1dc5037-1b2b-49d4-8965-52a772f5ee6f
+  subjects:
+  - entities:
+    - role: player
+      name: Randy Arozarena
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: '435'
+  uuid: 26f0ccc4-8fcc-453b-a574-ec7aa6ee5460
+  subjects:
+  - entities:
+    - role: player
+      name: Denzer Guzman
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: '439'
+  uuid: 8df14802-c7e7-4b06-bcfa-a9b8f468d6c5
+  subjects:
+  - entities:
+    - role: player
+      name: Gleyber Torres
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '441'
+  uuid: 2f4cc51c-09b3-4cf4-afaf-7fe20c9c4ed4
+  subjects:
+  - entities:
+    - role: player
+      name: Lars Nootbaar
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: '446'
+  uuid: 2420bbb9-15ec-4426-b43d-e9e5ce11d01e
+  subjects:
+  - entities:
+    - role: player
+      name: Eugenio Suárez
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '448'
+  uuid: c6f3f23c-8b4f-4938-b0cd-b78e4ca4a395
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Chourio
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: '450'
+  uuid: b124df19-c79b-4863-8e68-74361ed3e1ff
+  subjects:
+  - entities:
+    - role: player
+      name: Gerrit Cole
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '455'
+  uuid: c2ab6db4-1c02-4c57-af69-8d06f8d42e76
+  subjects:
+  - entities:
+    - role: player
+      name: George Springer
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '458'
+  uuid: f86459db-13d6-4d54-a103-0f0a2c3e5b99
+  subjects:
+  - entities:
+    - role: player
+      name: Chase DeLauter
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '459'
+  uuid: b355ae46-aae8-4f1b-ad28-04af24855d1e
+  subjects:
+  - entities:
+    - role: player
+      name: Ketel Marte
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: '463'
+  uuid: f06e9255-5740-42a1-801c-a4262ce7065c
+  subjects:
+  - entities:
+    - role: player
+      name: Aaron Nola
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: '468'
+  uuid: 974bc999-8332-42ec-bceb-40510ef40443
+  subjects:
+  - entities:
+    - role: player
+      name: Yordan Alvarez
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '470'
+  uuid: 36c4504b-8c3f-4df4-8458-0cce955f79e3
+  subjects:
+  - entities:
+    - role: player
+      name: Brandon Nimmo
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: '471'
+  uuid: 3bc1f160-ef8e-4179-9399-86725e2c295c
+  subjects:
+  - entities:
+    - role: player
+      name: J.P. Crawford
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: '473'
+  uuid: b5f67726-5bf5-4e5b-a236-f35a01709cfd
+  subjects:
+  - entities:
+    - role: player
+      name: Bo Bichette
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '483'
+  uuid: 9f521b34-1626-4d30-8d3c-88e41a50e440
+  subjects:
+  - entities:
+    - role: player
+      name: Logan O'Hoppe
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: '493'
+  uuid: 42d311cf-519f-449e-a229-4ea3aab54c0a
+  subjects:
+  - entities:
+    - role: player
+      name: George Kirby
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: '500'
+  uuid: 6ca81ab4-aa35-4bfd-8fad-e8c1b06dbccb
+  subjects:
+  - entities:
+    - role: player
+      name: Shohei Ohtani
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '501'
+  uuid: 9c8b38f9-7023-4cdb-8121-bbdcc7634d70
+  subjects:
+  - entities:
+    - role: player
+      name: Connelly Early
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '503'
+  uuid: bca2feaa-8cf4-4e35-8bae-e73e3eeb968d
+  subjects:
+  - entities:
+    - role: player
+      name: Munetaka Murakami
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: '507'
+  uuid: 78cbd7e3-3db8-4876-a73b-965b7b1782f6
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Castillo
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: '510'
+  uuid: 65525f45-227f-4300-8080-273af65193e9
+  subjects:
+  - entities:
+    - role: player
+      name: Philip Abner
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: '520'
+  uuid: b56d132a-7c34-4b66-9e64-75cb37770732
+  subjects:
+  - entities:
+    - role: player
+      name: Andrew Alvarez
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: '526'
+  uuid: 03fb55e3-3bdc-4413-b605-16656d0e5cf9
+  subjects:
+  - entities:
+    - role: player
+      name: Masyn Winn
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: '530'
+  uuid: 313adfe5-8390-4e35-bbcf-2d33d5c868fe
+  subjects:
+  - entities:
+    - role: player
+      name: Carter Jensen
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: '533'
+  uuid: b614fd37-a472-4bfb-8cd6-7e509ab1da98
+  subjects:
+  - entities:
+    - role: player
+      name: Jasson Domínguez
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '534'
+  uuid: 21a8fc8b-d2ec-4049-bf91-63ca4015c130
+  subjects:
+  - entities:
+    - role: player
+      name: Brandon Sproat
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: '536'
+  uuid: fce766a0-5a43-40dd-8a25-7b736ea18399
+  subjects:
+  - entities:
+    - role: player
+      name: Trevor Story
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '541'
+  uuid: acbbac3e-d78f-4474-a242-fb742b628544
+  subjects:
+  - entities:
+    - role: player
+      name: Jung Hoo Lee
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '547'
+  uuid: e8581d25-e14a-48ef-9648-1f881abe315a
+  subjects:
+  - entities:
+    - role: player
+      name: Dylan Cease
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '550'
+  uuid: 7c2328c4-80a8-49eb-ac95-81def396186e
+  subjects:
+  - entities:
+    - role: player
+      name: Dansby Swanson
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '551'
+  uuid: bf6d1a73-7238-4c3f-a56a-c3d2342de0c7
+  subjects:
+  - entities:
+    - role: player
+      name: Taylor Ward
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '560'
+  uuid: 23707199-c3f6-4169-b17e-5dd53a4b7725
+  subjects:
+  - entities:
+    - role: player
+      name: Jarren Duran
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '561'
+  uuid: 47f63f78-0fad-442f-84b1-34fa1fade572
+  subjects:
+  - entities:
+    - role: player
+      name: Matt Chapman
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '562'
+  uuid: 868541fe-b38c-4134-87bc-de8ec0d261a1
+  subjects:
+  - entities:
+    - role: player
+      name: Bryson Stott
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: '564'
+  uuid: 0e3bbf08-8df5-4a77-8038-ba9e94f92204
+  subjects:
+  - entities:
+    - role: player
+      name: Tyler Soderstrom
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: '568'
+  uuid: 922ef3de-4630-4c0d-875e-8d1859c820fc
+  subjects:
+  - entities:
+    - role: player
+      name: Ozzie Albies
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: '569'
+  uuid: 0ccd60b6-ee68-4cbf-b51e-c27a2a04ed8b
+  subjects:
+  - entities:
+    - role: player
+      name: Max Scherzer
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '570'
+  uuid: defd9f13-7683-439b-a0b8-9a66600c31a3
+  subjects:
+  - entities:
+    - role: player
+      name: Rolddy Muñoz
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: '578'
+  uuid: 465934c5-f3c9-4525-9bb9-794c55d291c8
+  subjects:
+  - entities:
+    - role: player
+      name: Heriberto Hernández
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: '585'
+  uuid: b3c1218a-f722-435d-ba36-47437c7342d1
+  subjects:
+  - entities:
+    - role: player
+      name: Ian Happ
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '586'
+  uuid: b1616c40-de18-4472-b854-1ae7100cd2c8
+  subjects:
+  - entities:
+    - role: player
+      name: Marcus Semien
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '594'
+  uuid: 33cc7a48-aff0-4aa4-8e25-a807fa1fbd0c
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Gil
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '597'
+  uuid: 3b348b15-254c-4490-b155-f9c0c9689ec0
+  subjects:
+  - entities:
+    - role: player
+      name: Paul Goldschmidt
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '598'
+  uuid: 64d05ff5-0310-411a-8f37-f4600b6e7996
+  subjects:
+  - entities:
+    - role: player
+      name: Jack Winkler
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '600'
+  uuid: de86020c-6fcb-47fe-8ca4-c443678acc79
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '601'
+  uuid: ba8215ed-27bf-47df-8ad4-02e02bc50c01
+  subjects:
+  - entities:
+    - role: player
+      name: Zach Cole
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '603'
+  uuid: cce33c36-9127-4359-b4e0-307258102947
+  subjects:
+  - entities:
+    - role: player
+      name: George Valera
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '607'
+  uuid: 8812959c-534b-4591-8ca8-7a0a95ab225c
+  subjects:
+  - entities:
+    - role: player
+      name: Cody Bellinger
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '611'
+  uuid: b9644a40-206f-4703-bef3-5cdd5abb332e
+  subjects:
+  - entities:
+    - role: player
+      name: Paul Gervase
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '613'
+  uuid: 1d52f0c5-25f0-45d7-aa48-654c7063a65a
+  subjects:
+  - entities:
+    - role: player
+      name: Jordan Westburg
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '614'
+  uuid: 41501e36-66d6-45cb-9727-3083096a792e
+  subjects:
+  - entities:
+    - role: player
+      name: Manny Machado
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: '618'
+  uuid: 158dbc80-7a57-4d7c-96c4-f60c7cd0684b
+  subjects:
+  - entities:
+    - role: player
+      name: Tanner Bibee
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '620'
+  uuid: 3377f6ba-2053-4c7b-9da2-e3acf9d0b540
+  subjects:
+  - entities:
+    - role: player
+      name: Trey Yesavage
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '623'
+  uuid: daeac05a-8665-4716-b97f-160f80faa473
+  subjects:
+  - entities:
+    - role: player
+      name: Rafael Flores
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '629'
+  uuid: 95239e93-5b98-46bf-9c00-a83db5c83acb
+  subjects:
+  - entities:
+    - role: player
+      name: Tyler Glasnow
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '631'
+  uuid: eb7ff0f5-a4d6-471f-86ee-df022d7774a7
+  subjects:
+  - entities:
+    - role: player
+      name: Will Smith
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '632'
+  uuid: 0ce0a4d1-3459-4587-9dd6-e4598afa300a
+  subjects:
+  - entities:
+    - role: player
+      name: Cade Horton
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '633'
+  uuid: 0c248c7a-27eb-4ede-8e5f-e363a279e9da
+  subjects:
+  - entities:
+    - role: player
+      name: Salvador Perez
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: '643'
+  uuid: 8e657cd1-cf9c-4528-821a-6456e49a7e81
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Lodolo
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '646'
+  uuid: ab5c38a4-b5df-487d-8c55-2908438bde86
+  subjects:
+  - entities:
+    - role: player
+      name: Mark Vientos
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '650'
+  uuid: 49f4d98f-c0be-4746-aabc-7055dcdfc02f
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Schwarber
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: '656'
+  uuid: 22070663-baf0-4867-a419-e64fa6cba3c1
+  subjects:
+  - entities:
+    - role: player
+      name: Aroldis Chapman
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '658'
+  uuid: ce236b5e-e394-4f46-9c27-289ba89a89fb
+  subjects:
+  - entities:
+    - role: player
+      name: Jack Flaherty
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '659'
+  uuid: 7ce09a6f-14f5-482a-9ba4-4c77ea72561d
+  subjects:
+  - entities:
+    - role: player
+      name: Harry Ford
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: '665'
+  uuid: 6a95d689-aced-4bd6-b7c3-184dad820b0d
+  subjects:
+  - entities:
+    - role: player
+      name: Jose Corniell
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: '667'
+  uuid: 2a55b4f4-31ec-4022-b827-265a4f8ae160
+  subjects:
+  - entities:
+    - role: player
+      name: Kodai Senga
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '668'
+  uuid: 91b6001a-59ed-4070-a91a-f1043d31457d
+  subjects:
+  - entities:
+    - role: player
+      name: Petey Halpin
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '674'
+  uuid: a077cda9-21a4-43cf-af54-e84e1fb826ee
+  subjects:
+  - entities:
+    - role: player
+      name: Andre Granillo
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: '675'
+  uuid: 8ba682af-c961-4a2b-ad57-40c70a560a51
+  subjects:
+  - entities:
+    - role: player
+      name: Steven Kwan
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '677'
+  uuid: 792e6510-7aed-496a-bd47-5a72926809fb
+  subjects:
+  - entities:
+    - role: player
+      name: Wilyer Abreu
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '680'
+  uuid: a0e6277f-af99-426d-850c-4c111dc64c13
+  subjects:
+  - entities:
+    - role: player
+      name: Carlos Correa
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '685'
+  uuid: 4a7fa7db-b04e-4127-8d72-84d558991236
+  subjects:
+  - entities:
+    - role: player
+      name: Seiya Suzuki
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '692'
+  uuid: 739603b9-82ff-42e5-b748-48ef508673ba
+  subjects:
+  - entities:
+    - role: player
+      name: Drake Baldwin
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: '697'
+  uuid: 541d467f-4e2c-49d8-96b0-6da6f1b7e71a
+  subjects:
+  - entities:
+    - role: player
+      name: Bryan Reynolds
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '700'
+  uuid: daada4e9-4296-4422-afb9-efe88cd0d649
+  subjects:
+  - entities:
+    - role: player
+      name: Freddie Freeman
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 

--- a/data/baseball/2026-topps-series-2/checklists/world-champion-autographs.yaml
+++ b/data/baseball/2026-topps-series-2/checklists/world-champion-autographs.yaml
@@ -1,0 +1,140 @@
+- number: WCA-AP
+  uuid: f0c59300-1993-4abf-b7de-d0a4abba3bcb
+  subjects:
+  - entities:
+    - role: player
+      name: Andy Pages
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: WCA-BS
+  uuid: 9a281e5b-59a4-40f6-808a-5f0bc59de98a
+  subjects:
+  - entities:
+    - role: player
+      name: Blake Snell
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: WCA-CK
+  uuid: 0b3bf25b-a5a3-45d2-9676-f864125cbefd
+  subjects:
+  - entities:
+    - role: player
+      name: Clayton Kershaw
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: WCA-DRY
+  uuid: b3528490-50ba-4048-8965-bbfd37fcbff9
+  subjects:
+  - entities:
+    - role: player
+      name: Jack Dreyer
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: WCA-EDG
+  uuid: 4f4c86f8-0e32-4e84-9c90-2de8192de99f
+  subjects:
+  - entities:
+    - role: player
+      name: Edgardo Henriquez
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: WCA-FF
+  uuid: bcb2efba-6612-4c8f-87c4-113df20d577e
+  subjects:
+  - entities:
+    - role: player
+      name: Freddie Freeman
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: WCA-HYE
+  uuid: 03d51845-b500-4c81-892a-9064a5d14245
+  subjects:
+  - entities:
+    - role: player
+      name: Hyeseong Kim
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: WCA-JD
+  uuid: 8f60fd0c-dcff-4292-bb31-724083b05a87
+  subjects:
+  - entities:
+    - role: player
+      name: Justin Dean
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: WCA-RS
+  uuid: 8dc0f56f-d88c-4c99-99d4-73076749767e
+  subjects:
+  - entities:
+    - role: player
+      name: Roki Sasaki
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: WCA-SO
+  uuid: 6b6c5de0-5de6-463c-9f4b-52707e1fcab3
+  subjects:
+  - entities:
+    - role: player
+      name: Shohei Ohtani
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: WCA-TE
+  uuid: 9892bc0b-69cb-4bb9-b8d7-58c3de404e6e
+  subjects:
+  - entities:
+    - role: player
+      name: Tommy Edman
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: WCA-WK
+  uuid: f11fcecc-f5df-4830-bd83-0f35736f9230
+  subjects:
+  - entities:
+    - role: player
+      name: Will Klein
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: WCA-WS
+  uuid: 902d78ce-3a28-4fc2-99cb-36753ae53d1c
+  subjects:
+  - entities:
+    - role: player
+      name: Will Smith
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: WCA-YY
+  uuid: 1edd6360-ae94-4812-b8aa-7a6d3078d17c
+  subjects:
+  - entities:
+    - role: player
+      name: Yoshinobu Yamamoto
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 

--- a/data/baseball/2026-topps-series-2/manifest.yaml
+++ b/data/baseball/2026-topps-series-2/manifest.yaml
@@ -145,6 +145,12 @@ base_sets:
     print_run: 399
     serial_numbered: true
   subsets:
+  - id: apple-foil-variations
+    name: Apple Foil Variations
+    uuid: 280ef4ca-a8fd-56f6-8f82-78b483a7af1b
+    type:
+    - variation
+    declared_card_count: 100
   - id: base-1952-variations
     name: Base - 1952 Variations
     uuid: 740eafbd-3f9c-544e-a08a-3e212a694896
@@ -163,6 +169,48 @@ base_sets:
     type:
     - insert
     declared_card_count: 4
+  - id: clear-variation
+    name: Clear Variation
+    uuid: d7802df4-19b0-5bfb-a368-000fa9190b8d
+    type:
+    - variation
+    declared_card_count: 100
+  - id: golden-mirror-variations
+    name: Golden Mirror Variations
+    uuid: d313671e-23a2-593b-a4ed-f2167ef2af42
+    type:
+    - variation
+    declared_card_count: 350
+  - id: holiday-variations
+    name: Holiday Variations
+    uuid: e1df895e-424c-5a2f-a985-7ac27e44f9a5
+    type:
+    - variation
+    declared_card_count: 100
+  - id: player-number-variations
+    name: Player Number Variations
+    uuid: cbca95ae-83c3-589f-adca-99306f28dc73
+    type:
+    - variation
+    declared_card_count: 25
+  - id: team-color-border-variations
+    name: Team Color Border Variations
+    uuid: 661bad15-cb1d-51cf-b64d-02a866a42e36
+    type:
+    - variation
+    declared_card_count: 100
+  - id: true-photo-variations
+    name: True Photo Variations
+    uuid: 43280dbd-dfb0-5732-8f27-43eb85a02b8b
+    type:
+    - variation
+    declared_card_count: 100
+  - id: vintage-stock-variations
+    name: Vintage Stock Variations
+    uuid: 9e0b1537-3238-513d-96b7-69114c555b2c
+    type:
+    - variation
+    declared_card_count: 100
 subsets:
 - id: 1952-rookie-variation-autographs
   name: 1952 Rookie Variation Autographs
@@ -344,13 +392,6 @@ subsets:
   - name: Relics Red
     print_run: 5
     serial_numbered: true
-  subsets:
-  - id: 1991-topps-baseball-autographs
-    name: 1991 Topps Baseball Autographs
-    uuid: c87032ed-4290-5f23-82f0-98c6873ec0ec
-    type:
-    - autograph
-    declared_card_count: 90
 - id: 1991-topps-baseball-all-star-autographs
   name: 1991 Topps Baseball All-Star Autographs
   uuid: '0518a403-f479-593a-91e8-1309bc1c872d'
@@ -363,32 +404,36 @@ subsets:
   type:
   - relic
   declared_card_count: 50
+- id: 1991-topps-baseball-autographs
+  name: 1991 Topps Baseball Autographs
+  uuid: c87032ed-4290-5f23-82f0-98c6873ec0ec
+  type:
+  - autograph
+  declared_card_count: 90
 - id: 1991-topps-baseball-chrome
   name: 1991 Topps Baseball Chrome
   uuid: e1c5517f-46f8-5e4f-8a82-6f19c0ccc133
   type:
   - insert
   declared_card_count: 50
-  subsets:
-  - id: 1991-topps-baseball-chrome-autographs
-    name: 1991 Topps Baseball Chrome Autographs
-    uuid: 4a5896fb-0cf7-5750-b1a0-f707005c34af
-    type:
-    - autograph
-    declared_card_count: 44
+- id: 1991-topps-baseball-chrome-all-star-autographs
+  name: 1991 Topps Baseball Chrome All-Star Autographs
+  uuid: 2d069dcd-9110-593e-9fb9-4e7ac2b758b9
+  type:
+  - autograph
+  declared_card_count: 43
 - id: 1991-topps-baseball-chrome-all-stars
   name: 1991 Topps Baseball Chrome All-Stars
   uuid: a2317b62-6861-59cf-a534-89f1eeed7c57
   type:
   - insert
   declared_card_count: 50
-  subsets:
-  - id: 1991-topps-baseball-chrome-all-star-autographs
-    name: 1991 Topps Baseball Chrome All-Star Autographs
-    uuid: 2d069dcd-9110-593e-9fb9-4e7ac2b758b9
-    type:
-    - autograph
-    declared_card_count: 43
+- id: 1991-topps-baseball-chrome-autographs
+  name: 1991 Topps Baseball Chrome Autographs
+  uuid: 4a5896fb-0cf7-5750-b1a0-f707005c34af
+  type:
+  - autograph
+  declared_card_count: 44
 - id: 1991-topps-baseball-relics
   name: 1991 Topps Baseball Relics
   uuid: f104cc8a-f979-500c-b952-04b0264b029e
@@ -421,12 +466,6 @@ subsets:
   - name: Gold
     print_run: 1
     serial_numbered: true
-- id: apple-foil-variations
-  name: Apple Foil Variations
-  uuid: 280ef4ca-a8fd-56f6-8f82-78b483a7af1b
-  type:
-  - variation
-  declared_card_count: 100
 - id: baseball-stars-autographs
   name: Baseball Stars Autographs
   uuid: 0f7ee745-4fdc-5b5a-b09e-8428814b044e
@@ -511,12 +550,6 @@ subsets:
   - autograph
   - relic
   declared_card_count: 56
-- id: clear-variation
-  name: Clear Variation
-  uuid: d7802df4-19b0-5bfb-a368-000fa9190b8d
-  type:
-  - variation
-  declared_card_count: 100
 - id: cover-athletes
   name: Cover Athletes
   uuid: 702c31f5-ad1d-50da-9436-13c4bf4036b7
@@ -631,12 +664,6 @@ subsets:
   type:
   - variation
   declared_card_count: 50
-- id: golden-mirror-variations
-  name: Golden Mirror Variations
-  uuid: d313671e-23a2-593b-a4ed-f2167ef2af42
-  type:
-  - variation
-  declared_card_count: 350
 - id: heavy-lumber
   name: Heavy Lumber
   uuid: be181310-ee5d-5bd8-bbac-f80236fafa03
@@ -666,12 +693,6 @@ subsets:
     type:
     - autograph
     declared_card_count: 5
-- id: holiday-variations
-  name: Holiday Variations
-  uuid: e1df895e-424c-5a2f-a985-7ac27e44f9a5
-  type:
-  - variation
-  declared_card_count: 100
 - id: home-field
   name: Home Field
   uuid: 3b38dfbf-d15c-5b02-abdd-31d3cc6d81be
@@ -778,12 +799,6 @@ subsets:
   type:
   - insert
   declared_card_count: 16
-- id: player-number-variations
-  name: Player Number Variations
-  uuid: cbca95ae-83c3-589f-adca-99306f28dc73
-  type:
-  - variation
-  declared_card_count: 25
 - id: postseason-performance-autographs
   name: Postseason Performance Autographs
   uuid: '00419d4f-9f52-5e7c-8675-22ab783af578'
@@ -888,12 +903,6 @@ subsets:
   - name: Chrome SuperFractor
     print_run: 1
     serial_numbered: true
-- id: team-color-border-variations
-  name: Team Color Border Variations
-  uuid: 661bad15-cb1d-51cf-b64d-02a866a42e36
-  type:
-  - variation
-  declared_card_count: 100
 - id: the-flagship-collection
   name: The Flagship Collection
   uuid: 5578b5fa-159f-5dba-9b23-35c7c0597641
@@ -964,18 +973,6 @@ subsets:
   - autograph
   - relic
   declared_card_count: 51
-- id: true-photo-variations
-  name: True Photo Variations
-  uuid: 43280dbd-dfb0-5732-8f27-43eb85a02b8b
-  type:
-  - variation
-  declared_card_count: 100
-- id: vintage-stock-variations
-  name: Vintage Stock Variations
-  uuid: 9e0b1537-3238-513d-96b7-69114c555b2c
-  type:
-  - variation
-  declared_card_count: 100
 - id: world-champion-autographs
   name: World Champion Autographs
   uuid: 745948b1-1b45-56e8-bb73-723541525e39

--- a/data/baseball/2026-topps-series-2/manifest.yaml
+++ b/data/baseball/2026-topps-series-2/manifest.yaml
@@ -828,7 +828,7 @@ subsets:
   name: Signature Tunes Dual Aurographs
   uuid: d80a0790-bb78-51d2-b00d-2513a3ff87e4
   type:
-  - insert
+  - autograph
   declared_card_count: 2
 - id: stars-of-mlb
   name: Stars Of MLB

--- a/data/baseball/2026-topps-series-2/manifest.yaml
+++ b/data/baseball/2026-topps-series-2/manifest.yaml
@@ -1,0 +1,984 @@
+set_id: 2026-topps-series-2
+base_sets:
+- id: base
+  name: Base
+  uuid: 55e1e02f-eebf-55ca-b7ee-841ee4ef4ae1
+  declared_card_count: 350
+  parallels:
+  - name: 75 Years Of Topps
+    print_run: 75
+    serial_numbered: true
+  - name: All-Star Game
+  - name: All-Star Game Black
+    print_run: 10
+    serial_numbered: true
+  - name: All-Star Game Gold
+    print_run: 50
+    serial_numbered: true
+  - name: All-Star Game Green
+    print_run: 99
+    serial_numbered: true
+  - name: All-Star Game Orange
+    print_run: 25
+    serial_numbered: true
+  - name: All-Star Game Platinum
+    print_run: 1
+    serial_numbered: true
+  - name: All-Star Game Red
+    print_run: 5
+    serial_numbered: true
+  - name: Aqua Holo
+  - name: Aqua Rainbow Foil
+  - name: Black
+    print_run: 75
+    serial_numbered: true
+  - name: Black Diamante Foil
+    print_run: 10
+    serial_numbered: true
+  - name: Black Holo Foil
+    print_run: 10
+    serial_numbered: true
+  - name: Black Rainbow Foil
+    print_run: 10
+    serial_numbered: true
+  - name: Blue Holo Foil
+    print_run: 150
+    serial_numbered: true
+  - name: Blue Rainbow Foil
+    print_run: 150
+    serial_numbered: true
+  - name: Canvas
+    print_run: 50
+    serial_numbered: true
+  - name: Cherry Blossom
+    print_run: 99
+    serial_numbered: true
+  - name: Diamante Foil
+  - name: FoilFractor
+    print_run: 1
+    serial_numbered: true
+  - name: Gold
+    print_run: 2026
+    serial_numbered: true
+  - name: Gold Diamante Foil
+    print_run: 50
+    serial_numbered: true
+  - name: Gold Holo Foil
+    print_run: 50
+    serial_numbered: true
+  - name: Gold Rainbow Foil
+    print_run: 50
+    serial_numbered: true
+  - name: Green Diamante Foil
+    print_run: 99
+    serial_numbered: true
+  - name: Green Holo Foil
+    print_run: 99
+    serial_numbered: true
+  - name: Green Rainbow Foil
+    print_run: 99
+    serial_numbered: true
+  - name: Holo Foil
+  - name: Independence Day
+    print_run: 76
+    serial_numbered: true
+  - name: Memorial Day Camo
+    print_run: 25
+    serial_numbered: true
+  - name: Orange Diamante Foil
+    print_run: 25
+    serial_numbered: true
+  - name: Orange Holo Foil
+    print_run: 25
+    serial_numbered: true
+  - name: Orange Rainbow Foil
+    print_run: 25
+    serial_numbered: true
+  - name: Pink Diamante Foil
+  - name: Pink Holo
+    print_run: 800
+    serial_numbered: true
+  - name: Printing Plates
+    print_run: 4
+    serial_numbered: true
+  - name: Purple Holo Foil
+    print_run: 250
+    serial_numbered: true
+  - name: Purple Rainbow Foil
+    print_run: 250
+    serial_numbered: true
+  - name: Rainbow Foil
+  - name: Red Diamante Foil
+    print_run: 5
+    serial_numbered: true
+  - name: Red Holo Foil
+    print_run: 5
+    serial_numbered: true
+  - name: Red Rainbow Foil
+    print_run: 5
+    serial_numbered: true
+  - name: Rose Gold Holo Foil
+    print_run: 1
+    serial_numbered: true
+  - name: Sandglitter
+  - name: Sandglitter Black
+    print_run: 10
+    serial_numbered: true
+  - name: Sandglitter Gold
+    print_run: 50
+    serial_numbered: true
+  - name: Sandglitter Orange
+    print_run: 25
+    serial_numbered: true
+  - name: Sandglitter Red
+    print_run: 5
+    serial_numbered: true
+  - name: Silver Crackle Foil Board
+  - name: Topps Logo
+  - name: Wood
+    print_run: 25
+    serial_numbered: true
+  - name: Yellow Holo Foil
+    print_run: 399
+    serial_numbered: true
+  - name: Yellow Rainbow Foil
+    print_run: 399
+    serial_numbered: true
+  subsets:
+  - id: base-1952-variations
+    name: Base - 1952 Variations
+    uuid: 740eafbd-3f9c-544e-a08a-3e212a694896
+    type:
+    - variation
+    declared_card_count: 20
+  - id: base-funko-pop-cards
+    name: Base - Funko Pop Cards
+    uuid: '0409bfa2-e9ca-5f06-a09e-f32d456f48f8'
+    type:
+    - insert
+    declared_card_count: 5
+  - id: base-short-print-rookie-cards
+    name: Base - Short Print Rookie Cards
+    uuid: aff81f8f-9630-5d79-9d5a-3fea33898602
+    type:
+    - insert
+    declared_card_count: 4
+subsets:
+- id: 1952-rookie-variation-autographs
+  name: 1952 Rookie Variation Autographs
+  uuid: be146d45-27a3-5d08-81e8-f2c13a05fd17
+  type:
+  - autograph
+  - variation
+  declared_card_count: 19
+- id: 1991-topps-all-stars
+  name: 1991 Topps All-Stars
+  uuid: ee0380b6-7163-5c02-b173-202670e80c48
+  type:
+  - insert
+  declared_card_count: 50
+- id: 1991-topps-baseball
+  name: 1991 Topps Baseball
+  uuid: 9847c253-6521-5ed9-886c-82ab4efacca5
+  type:
+  - insert
+  declared_card_count: 50
+  parallels:
+  - name: '"The Real One"'
+    print_run: 91
+    serial_numbered: true
+  - name: All-Star Autograph
+  - name: All-Star Autograph Black
+    print_run: 10
+    serial_numbered: true
+  - name: All-Star Autograph Blue
+    print_run: 150
+    serial_numbered: true
+  - name: All-Star Autograph FoilFractor
+    print_run: 1
+    serial_numbered: true
+  - name: All-Star Autograph Gold
+    print_run: 50
+    serial_numbered: true
+  - name: All-Star Autograph Green
+    print_run: 99
+    serial_numbered: true
+  - name: All-Star Autograph Orange
+    print_run: 25
+    serial_numbered: true
+  - name: All-Star Autograph Red
+    print_run: 5
+    serial_numbered: true
+  - name: All-Star Game Black Parallel
+    print_run: 10
+    serial_numbered: true
+  - name: All-Star Game Gold Parallel
+    print_run: 50
+    serial_numbered: true
+  - name: All-Star Game Orange Parallel
+    print_run: 25
+    serial_numbered: true
+  - name: All-Star Game Parallel
+  - name: All-Star Game Platinum Parallel
+    print_run: 1
+    serial_numbered: true
+  - name: All-Star Game Red Parallel
+    print_run: 5
+    serial_numbered: true
+  - name: All-Star Relics
+  - name: All-Star Relics Black
+    print_run: 10
+    serial_numbered: true
+  - name: All-Star Relics Blue
+    print_run: 150
+    serial_numbered: true
+  - name: All-Star Relics Gold
+    print_run: 50
+    serial_numbered: true
+  - name: All-Star Relics Green
+    print_run: 99
+    serial_numbered: true
+  - name: All-Star Relics Orange
+    print_run: 25
+    serial_numbered: true
+  - name: All-Star Relics Platinum
+    print_run: 1
+    serial_numbered: true
+  - name: All-Star Relics Red
+    print_run: 5
+    serial_numbered: true
+  - name: Autograph Black
+    print_run: 10
+    serial_numbered: true
+  - name: Autograph Blue
+    print_run: 150
+    serial_numbered: true
+  - name: Autograph FoilFractor
+    print_run: 1
+    serial_numbered: true
+  - name: Autograph Gold
+    print_run: 50
+    serial_numbered: true
+  - name: Autograph Green
+    print_run: 99
+    serial_numbered: true
+  - name: Autograph Orange
+    print_run: 25
+    serial_numbered: true
+  - name: Autograph Red
+    print_run: 5
+    serial_numbered: true
+  - name: Black
+    print_run: 10
+    serial_numbered: true
+  - name: Black Crackle Foil
+    print_run: 10
+    serial_numbered: true
+  - name: Blue
+    print_run: 150
+    serial_numbered: true
+  - name: Blue Crackle Foil
+    print_run: 150
+    serial_numbered: true
+  - name: Crackle Foil
+  - name: FoilFractor
+    print_run: 1
+    serial_numbered: true
+  - name: Gold
+    print_run: 50
+    serial_numbered: true
+  - name: Gold Crackle Foil
+    print_run: 50
+    serial_numbered: true
+  - name: Green
+    print_run: 99
+    serial_numbered: true
+  - name: Green Crackle Foil
+    print_run: 99
+    serial_numbered: true
+  - name: Koi Fish
+  - name: Koi Fish Black
+    print_run: 10
+    serial_numbered: true
+  - name: Koi Fish Gold
+    print_run: 50
+    serial_numbered: true
+  - name: Koi Fish Orange
+    print_run: 25
+    serial_numbered: true
+  - name: Koi Fish Red
+    print_run: 5
+    serial_numbered: true
+  - name: Orange
+    print_run: 25
+    serial_numbered: true
+  - name: "Orange Crackle\tFoil"
+    print_run: 25
+    serial_numbered: true
+  - name: Pink
+  - name: Pink Crackle Foil
+  - name: Red
+    print_run: 5
+    serial_numbered: true
+  - name: Red Crackle Foil
+    print_run: 5
+    serial_numbered: true
+  - name: Relics Black
+    print_run: 10
+    serial_numbered: true
+  - name: Relics Blue
+    print_run: 150
+    serial_numbered: true
+  - name: Relics Gold
+    print_run: 50
+    serial_numbered: true
+  - name: Relics Green
+    print_run: 99
+    serial_numbered: true
+  - name: Relics Orange
+    print_run: 25
+    serial_numbered: true
+  - name: Relics Platinum
+    print_run: 1
+    serial_numbered: true
+  - name: Relics Red
+    print_run: 5
+    serial_numbered: true
+  subsets:
+  - id: 1991-topps-baseball-autographs
+    name: 1991 Topps Baseball Autographs
+    uuid: c87032ed-4290-5f23-82f0-98c6873ec0ec
+    type:
+    - autograph
+    declared_card_count: 90
+- id: 1991-topps-baseball-all-star-autographs
+  name: 1991 Topps Baseball All-Star Autographs
+  uuid: '0518a403-f479-593a-91e8-1309bc1c872d'
+  type:
+  - autograph
+  declared_card_count: 71
+- id: 1991-topps-baseball-all-star-relics
+  name: 1991 Topps Baseball All-Star Relics
+  uuid: 1390a376-7e0f-530e-8619-8619b2a519c0
+  type:
+  - relic
+  declared_card_count: 50
+- id: 1991-topps-baseball-chrome
+  name: 1991 Topps Baseball Chrome
+  uuid: e1c5517f-46f8-5e4f-8a82-6f19c0ccc133
+  type:
+  - insert
+  declared_card_count: 50
+  subsets:
+  - id: 1991-topps-baseball-chrome-autographs
+    name: 1991 Topps Baseball Chrome Autographs
+    uuid: 4a5896fb-0cf7-5750-b1a0-f707005c34af
+    type:
+    - autograph
+    declared_card_count: 44
+- id: 1991-topps-baseball-chrome-all-stars
+  name: 1991 Topps Baseball Chrome All-Stars
+  uuid: a2317b62-6861-59cf-a534-89f1eeed7c57
+  type:
+  - insert
+  declared_card_count: 50
+  subsets:
+  - id: 1991-topps-baseball-chrome-all-star-autographs
+    name: 1991 Topps Baseball Chrome All-Star Autographs
+    uuid: 2d069dcd-9110-593e-9fb9-4e7ac2b758b9
+    type:
+    - autograph
+    declared_card_count: 43
+- id: 1991-topps-baseball-relics
+  name: 1991 Topps Baseball Relics
+  uuid: f104cc8a-f979-500c-b952-04b0264b029e
+  type:
+  - relic
+  declared_card_count: 50
+- id: 75-years-of-topps-die-cut-autographs
+  name: 75 Years Of Topps Die-Cut Autographs
+  uuid: eab0466f-85d7-5463-9add-2288ebe8f14f
+  type:
+  - autograph
+  declared_card_count: 11
+- id: all-aces
+  name: All Aces
+  uuid: afb40a92-5871-581c-a6bb-0252d60b3b86
+  type:
+  - insert
+  declared_card_count: 10
+  parallels:
+  - name: Gold
+    print_run: 1
+    serial_numbered: true
+- id: all-kings
+  name: All Kings
+  uuid: 91829fd2-c420-5007-9b80-0cb1f4e7f3a6
+  type:
+  - insert
+  declared_card_count: 15
+  parallels:
+  - name: Gold
+    print_run: 1
+    serial_numbered: true
+- id: apple-foil-variations
+  name: Apple Foil Variations
+  uuid: 280ef4ca-a8fd-56f6-8f82-78b483a7af1b
+  type:
+  - variation
+  declared_card_count: 100
+- id: baseball-stars-autographs
+  name: Baseball Stars Autographs
+  uuid: 0f7ee745-4fdc-5b5a-b09e-8428814b044e
+  type:
+  - autograph
+  declared_card_count: 92
+  parallels:
+  - name: Black
+    print_run: 10
+    serial_numbered: true
+  - name: Blue
+    print_run: 150
+    serial_numbered: true
+  - name: Gold
+    print_run: 50
+    serial_numbered: true
+  - name: Green
+    print_run: 99
+    serial_numbered: true
+  - name: Orange
+    print_run: 25
+    serial_numbered: true
+  - name: Platinum
+    print_run: 1
+    serial_numbered: true
+  - name: Red
+    print_run: 5
+    serial_numbered: true
+- id: bulk-order
+  name: Bulk Order
+  uuid: 96a733fb-f9e7-536d-989f-3ec08dff1038
+  type:
+  - insert
+  declared_card_count: 10
+- id: city-connect-swatch-collection
+  name: City Connect Swatch Collection
+  uuid: 0605a9b8-e1ff-5e93-92c7-c326d62e6db5
+  type:
+  - relic
+  declared_card_count: 50
+  parallels:
+  - name: Autograph Black
+    print_run: 10
+    serial_numbered: true
+  - name: Autograph Gold
+    print_run: 50
+    serial_numbered: true
+  - name: Autograph Orange
+    print_run: 25
+    serial_numbered: true
+  - name: Autograph Platinum
+    print_run: 1
+    serial_numbered: true
+  - name: Autograph Red
+    print_run: 5
+    serial_numbered: true
+  - name: Black
+    print_run: 10
+    serial_numbered: true
+  - name: Blue
+    print_run: 150
+    serial_numbered: true
+  - name: Gold
+    print_run: 50
+    serial_numbered: true
+  - name: Green
+    print_run: 99
+    serial_numbered: true
+  - name: Orange
+    print_run: 25
+    serial_numbered: true
+  - name: Platinum
+    print_run: 1
+    serial_numbered: true
+  - name: Red
+    print_run: 5
+    serial_numbered: true
+- id: city-connect-swatches-autographs
+  name: City Connect Swatches Autographs
+  uuid: 5d29e974-bdf8-5653-a73a-4d84a8fcd239
+  type:
+  - autograph
+  - relic
+  declared_card_count: 56
+- id: clear-variation
+  name: Clear Variation
+  uuid: d7802df4-19b0-5bfb-a368-000fa9190b8d
+  type:
+  - variation
+  declared_card_count: 100
+- id: cover-athletes
+  name: Cover Athletes
+  uuid: 702c31f5-ad1d-50da-9436-13c4bf4036b7
+  type:
+  - insert
+  declared_card_count: 10
+  subsets:
+  - id: cover-athlete-autographs
+    name: Cover Athlete Autographs
+    uuid: 9252205a-fe5b-59d9-be4a-466505451ab9
+    type:
+    - autograph
+    declared_card_count: 9
+- id: crooked-numbers
+  name: Crooked Numbers
+  uuid: 17141300-6c74-5017-a999-0c665aaaf1b4
+  type:
+  - insert
+  declared_card_count: 25
+  parallels:
+  - name: Black Foil
+    print_run: 10
+    serial_numbered: true
+  - name: Blue Foil
+    print_run: 150
+    serial_numbered: true
+  - name: FoilFractor
+    print_run: 1
+    serial_numbered: true
+  - name: Gold Foil
+    print_run: 50
+    serial_numbered: true
+  - name: Green Foil
+    print_run: 99
+    serial_numbered: true
+  - name: Orange Foil
+    print_run: 25
+    serial_numbered: true
+  - name: Pink Foil
+  - name: Red Foil
+    print_run: 5
+    serial_numbered: true
+- id: diamond-dust
+  name: Diamond Dust
+  uuid: 9eaef907-47f4-545d-90c6-96a66eb64ce5
+  type:
+  - insert
+  declared_card_count: 10
+- id: fanatics-authentics-redemptions
+  name: Fanatics Authentics Redemptions
+  uuid: 3149ba59-3172-5687-b744-f0b1920d8bc0
+  type:
+  - insert
+  declared_card_count: 30
+- id: first-pitch
+  name: First Pitch
+  uuid: 45f35ad0-6266-5714-a571-58eaf23c5bb4
+  type:
+  - insert
+  declared_card_count: 6
+  subsets:
+  - id: first-pitch-autographs
+    name: First Pitch Autographs
+    uuid: a0b8aecc-9e10-56dd-b4b4-badd33460f61
+    type:
+    - autograph
+    declared_card_count: 6
+- id: flagship-real-one-autographs
+  name: Flagship Real One Autographs
+  uuid: da755b1b-9f9c-54e8-a449-bc33c7d17c38
+  type:
+  - autograph
+  declared_card_count: 66
+- id: funko-pops
+  name: Funko Pops
+  uuid: f10f6ab7-f92a-51b1-b26b-8e1c839869ed
+  type:
+  - insert
+  declared_card_count: 5
+- id: glove-work
+  name: Glove Work
+  uuid: '009231c5-58e4-55c0-9692-1e5f3e3bacbf'
+  type:
+  - insert
+  declared_card_count: 65
+  parallels:
+  - name: Black Foil
+    print_run: 10
+    serial_numbered: true
+  - name: Blue Foil
+    print_run: 150
+    serial_numbered: true
+  - name: FoilFractor
+    print_run: 1
+    serial_numbered: true
+  - name: Gold Foil
+    print_run: 50
+    serial_numbered: true
+  - name: Green Foil
+    print_run: 99
+    serial_numbered: true
+  - name: Orange Foil
+    print_run: 25
+    serial_numbered: true
+  - name: Pink Foil
+  - name: Red Foil
+    print_run: 5
+    serial_numbered: true
+- id: golden-mirror-legend-variations
+  name: Golden Mirror Legend Variations
+  uuid: f801de1e-3649-5ff4-99ef-205990b0e404
+  type:
+  - variation
+  declared_card_count: 50
+- id: golden-mirror-variations
+  name: Golden Mirror Variations
+  uuid: d313671e-23a2-593b-a4ed-f2167ef2af42
+  type:
+  - variation
+  declared_card_count: 350
+- id: heavy-lumber
+  name: Heavy Lumber
+  uuid: be181310-ee5d-5bd8-bbac-f80236fafa03
+  type:
+  - insert
+  declared_card_count: 25
+  parallels:
+  - name: Autograph Relics
+  subsets:
+  - id: heavy-lumber-autograph-relics
+    name: Heavy Lumber Autograph Relics
+    uuid: ba703893-3960-578a-aac5-9e0cb5696ce5
+    type:
+    - autograph
+    - relic
+    declared_card_count: 43
+- id: highlight-reels
+  name: Highlight Reels
+  uuid: 4075f8fc-4918-5986-b134-4c70cdef2e42
+  type:
+  - insert
+  declared_card_count: 10
+  subsets:
+  - id: highlight-reels-autographs
+    name: Highlight Reels Autographs
+    uuid: 4dbb15b8-c90d-596f-a275-8e46dce05a84
+    type:
+    - autograph
+    declared_card_count: 5
+- id: holiday-variations
+  name: Holiday Variations
+  uuid: e1df895e-424c-5a2f-a985-7ac27e44f9a5
+  type:
+  - variation
+  declared_card_count: 100
+- id: home-field
+  name: Home Field
+  uuid: 3b38dfbf-d15c-5b02-abdd-31d3cc6d81be
+  type:
+  - insert
+  declared_card_count: 20
+- id: home-field-fanfest
+  name: Home Field FanFest
+  uuid: acf9a0dc-2cae-5c4c-8892-c51ea8def96e
+  type:
+  - insert
+  declared_card_count: 1
+- id: iconic-topps-buyback-cards
+  name: Iconic Topps Buyback Cards
+  uuid: 6c9ce4a2-d1c7-54d4-b663-19e055648498
+  type:
+  - insert
+  declared_card_count: 19
+- id: in-the-name-relics
+  name: In The Name Relics
+  uuid: 101d2baf-9806-53ac-b2e2-a511f274df31
+  type:
+  - relic
+  declared_card_count: 91
+- id: major-league-material
+  name: Major League Material
+  uuid: 4f6629a6-2601-51cd-a9b0-c1354e585c6e
+  type:
+  - relic
+  declared_card_count: 98
+  parallels:
+  - name: Autograph Black
+    print_run: 10
+    serial_numbered: true
+  - name: Autograph Gold
+    print_run: 50
+    serial_numbered: true
+  - name: Autograph Orange
+    print_run: 25
+    serial_numbered: true
+  - name: Autograph Platinum
+    print_run: 1
+    serial_numbered: true
+  - name: Autograph Red
+    print_run: 5
+    serial_numbered: true
+  - name: Black
+    print_run: 10
+    serial_numbered: true
+  - name: Blue
+    print_run: 150
+    serial_numbered: true
+  - name: Dual Autograph
+  - name: Dual Autograph Black
+    print_run: 10
+    serial_numbered: true
+  - name: Dual Autograph Orange
+    print_run: 25
+    serial_numbered: true
+  - name: Dual Autograph Platinum
+    print_run: 1
+    serial_numbered: true
+  - name: Dual Autograph Red
+    print_run: 5
+    serial_numbered: true
+  - name: Gold
+    print_run: 50
+    serial_numbered: true
+  - name: Green
+    print_run: 99
+    serial_numbered: true
+  - name: Orange
+    print_run: 25
+    serial_numbered: true
+  - name: Platinum
+    print_run: 1
+    serial_numbered: true
+  - name: Red
+    print_run: 5
+    serial_numbered: true
+- id: major-league-materials-autographs
+  name: Major League Materials Autographs
+  uuid: 932147a7-5abf-56f6-906b-4088c4dc0b29
+  type:
+  - autograph
+  - relic
+  declared_card_count: 65
+- id: major-legaue-materials-dual-autographs
+  name: Major Legaue Materials Dual Autographs
+  uuid: dd02530b-6af3-53ec-bf48-6de3957f33ea
+  type:
+  - autograph
+  - relic
+  declared_card_count: 4
+- id: oversized-1991-topps-baseball
+  name: Oversized 1991 Topps Baseball
+  uuid: b8aa5dfa-eb1b-54ab-935c-2d5396be9771
+  type:
+  - insert
+  declared_card_count: 16
+- id: oversized-2026-topps-baseball
+  name: Oversized 2026 Topps Baseball
+  uuid: 0b05fc69-d03f-57f1-a05a-1cdadf7c9422
+  type:
+  - insert
+  declared_card_count: 16
+- id: player-number-variations
+  name: Player Number Variations
+  uuid: cbca95ae-83c3-589f-adca-99306f28dc73
+  type:
+  - variation
+  declared_card_count: 25
+- id: postseason-performance-autographs
+  name: Postseason Performance Autographs
+  uuid: '00419d4f-9f52-5e7c-8675-22ab783af578'
+  type:
+  - autograph
+  declared_card_count: 33
+- id: real-one-relics
+  name: Real One Relics
+  uuid: 5a0644ad-ab45-5bf5-9b53-3a7584067821
+  type:
+  - relic
+  declared_card_count: 45
+  parallels:
+  - name: Black Foil
+    print_run: 10
+    serial_numbered: true
+  - name: FoilFractor
+    print_run: 1
+    serial_numbered: true
+  - name: Gold Foil
+    print_run: 50
+    serial_numbered: true
+  - name: Orange Foil
+    print_run: 25
+    serial_numbered: true
+  - name: Red Foil
+    print_run: 5
+    serial_numbered: true
+- id: rounding-the-bases-autographs
+  name: Rounding The Bases Autographs
+  uuid: c9ff9e7f-ce16-5fb2-a845-7d99e0d3a382
+  type:
+  - autograph
+  declared_card_count: 61
+- id: rounding-the-bases-relics
+  name: Rounding The Bases Relics
+  uuid: a4e70e61-1e9b-537d-bbd8-e62decbb56c9
+  type:
+  - relic
+  declared_card_count: 79
+- id: signature-tunes-dual-aurographs
+  name: Signature Tunes Dual Aurographs
+  uuid: d80a0790-bb78-51d2-b00d-2513a3ff87e4
+  type:
+  - insert
+  declared_card_count: 2
+- id: stars-of-mlb
+  name: Stars Of MLB
+  uuid: 222b63a8-7161-5ee2-86f3-344670b922de
+  type:
+  - insert
+  declared_card_count: 30
+  parallels:
+  - name: "Black Crackle\tFoil"
+    print_run: 10
+    serial_numbered: true
+  - name: Black Foil
+    print_run: 10
+    serial_numbered: true
+  - name: Crackle Foil
+  - name: FoilFractor
+    print_run: 1
+    serial_numbered: true
+  - name: Gold Crackle Foil
+    print_run: 50
+    serial_numbered: true
+  - name: Gold Foil
+    print_run: 50
+    serial_numbered: true
+  - name: Green Foil
+    print_run: 99
+    serial_numbered: true
+  - name: Orange Crackle Foil
+    print_run: 25
+    serial_numbered: true
+  - name: Orange Foil
+    print_run: 25
+    serial_numbered: true
+  - name: Red Crackle Foil
+    print_run: 5
+    serial_numbered: true
+  - name: Red Foil
+    print_run: 5
+    serial_numbered: true
+- id: swinging-with-the-stars
+  name: Swinging With The Stars
+  uuid: 55bbb2fe-9746-5297-b62d-094ab60bbbfe
+  type:
+  - insert
+  declared_card_count: 25
+  parallels:
+  - name: Chrome
+  - name: Chrome Black Refractor
+    print_run: 10
+    serial_numbered: true
+  - name: Chrome Orange Refractor
+    print_run: 25
+    serial_numbered: true
+  - name: Chrome Red Refractor
+    print_run: 5
+    serial_numbered: true
+  - name: Chrome SuperFractor
+    print_run: 1
+    serial_numbered: true
+- id: team-color-border-variations
+  name: Team Color Border Variations
+  uuid: 661bad15-cb1d-51cf-b64d-02a866a42e36
+  type:
+  - variation
+  declared_card_count: 100
+- id: the-flagship-collection
+  name: The Flagship Collection
+  uuid: 5578b5fa-159f-5dba-9b23-35c7c0597641
+  type:
+  - insert
+  declared_card_count: 90
+- id: the-flagship-collection-chrome
+  name: The Flagship Collection - Chrome
+  uuid: baee6950-7ef0-5b8b-8038-ac11373ce38d
+  type:
+  - insert
+  declared_card_count: 90
+  subsets:
+  - id: the-flagship-collection-chrome-autographs
+    name: The Flagship Collection - Chrome Autographs
+    uuid: b76e9c0c-d2db-52dd-ad64-5417a2920c9f
+    type:
+    - autograph
+    declared_card_count: 63
+- id: through-the-years-golden-mirror-rookie-cards
+  name: Through The Years Golden Mirror Rookie Cards
+  uuid: 06ee07b9-af97-54fa-8971-53ae36a6a06e
+  type:
+  - insert
+  declared_card_count: 5
+- id: titans-of-the-game
+  name: Titans Of The Game
+  uuid: 65d8467c-d4c9-5838-9f16-28b0f7dcaf45
+  type:
+  - insert
+  declared_card_count: 20
+  parallels:
+  - name: Black Crackle Foil
+    print_run: 10
+    serial_numbered: true
+  - name: Black Foil
+    print_run: 10
+    serial_numbered: true
+  - name: "Crackle\tFoil"
+  - name: FoilFractor
+    print_run: 1
+    serial_numbered: true
+  - name: Gold Crackle Foil
+    print_run: 50
+    serial_numbered: true
+  - name: Gold Foil
+    print_run: 50
+    serial_numbered: true
+  - name: Green Foil
+    print_run: 99
+    serial_numbered: true
+  - name: Orange Crackle Foil
+    print_run: 25
+    serial_numbered: true
+  - name: Orange Foil
+    print_run: 25
+    serial_numbered: true
+  - name: "Red Crackle\tFoil"
+    print_run: 5
+    serial_numbered: true
+  - name: Red Foil
+    print_run: 5
+    serial_numbered: true
+- id: topps-flagship-autograph-patches
+  name: Topps Flagship Autograph Patches
+  uuid: fed5dfc3-7389-5d66-a0f7-57d8d7449aa4
+  type:
+  - autograph
+  - relic
+  declared_card_count: 51
+- id: true-photo-variations
+  name: True Photo Variations
+  uuid: 43280dbd-dfb0-5732-8f27-43eb85a02b8b
+  type:
+  - variation
+  declared_card_count: 100
+- id: vintage-stock-variations
+  name: Vintage Stock Variations
+  uuid: 9e0b1537-3238-513d-96b7-69114c555b2c
+  type:
+  - variation
+  declared_card_count: 100
+- id: world-champion-autographs
+  name: World Champion Autographs
+  uuid: 745948b1-1b45-56e8-bb73-723541525e39
+  type:
+  - autograph
+  declared_card_count: 14

--- a/data/baseball/2026-topps-series-2/set.yaml
+++ b/data/baseball/2026-topps-series-2/set.yaml
@@ -1,0 +1,23 @@
+uuid: 454adae3-692f-42e6-8f6a-459079498348
+set_id: 2026-topps-series-2
+name: 2026 Topps Series 2
+genre: Sports
+category:
+- MLB
+sports:
+- Baseball
+season: '2026'
+years:
+- 2026
+series: 2026 Topps Baseball
+series_number: 2
+manufacturer: Topps
+release_date: '2026-06-11'
+description: 2026 Topps is a 700-card set released in two equal series of 350 cards.
+  Series One was issued the week of February 13th. As usual, each 20-pack Hobby box
+  will yield either an autograph or a Relic card while Hobby-exclusive jumbo boxes
+  will yield an autograph, a game-used Relic -- down from the previous year's two.
+source:
+  name: BaseballCardpedia
+  url: https://baseballcardpedia.com/index.php/2026_Topps#Checklist
+  file: import/2026-Topps-Series-2-Baseball-Checklist.xlsx


### PR DESCRIPTION
Converts jmurphyrum's **2026 Topps Series 2** (#23, exploded one-file-per-card) into **v0.3**. This is the **second manufacturer/product** converted — done specifically to stress-test the schema against something structurally unlike Bowman.

## The collapse
**29,498 card files → 70 files** (`set.yaml` + `manifest.yaml` + 67 checklists)
- **1 base set** (350 cards, numbered **351–700** — Series 2 continues Series 1's numbering)
- **56 product-level subsets** + nested autos/variations, **~3,468 committed rows**

## What this validated
- **The series model.** `series: "2026 Topps Baseball"` + `series_number: 2` — Topps genuinely splits into Series 1 / Series 2, so unlike Bowman this set *keeps* the series fields. Confirms dropping them from Bowman and keeping them here was right.
- **The whole structure holds** for a totally different manufacturer — 0 unmatched files out of 29,498.

## What it surfaced — the `type` list change
Real Topps data has subsets that are **both autograph and relic** (Heavy Lumber Autograph Relics, Flagship Autograph Patches, City Connect Swatches Autographs, Major League Materials Autographs) and **variation-autographs** (1952 Rookie Variation Autographs). A single-enum `type` can't express those. Drove the schema change in **#28**: subset `type` is now a **list** — `[autograph, relic]`, `[autograph, variation]`. Bowman didn't have relics at all, so only cross-manufacturer data exposed this.

## Review items (same class as #29)
1. Some **Base "parallels" may be mis-filed subsets** (the Bowman-Scouts pattern) — worth a scan; salvage may apply.
2. **Insert-family nesting** — "1991 Topps Baseball" + its Chrome / All-Stars / Autographs / Relics are flat at product level where some could nest.
3. **Node `type` inferred from names** (autograph/relic/variation/insert).

## ⚠️ Draft — dependencies
Cannot pass CI or merge until **#28** is adopted and `validate.py` is ported to v0.3. Reviewable now. Supersedes #23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)