### PR TITLE
feat(data): 2025-26 Topps Transcendent in v0.3 manifest form (converted from #18)

### DIFF
--- a/data/baseball/2025-26-topps-transcendent/checklists/1961-topps-all-star-superfractor-autographs.yaml
+++ b/data/baseball/2025-26-topps-transcendent/checklists/1961-topps-all-star-superfractor-autographs.yaml
@@ -1,0 +1,270 @@
+- number: 61AS-AP
+  uuid: db6cb26c-7df2-49cf-b5ad-75062b076161
+  subjects:
+  - entities:
+    - role: player
+      name: Albert Pujols
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: 61AS-BH
+  uuid: a41bdf90-f3d8-446f-8167-d32f9bdd3266
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Harper
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: 61AS-BJ
+  uuid: 13a5eb2f-e09f-4d38-916d-bd1402ca7d35
+  subjects:
+  - entities:
+    - role: player
+      name: Bo Jackson
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: 61AS-BW
+  uuid: 93d2038c-5d46-48fa-91a3-90c1d4954725
+  subjects:
+  - entities:
+    - role: player
+      name: Bobby Witt Jr.
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: 61AS-CJ
+  uuid: 04d44358-7b49-4e86-be1e-e31b46c6847a
+  subjects:
+  - entities:
+    - role: player
+      name: Chipper Jones
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: 61AS-CK
+  uuid: db3b9acd-2da1-4e5d-8312-a4801efb3b13
+  subjects:
+  - entities:
+    - role: player
+      name: Clayton Kershaw
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: 61AS-CR
+  uuid: babda1a5-a7e8-449c-a662-42d9e51218c6
+  subjects:
+  - entities:
+    - role: player
+      name: Cal Ripken Jr.
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: 61AS-DC
+  uuid: de0a9412-427b-4c18-ba64-7804e93434c3
+  subjects:
+  - entities:
+    - role: player
+      name: Dylan Crews
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: 61AS-DJ
+  uuid: 3fb7892c-2bbd-40b8-83af-0c1638ffb0fd
+  subjects:
+  - entities:
+    - role: player
+      name: Derek Jeter
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: 61AS-DO
+  uuid: cca05d6b-b070-40f5-b8f9-e9edbca5cf17
+  subjects:
+  - entities:
+    - role: player
+      name: David Ortiz
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: 61AS-GB
+  uuid: 6571c6c4-fdbd-4c58-84ce-c75359efe5ea
+  subjects:
+  - entities:
+    - role: player
+      name: George Brett
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: 61AS-I
+  uuid: f53e1498-8536-4f8a-9bc6-8b897f64d706
+  subjects:
+  - entities:
+    - role: player
+      name: Ichiro
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: 61AS-IR
+  uuid: 4ac236d8-f4d0-4e86-b345-4c879a1c4a4c
+  subjects:
+  - entities:
+    - role: player
+      name: Ivan Rodriguez
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: 61AS-JB
+  uuid: 9f993b32-d3a3-4d37-8421-e927f0b079b6
+  subjects:
+  - entities:
+    - role: player
+      name: Johnny Bench
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: 61AS-JS
+  uuid: ec3d8076-a69a-4df0-afd6-146e267408b4
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: 61AS-JT
+  uuid: 10b53b36-9fa9-4709-b2a8-d423cd0f3ef9
+  subjects:
+  - entities:
+    - role: player
+      name: Joe Torre
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: 61AS-JW
+  uuid: ee844676-a0d4-4678-ab6f-e240b5e8fd54
+  subjects:
+  - entities:
+    - role: player
+      name: James Wood
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: 61AS-KG
+  uuid: 61d106c2-f1e4-4832-9e50-819eb45c5da8
+  subjects:
+  - entities:
+    - role: player
+      name: Ken Griffey Jr.
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: 61AS-MM
+  uuid: e6669107-31b4-4292-b38f-bfa6c532d0a9
+  subjects:
+  - entities:
+    - role: player
+      name: Mark McGwire
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: 61AS-MP
+  uuid: 0d2cc98a-6497-4b87-b07a-0c75c9e12a43
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Piazza
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: 61AS-MT
+  uuid: 87a1eb28-a3ba-49a1-af88-c854bca118a9
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Trout
+      ref: 
+    - role: team
+      name: Angels
+      ref: 
+- number: 61AS-RA
+  uuid: '0886d35c-1c5c-4461-9470-3ae1e8c69fea'
+  subjects:
+  - entities:
+    - role: player
+      name: Ronald Acuña Jr.
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: 61AS-RC
+  uuid: 26537502-21a5-4e79-8112-1fd094a9b961
+  subjects:
+  - entities:
+    - role: player
+      name: Roger Clemens
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: 61AS-RJ
+  uuid: 76c6ddc1-4e2c-4d2c-bdc0-2529d79e1dad
+  subjects:
+  - entities:
+    - role: player
+      name: Randy Johnson
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: 61AS-RJA
+  uuid: f5749156-2d3b-4c4e-85b1-2c9ce58eda02
+  subjects:
+  - entities:
+    - role: player
+      name: Reggie Jackson
+      ref: 
+    - role: team
+      name: Oakland Athletics
+      ref: 
+- number: 61AS-RS
+  uuid: a7d63c5d-55fc-44b9-ad88-235119acb6d6
+  subjects:
+  - entities:
+    - role: player
+      name: Roki Sasaki
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: 61AS-SK
+  uuid: a19b3686-453d-4543-8a2f-2977b8ae25ae
+  subjects:
+  - entities:
+    - role: player
+      name: Sandy Koufax
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 

--- a/data/baseball/2025-26-topps-transcendent/checklists/1961-topps-combos-superfractor-autographs.yaml
+++ b/data/baseball/2025-26-topps-transcendent/checklists/1961-topps-combos-superfractor-autographs.yaml
@@ -1,0 +1,119 @@
+- number: 61CA-IG
+  uuid: 5c3c066b-f1ed-44a3-9f5b-99f8de4fc1ca
+  subjects:
+  - entities:
+    - role: player
+      name: Ichiro
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+  - entities:
+    - role: player
+      name: Ken Griffey Jr.
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: 61CA-JC
+  uuid: cb855788-c617-4d58-9cfe-5fb7b85cec47
+  subjects:
+  - entities:
+    - role: player
+      name: Reggie Jackson
+      ref: 
+    - role: team
+      name: California Angels
+      ref: 
+  - entities:
+    - role: player
+      name: Rod Carew
+      ref: 
+    - role: team
+      name: California Angels
+      ref: 
+- number: 61CA-JP
+  uuid: d19c935a-0a43-4fad-bc41-21d04ca9546e
+  subjects:
+  - entities:
+    - role: player
+      name: Jorge Posada
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+  - entities:
+    - role: player
+      name: Derek Jeter
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: 61CA-MT
+  uuid: cda31dc4-76cc-4fb3-a16a-c1aec6e82d2c
+  subjects:
+  - entities:
+    - role: player
+      name: Fernando Tatis Jr.
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+  - entities:
+    - role: player
+      name: Manny Machado
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: 61CA-SJ
+  uuid: 36b55532-31ca-43b9-9100-daa06a86dae0
+  subjects:
+  - entities:
+    - role: player
+      name: Derek Jeter
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+  - entities:
+    - role: player
+      name: CC Sabathia
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: 61CA-WC
+  uuid: c638fe88-8f0d-4765-8f3d-103c0c224ca2
+  subjects:
+  - entities:
+    - role: player
+      name: James Wood
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+  - entities:
+    - role: player
+      name: Dylan Crews
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: 61CA-YC
+  uuid: ed350b7d-8160-462c-9310-02fbb0efe0e3
+  subjects:
+  - entities:
+    - role: player
+      name: Christian Yelich
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+  - entities:
+    - role: player
+      name: Jackson Chourio
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 

--- a/data/baseball/2025-26-topps-transcendent/checklists/1961-topps-mvp-superfractor-autographs.yaml
+++ b/data/baseball/2025-26-topps-transcendent/checklists/1961-topps-mvp-superfractor-autographs.yaml
@@ -1,0 +1,400 @@
+- number: 61MVP-AD
+  uuid: 972ec805-d0c7-4c4d-a598-b16b01d90650
+  subjects:
+  - entities:
+    - role: player
+      name: Andre Dawson
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: 61MVP-AJ
+  uuid: 908b4ed8-94f4-4938-9bf2-3a70d0c87cb3
+  subjects:
+  - entities:
+    - role: player
+      name: Aaron Judge
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: 61MVP-AM
+  uuid: 5130b245-bb98-4256-bbb9-40f642dcf7f6
+  subjects:
+  - entities:
+    - role: player
+      name: Andrew McCutchen
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: 61MVP-AP
+  uuid: 5860a8ea-87bf-4353-9cee-0661b4e88084
+  subjects:
+  - entities:
+    - role: player
+      name: Albert Pujols
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: 61MVP-BH
+  uuid: 6289ada3-573c-428e-8dbe-2f4df861aa36
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Harper
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: 61MVP-BHA
+  uuid: 41bb820a-f295-4fe0-a015-2a9334e7012b
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Harper
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: 61MVP-BL
+  uuid: 6877fb16-04b9-4b90-980d-369823aade4a
+  subjects:
+  - entities:
+    - role: player
+      name: Barry Larkin
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: 61MVP-BP
+  uuid: 4d50cc09-8944-4257-b798-fb9c99a9f852
+  subjects:
+  - entities:
+    - role: player
+      name: Buster Posey
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: 61MVP-CJ
+  uuid: 8c4e66ed-e99a-45e4-baad-6c6c6a639360
+  subjects:
+  - entities:
+    - role: player
+      name: Chipper Jones
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: 61MVP-CK
+  uuid: 451e9002-b90b-4740-8bfe-76d6f79a07d9
+  subjects:
+  - entities:
+    - role: player
+      name: Clayton Kershaw
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: 61MVP-CR
+  uuid: 5e67bf0b-33a0-4857-a5e9-c19f1bd76df4
+  subjects:
+  - entities:
+    - role: player
+      name: Cal Ripken Jr.
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: 61MVP-DE
+  uuid: b53f2fed-9f30-4c9c-b9eb-8130b4cd6f08
+  subjects:
+  - entities:
+    - role: player
+      name: Dennis Eckersley
+      ref: 
+    - role: team
+      name: Oakland Athletics
+      ref: 
+- number: 61MVP-DM
+  uuid: 62624f0f-256c-4c10-93c1-fa9deb77e4d5
+  subjects:
+  - entities:
+    - role: player
+      name: Don Mattingly
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: 61MVP-DMU
+  uuid: df320cce-bda3-45fe-add3-513c7202a64a
+  subjects:
+  - entities:
+    - role: player
+      name: Dale Murphy
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: 61MVP-FT
+  uuid: 950168d8-b8a5-4485-a0de-84c141c4d317
+  subjects:
+  - entities:
+    - role: player
+      name: Frank Thomas
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: 61MVP-GBR
+  uuid: 60034961-16e7-4c93-a6b7-28c3c5ed8a59
+  subjects:
+  - entities:
+    - role: player
+      name: George Brett
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: 61MVP-I
+  uuid: 0d025a2e-144a-4dcb-b419-f8373ad0a6dd
+  subjects:
+  - entities:
+    - role: player
+      name: Ichiro
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: 61MVP-IR
+  uuid: 5fa01ee8-a1c2-414a-b8a7-658d5eed7e3f
+  subjects:
+  - entities:
+    - role: player
+      name: Ivan Rodriguez
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: 61MVP-JA
+  uuid: 865c8b51-e5d1-45c7-8fd8-91bf99b30687
+  subjects:
+  - entities:
+    - role: player
+      name: Jose Altuve
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: 61MVP-JB
+  uuid: 6f1e65cf-a71b-479a-8a7e-9cffc35b2124
+  subjects:
+  - entities:
+    - role: player
+      name: Johnny Bench
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: 61MVP-JC
+  uuid: cba6b85b-f47d-4b1d-b888-9b97039d3762
+  subjects:
+  - entities:
+    - role: player
+      name: José Canseco
+      ref: 
+    - role: team
+      name: Oakland Athletics
+      ref: 
+- number: 61MVP-JR
+  uuid: 806dfcab-a702-4298-a255-13cd9a3d16ad
+  subjects:
+  - entities:
+    - role: player
+      name: Jim Rice
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: 61MVP-JRO
+  uuid: 786ec567-677f-4967-8b86-72b22349b1b0
+  subjects:
+  - entities:
+    - role: player
+      name: Jimmy Rollins
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: 61MVP-JT
+  uuid: dce02817-5e6a-4033-b627-57d27d785a92
+  subjects:
+  - entities:
+    - role: player
+      name: Joe Torre
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: 61MVP-JV
+  uuid: 2c1ae853-7f19-47ef-9738-89d6d36d4676
+  subjects:
+  - entities:
+    - role: player
+      name: Joey Votto
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: 61MVP-KG
+  uuid: 1af9e275-5257-44bb-97c5-1b5974261b63
+  subjects:
+  - entities:
+    - role: player
+      name: Ken Griffey Jr.
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: 61MVP-LW
+  uuid: 18a9bd3f-2801-40e4-9f44-8d8e5a46f5b0
+  subjects:
+  - entities:
+    - role: player
+      name: Larry Walker
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: 61MVP-MS
+  uuid: fb83fa2b-28fc-40ae-b4a0-b5cd9d703bc5
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Schmidt
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: 61MVP-MT
+  uuid: 2c34cff3-0857-4e89-bbea-bf8479622b7a
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Trout
+      ref: 
+    - role: team
+      name: Angels
+      ref: 
+- number: 61MVP-RA
+  uuid: bab495ae-4449-4039-9d05-634289ded890
+  subjects:
+  - entities:
+    - role: player
+      name: Ronald Acuña Jr.
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: 61MVP-RC
+  uuid: 5cf52292-aaea-4ac5-a3da-89f6e5ccc690
+  subjects:
+  - entities:
+    - role: player
+      name: Roger Clemens
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: 61MVP-RF
+  uuid: 6be186b0-36dc-4167-90a2-735975811c3c
+  subjects:
+  - entities:
+    - role: player
+      name: Rollie Fingers
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: 61MVP-RJ
+  uuid: 613c70f9-95fb-491c-9f8a-9590015a2291
+  subjects:
+  - entities:
+    - role: player
+      name: Reggie Jackson
+      ref: 
+    - role: team
+      name: Oakland Athletics
+      ref: 
+- number: 61MVP-ROD
+  uuid: 782511b3-f8e9-4dff-aa2c-7ab374b595bf
+  subjects:
+  - entities:
+    - role: player
+      name: Rod Carew
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: 61MVP-RY
+  uuid: 23f8c2b1-ebf8-4aeb-82cd-f6b6dfb4f914
+  subjects:
+  - entities:
+    - role: player
+      name: Robin Yount
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: 61MVP-SHO
+  uuid: afb334f2-4e6f-4e13-b0a4-f046946b7c10
+  subjects:
+  - entities:
+    - role: player
+      name: Shohei Ohtani
+      ref: 
+    - role: team
+      name: Angels
+      ref: 
+- number: 61MVP-SK
+  uuid: fda591af-50ae-467e-b301-cc0218c81ddf
+  subjects:
+  - entities:
+    - role: player
+      name: Sandy Koufax
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: 61MVP-SO
+  uuid: e2f3874a-42cf-4aa6-9dd1-f752d7a54e5e
+  subjects:
+  - entities:
+    - role: player
+      name: Shohei Ohtani
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: 61MVP-SS
+  uuid: 9f87af8d-a06e-4f4f-9ce5-4a2f448dc86d
+  subjects:
+  - entities:
+    - role: player
+      name: Sammy Sosa
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: 61MVP-VG
+  uuid: be8409c9-acd2-4d42-8ecc-ca62e671cf99
+  subjects:
+  - entities:
+    - role: player
+      name: Vladimir Guerrero
+      ref: 
+    - role: team
+      name: Angels
+      ref: 

--- a/data/baseball/2025-26-topps-transcendent/checklists/1961-topps-superfractor-autographs.yaml
+++ b/data/baseball/2025-26-topps-transcendent/checklists/1961-topps-superfractor-autographs.yaml
@@ -1,0 +1,770 @@
+- number: 61S-AG
+  uuid: f72b28d3-3af8-4b82-ab5e-ce8528dd28f8
+  subjects:
+  - entities:
+    - role: player
+      name: Agustín Ramírez
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: 61S-AP
+  uuid: 99f4dd3a-f63e-488f-99c4-18e0228ac45c
+  subjects:
+  - entities:
+    - role: player
+      name: Albert Pujols
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: 61S-AR
+  uuid: deeebe6a-8dc1-4188-88ce-48ef56eaf3f5
+  subjects:
+  - entities:
+    - role: player
+      name: Austin Riley
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: 61S-ARU
+  uuid: 36c3201a-c5f9-4544-8b75-a330f0bd6c4b
+  subjects:
+  - entities:
+    - role: player
+      name: Adley Rutschman
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: 61S-BH
+  uuid: b47b1472-1707-4745-9359-3e069772ec81
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Harper
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: 61S-BJ
+  uuid: f8c30f91-74b3-4cd9-997a-f0c52f1131ba
+  subjects:
+  - entities:
+    - role: player
+      name: Bo Jackson
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: 61S-BL
+  uuid: 3c956b69-e83e-4764-b8de-09fc33d13996
+  subjects:
+  - entities:
+    - role: player
+      name: Barry Larkin
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: 61S-BP
+  uuid: f980312e-28f6-41c7-88bc-af1bfcf4f6c8
+  subjects:
+  - entities:
+    - role: player
+      name: Buster Posey
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: 61S-BW
+  uuid: c80a0dd9-e9bd-4977-8c61-4a59c88bf254
+  subjects:
+  - entities:
+    - role: player
+      name: Bobby Witt Jr.
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: 61S-CA
+  uuid: ce388804-c34e-4760-92bf-354857c8415d
+  subjects:
+  - entities:
+    - role: player
+      name: Cam Smith
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: 61S-CC
+  uuid: c1dbefd7-ed9b-4dfa-a229-f28d0856febc
+  subjects:
+  - entities:
+    - role: player
+      name: Corbin Carroll
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: 61S-CF
+  uuid: 27f416e4-0c46-48b7-b85e-eb06f745458a
+  subjects:
+  - entities:
+    - role: player
+      name: Carlton Fisk
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: 61S-CJ
+  uuid: 34d9b527-00dd-468a-9c95-219c84a93769
+  subjects:
+  - entities:
+    - role: player
+      name: Chipper Jones
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: 61S-CK
+  uuid: 2b813f31-8b2a-4911-81ab-3c73674c6b10
+  subjects:
+  - entities:
+    - role: player
+      name: Clayton Kershaw
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: 61S-CM
+  uuid: 6fffec04-1ebb-4e88-ac41-17976dcbd0fb
+  subjects:
+  - entities:
+    - role: player
+      name: Coby Mayo
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: 61S-CP
+  uuid: 39736f25-4d0f-4c8a-b6b4-99c8b03de86b
+  subjects:
+  - entities:
+    - role: player
+      name: Chan Ho Park
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: 61S-CR
+  uuid: 1a6a0de0-413d-4f30-abb1-f5c531fdefb6
+  subjects:
+  - entities:
+    - role: player
+      name: Cal Ripken Jr.
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: 61S-CS
+  uuid: 28fa1871-404f-449f-bae1-4bdd503abb65
+  subjects:
+  - entities:
+    - role: player
+      name: Corey Seager
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: 61S-CSA
+  uuid: 8f79c58d-130c-42b0-a84f-678d52b5555a
+  subjects:
+  - entities:
+    - role: player
+      name: Chris Sale
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: 61S-CU
+  uuid: bad6c01c-3df1-4c05-9073-192cc02d8669
+  subjects:
+  - entities:
+    - role: player
+      name: Chase Utley
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: 61S-CY
+  uuid: b69f3b89-c138-478b-8755-b37bf9484973
+  subjects:
+  - entities:
+    - role: player
+      name: Christian Yelich
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: 61S-DC
+  uuid: 4a756046-4182-4d94-bb9d-54a259a2ab09
+  subjects:
+  - entities:
+    - role: player
+      name: Dylan Crews
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: 61S-DJ
+  uuid: c203ac7d-f550-4825-9f26-64af8153b4a9
+  subjects:
+  - entities:
+    - role: player
+      name: Derek Jeter
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: 61S-DM
+  uuid: dc843a2c-bc5d-4d3c-b6df-a6123676b349
+  subjects:
+  - entities:
+    - role: player
+      name: Dale Murphy
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: 61S-DO
+  uuid: 553e7b1f-ba8a-4a8a-9b4a-6d2be21964e8
+  subjects:
+  - entities:
+    - role: player
+      name: David Ortiz
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: 61S-EM
+  uuid: b776063a-1fe6-4a11-bdc3-399b21fcb5e4
+  subjects:
+  - entities:
+    - role: player
+      name: Eddie Murray
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: 61S-FL
+  uuid: 9f06675c-610f-4cd3-a51f-05d019fe56fa
+  subjects:
+  - entities:
+    - role: player
+      name: Francisco Lindor
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: 61S-FT
+  uuid: 8300404d-3bfb-4712-9cab-3a4faa263352
+  subjects:
+  - entities:
+    - role: player
+      name: Frank Thomas
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: 61S-FTJ
+  uuid: e5b4863f-6a5a-40fb-a84d-287e1357ef09
+  subjects:
+  - entities:
+    - role: player
+      name: Fernando Tatis Jr.
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: 61S-GB
+  uuid: 678fd184-0c75-4333-bdec-bff39ba9d861
+  subjects:
+  - entities:
+    - role: player
+      name: George Brett
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: 61S-GH
+  uuid: 34ac9091-7b96-4903-b080-01a236425d41
+  subjects:
+  - entities:
+    - role: player
+      name: Gunnar Henderson
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: 61S-GM
+  uuid: 5e50284c-1b68-4e40-95b8-29e362196ee8
+  subjects:
+  - entities:
+    - role: player
+      name: Greg Maddux
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: 61S-HK
+  uuid: '02129071-c526-4b3b-998f-06332468293f'
+  subjects:
+  - entities:
+    - role: player
+      name: Hyeseong Kim
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: 61S-HM
+  uuid: 8e4232e0-96b1-4234-84ef-e189f4edfd4c
+  subjects:
+  - entities:
+    - role: player
+      name: Hideki Matsui
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: 61S-I
+  uuid: 3082962d-a523-447d-8c95-78a79b9a964a
+  subjects:
+  - entities:
+    - role: player
+      name: Ichiro
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: 61S-IR
+  uuid: c1f80a2f-1509-48dd-8d51-5a76811429b7
+  subjects:
+  - entities:
+    - role: player
+      name: Ivan Rodriguez
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: 61S-JB
+  uuid: 712e1ca1-38d6-4cda-960e-8bccaf34908a
+  subjects:
+  - entities:
+    - role: player
+      name: Johnny Bench
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: 61S-JC
+  uuid: c0dbe3ea-34a7-442d-8bce-b9397d0cca40
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Chourio
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: 61S-JH
+  uuid: 14d3c3e2-e378-4987-9cc1-5cca531db113
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Holliday
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: 61S-JJ
+  uuid: 39b3ed5a-069d-41bc-b82b-36a2a51ef862
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Jobe
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: 61S-JP
+  uuid: 272e924e-5b7d-4178-a7cf-0e123c2847ad
+  subjects:
+  - entities:
+    - role: player
+      name: Jorge Posada
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: 61S-JR
+  uuid: aaa9b0e5-5673-4a94-b6b3-093252698957
+  subjects:
+  - entities:
+    - role: player
+      name: José Ramírez
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: 61S-JS
+  uuid: b47e0e69-e6f8-42e4-b9ce-22cb3aa1d179
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: 61S-JV
+  uuid: 94f1e252-1503-4ad8-bdd6-cbacf029e742
+  subjects:
+  - entities:
+    - role: player
+      name: Joey Votto
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: 61S-JW
+  uuid: c9be362a-2296-4b24-b7ca-e7df6ef36c8b
+  subjects:
+  - entities:
+    - role: player
+      name: James Wood
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: 61S-JWI
+  uuid: 88a7674d-5661-47b8-8510-875fcfea95fc
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Wilson
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: 61S-KC
+  uuid: 3a7f6d53-f960-4d42-9585-2e8cbb8df4b4
+  subjects:
+  - entities:
+    - role: player
+      name: Kristian Campbell
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: 61S-KG
+  uuid: 1c2d3f26-ba74-4ec1-95aa-f3cf18271d05
+  subjects:
+  - entities:
+    - role: player
+      name: Ken Griffey Jr.
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: 61S-LEE
+  uuid: 03ed9c88-02f3-44db-be14-04b534076605
+  subjects:
+  - entities:
+    - role: player
+      name: Brooks Lee
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: 61S-LK
+  uuid: 6feaed80-2189-4f54-a56a-84d400046014
+  subjects:
+  - entities:
+    - role: player
+      name: Luke Keaschall
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: 61S-MA
+  uuid: 07fef6ee-3e7e-485e-9cf9-facad96701cc
+  subjects:
+  - entities:
+    - role: player
+      name: Matt Shaw
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: 61S-MM
+  uuid: 45feeb41-f390-4553-8f4a-79e927f05584
+  subjects:
+  - entities:
+    - role: player
+      name: Manny Machado
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: 61S-MMG
+  uuid: 21b51b84-2f34-4e62-99e6-7154e624a39e
+  subjects:
+  - entities:
+    - role: player
+      name: Mark McGwire
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: 61S-MMY
+  uuid: 95d3c090-d6a7-45da-9613-41e8554b8964
+  subjects:
+  - entities:
+    - role: player
+      name: Marcelo Mayer
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: 61S-MP
+  uuid: d36fd310-b806-47d7-ab94-5830f10b518f
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Piazza
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: 61S-MS
+  uuid: 3e55f106-45d3-47ae-b8c5-e1c5c95d6524
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Schmidt
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: 61S-MT
+  uuid: dbf7b02f-506c-4355-9502-e19fac1243a5
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Trout
+      ref: 
+    - role: team
+      name: Angels
+      ref: 
+- number: 61S-NA
+  uuid: ce7bf617-02b4-42fe-b423-e17eb27a6b4e
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan Arenado
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: 61S-NK
+  uuid: abbc541a-db39-4380-b8b7-1441245f579e
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Kurtz
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: 61S-NR
+  uuid: bc3f40d0-2863-46c4-b7e0-ef27fbf85ba7
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan Ryan
+      ref: 
+    - role: team
+      name: California Angels
+      ref: 
+- number: 61S-OH
+  uuid: f1edbd07-84cc-481e-bdec-fcb3e447bb65
+  subjects:
+  - entities:
+    - role: player
+      name: Orel Hershiser
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: 61S-OS
+  uuid: 65a2582c-9e60-446c-9280-0958c7e53faa
+  subjects:
+  - entities:
+    - role: player
+      name: Ozzie Smith
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: 61S-PS
+  uuid: 5e371a40-3a51-48fd-ac55-141b56cd4908
+  subjects:
+  - entities:
+    - role: player
+      name: Paul Skenes
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: 61S-RAJ
+  uuid: 2a5a934d-0f02-4e86-9196-389b5577c6de
+  subjects:
+  - entities:
+    - role: player
+      name: Ronald Acuña Jr.
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: 61S-RC
+  uuid: 1cbcba49-6317-46a6-b738-03c84ead9a0e
+  subjects:
+  - entities:
+    - role: player
+      name: Roger Clemens
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: 61S-RJ
+  uuid: 1d7a5f9b-5f7c-495f-a2a1-af8206f6f314
+  subjects:
+  - entities:
+    - role: player
+      name: Randy Johnson
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: 61S-RJA
+  uuid: ea21c44b-f2c4-46bc-b3dc-0c8a58cc29c6
+  subjects:
+  - entities:
+    - role: player
+      name: Reggie Jackson
+      ref: 
+    - role: team
+      name: Oakland Athletics
+      ref: 
+- number: 61S-RL
+  uuid: 43016a43-91ac-48d8-89c5-359fb74238ed
+  subjects:
+  - entities:
+    - role: player
+      name: Rhett Lowder
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: 61S-ROD
+  uuid: 413c7b07-0180-476b-80e2-152b6262bca1
+  subjects:
+  - entities:
+    - role: player
+      name: Rod Carew
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: 61S-RS
+  uuid: c907b48e-ce10-415c-954c-db55f1f5f10e
+  subjects:
+  - entities:
+    - role: player
+      name: Roki Sasaki
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: 61S-RY
+  uuid: d385d0da-82b1-4ea1-b9f7-3c8c7cd4713f
+  subjects:
+  - entities:
+    - role: player
+      name: Robin Yount
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: 61S-SK
+  uuid: 610547a5-748f-4164-90c2-d6fa073cc3e4
+  subjects:
+  - entities:
+    - role: player
+      name: Sandy Koufax
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: 61S-SR
+  uuid: d4afcf11-b66a-43ee-a6b1-e44880842270
+  subjects:
+  - entities:
+    - role: player
+      name: Scott Rolen
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: 61S-SS
+  uuid: be1dfc08-abf3-4e68-be91-549edb931735
+  subjects:
+  - entities:
+    - role: player
+      name: Sammy Sosa
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: 61S-TT
+  uuid: 735ba29f-1232-4209-be75-494ed68e108d
+  subjects:
+  - entities:
+    - role: player
+      name: Trea Turner
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: 61S-VG
+  uuid: 51cf0ffb-d184-4719-bf90-f18284a5e502
+  subjects:
+  - entities:
+    - role: player
+      name: Vladimir Guerrero
+      ref: 
+    - role: team
+      name: Angels
+      ref: 
+- number: 61S-YY
+  uuid: 3dc8a456-c8e6-4e55-820b-86b544bf1cae
+  subjects:
+  - entities:
+    - role: player
+      name: Yoshinobu Yamamoto
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 

--- a/data/baseball/2025-26-topps-transcendent/checklists/2025-rookies-through-the-years-autographs.yaml
+++ b/data/baseball/2025-26-topps-transcendent/checklists/2025-rookies-through-the-years-autographs.yaml
@@ -1,0 +1,810 @@
+- number: BL-1958
+  uuid: a6ad39eb-2c14-4f4e-a206-c0a1a475d362
+  subjects:
+  - entities:
+    - role: player
+      name: Brooks Lee
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: BL-1977
+  uuid: fb713fa4-a81d-4de8-acd1-abfa279ce047
+  subjects:
+  - entities:
+    - role: player
+      name: Brooks Lee
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: BL-1979
+  uuid: f43da8f4-dc92-45a0-b615-034137d2b5d7
+  subjects:
+  - entities:
+    - role: player
+      name: Brooks Lee
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: BL-2007
+  uuid: 246cc203-2b80-4c38-a39f-afed2a30ace2
+  subjects:
+  - entities:
+    - role: player
+      name: Brooks Lee
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: BL-2022
+  uuid: a251d0ed-3aeb-4b5a-80c3-955c938b26ba
+  subjects:
+  - entities:
+    - role: player
+      name: Brooks Lee
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: CD-90DP
+  uuid: 76f4f503-3f73-49c9-a28f-a37732cf332a
+  subjects:
+  - entities:
+    - role: player
+      name: Chase Dollander
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: CD-93CA
+  uuid: 6eb2ff0c-f726-41e0-8bd0-00d01ab6a15a
+  subjects:
+  - entities:
+    - role: player
+      name: Chase Dollander
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: CD-1964
+  uuid: 52ff4b2f-6f68-4a38-88d6-6fe1d42f7580
+  subjects:
+  - entities:
+    - role: player
+      name: Chase Dollander
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: CD-2012
+  uuid: 23d776ab-95c2-4668-a416-e2a309e0edb9
+  subjects:
+  - entities:
+    - role: player
+      name: Chase Dollander
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: CM-82H
+  uuid: d1882046-aac3-496e-ba27-0d0e4051ff3e
+  subjects:
+  - entities:
+    - role: player
+      name: Coby Mayo
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: CM-1952
+  uuid: e63e7224-75c5-425b-a059-5f8b5dde2a38
+  subjects:
+  - entities:
+    - role: player
+      name: Coby Mayo
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: CM-1953
+  uuid: 16da00e6-1334-460c-85ff-bcd7f7b7c5dc
+  subjects:
+  - entities:
+    - role: player
+      name: Coby Mayo
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: CM-1977
+  uuid: 075b2841-521c-4f08-89cf-5427e8130e18
+  subjects:
+  - entities:
+    - role: player
+      name: Coby Mayo
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: CM-1985
+  uuid: e005a21d-309c-41bf-bc0d-f05735d486c4
+  subjects:
+  - entities:
+    - role: player
+      name: Coby Mayo
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: CM-2013
+  uuid: 6528509c-133f-4da9-a3ed-0a53a68f0bff
+  subjects:
+  - entities:
+    - role: player
+      name: Coby Mayo
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: CM-2021
+  uuid: c6ffcdbb-13be-42c4-9108-fb8ea3a34036
+  subjects:
+  - entities:
+    - role: player
+      name: Coby Mayo
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: CS-68TG
+  uuid: 183b8c6b-6a5b-49a3-bcd2-ecc945b8ce4f
+  subjects:
+  - entities:
+    - role: player
+      name: Cam Smith
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: CS-1958
+  uuid: aba12cbe-b690-465e-a032-0983ebd27852
+  subjects:
+  - entities:
+    - role: player
+      name: Cam Smith
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: CS-1980
+  uuid: a5248445-a935-4338-adc2-2fbdeeb32f9e
+  subjects:
+  - entities:
+    - role: player
+      name: Cam Smith
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: CS-2017
+  uuid: 92f3cf1c-1f4a-4689-9582-c2d23d872b43
+  subjects:
+  - entities:
+    - role: player
+      name: Cam Smith
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: DC-1951
+  uuid: b0cb7d99-bf19-45fd-838b-34ccbc00edc2
+  subjects:
+  - entities:
+    - role: player
+      name: Dylan Crews
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: DC-1957
+  uuid: 39247f80-63d2-42f6-9b72-6ef78f5a51c2
+  subjects:
+  - entities:
+    - role: player
+      name: Dylan Crews
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: DC-1958
+  uuid: 62eec3a8-4354-48b8-b140-02d06d52b117
+  subjects:
+  - entities:
+    - role: player
+      name: Dylan Crews
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: DC-1969
+  uuid: 0d725131-7f9b-4187-9546-da05cb3ede08
+  subjects:
+  - entities:
+    - role: player
+      name: Dylan Crews
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: DC-1978
+  uuid: 1502c4e3-de0e-4ad3-9638-ac3f674e36f7
+  subjects:
+  - entities:
+    - role: player
+      name: Dylan Crews
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: DC-1988
+  uuid: 28408036-1f5a-445a-b3f1-a0ccaef3933d
+  subjects:
+  - entities:
+    - role: player
+      name: Dylan Crews
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: DC-1990
+  uuid: 71b6071a-4bc8-4b38-8519-6e2dced57141
+  subjects:
+  - entities:
+    - role: player
+      name: Dylan Crews
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: DR-55B
+  uuid: 8b155fb3-50a4-4b63-8f9a-938fa61cdb9c
+  subjects:
+  - entities:
+    - role: player
+      name: Dalton Rushing
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: DR-93CA
+  uuid: 6bb75839-f008-4acd-a57d-6fe7b91805c8
+  subjects:
+  - entities:
+    - role: player
+      name: Dalton Rushing
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: DR-1973
+  uuid: b8011eab-982b-4c01-9064-d5e49271e047
+  subjects:
+  - entities:
+    - role: player
+      name: Dalton Rushing
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: DR-R1966
+  uuid: 68daba82-fa38-43b8-8e2e-d406c36c75c5
+  subjects:
+  - entities:
+    - role: player
+      name: Dalton Rushing
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: HK-55B
+  uuid: 0ed88730-46b4-4b87-9e5f-268a34cf2df0
+  subjects:
+  - entities:
+    - role: player
+      name: Hyeseong Kim
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: HK-93CA
+  uuid: 0fec4c77-33e9-4c4c-9594-0db93210abab
+  subjects:
+  - entities:
+    - role: player
+      name: Hyeseong Kim
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: HK-1973
+  uuid: 14444fd4-1977-47bf-bf13-6237a4d590a2
+  subjects:
+  - entities:
+    - role: player
+      name: Hyeseong Kim
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: HK-1990
+  uuid: f79f748a-c2a3-4582-9545-ff9fe5800301
+  subjects:
+  - entities:
+    - role: player
+      name: Hyeseong Kim
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: HK-R1966
+  uuid: 88ac7917-026f-4329-ba8e-295906e61d9c
+  subjects:
+  - entities:
+    - role: player
+      name: Hyeseong Kim
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: JA-69TS
+  uuid: 9fadceb2-72fa-4d12-9645-1f0bf4f409a0
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Wilson
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: JA-94FS
+  uuid: 5ba6f2ed-dcb5-4284-a78e-2ccfb207fd70
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Wilson
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: JA-1985
+  uuid: fb8c13fe-1ea7-41a0-82a7-14d92c5d6883
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Wilson
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: JA-2011
+  uuid: 9ee6fc47-04b0-42c8-a243-913d34a2fc7e
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Wilson
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: JA-2018
+  uuid: '09b36feb-4234-4966-9cf0-8b8bdbed7980'
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Wilson
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: JJ-90DP
+  uuid: 9f8fdeb9-19fc-4618-9c03-be521ef7a09b
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Jobe
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: JJ-93CA
+  uuid: 4e0edcb9-501a-47d8-b3d8-84f92480fba0
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Jobe
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: JJ-1964
+  uuid: b9ff50b5-c82f-4ff7-aee3-a2557d3d369f
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Jobe
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: JJ-1970
+  uuid: 4ff70876-1740-4061-bec0-f3b6f622d18a
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Jobe
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: JJ-2012
+  uuid: 4c2fa055-3d9b-4ae2-8988-db7f1069b142
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Jobe
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: JW-75H
+  uuid: de382501-61fb-4918-9ce6-01a5ddc4ef98
+  subjects:
+  - entities:
+    - role: player
+      name: James Wood
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: JW-82IA
+  uuid: 7cbf590e-91ae-4be8-8061-98c1067b45bf
+  subjects:
+  - entities:
+    - role: player
+      name: James Wood
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: JW-93CA
+  uuid: da083668-d719-4bf8-b138-7e0e5010a111
+  subjects:
+  - entities:
+    - role: player
+      name: James Wood
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: JW-93DP
+  uuid: 0a5c21fd-6ace-4f48-8e50-0bc0f838202e
+  subjects:
+  - entities:
+    - role: player
+      name: James Wood
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: JW-1972
+  uuid: 73733067-0ec9-486b-859e-8149a199eb08
+  subjects:
+  - entities:
+    - role: player
+      name: James Wood
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: JW-1976
+  uuid: 33d0f9f8-daac-4000-b9ae-d83756a141c3
+  subjects:
+  - entities:
+    - role: player
+      name: James Wood
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: JW-1977
+  uuid: c0d8330b-f483-4e85-9a44-98a652b21487
+  subjects:
+  - entities:
+    - role: player
+      name: James Wood
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: KC-68TG
+  uuid: 1eabbde7-b617-41ce-844c-f254251b6cee
+  subjects:
+  - entities:
+    - role: player
+      name: Kristian Cambpell
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: KC-1958
+  uuid: dd2118b3-e28f-4a4a-95f8-2f5897786952
+  subjects:
+  - entities:
+    - role: player
+      name: Kristian Cambpell
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: KC-1961
+  uuid: 46310404-9faf-4d0b-82fa-ed9e1b5fa6f1
+  subjects:
+  - entities:
+    - role: player
+      name: Kristian Cambpell
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: KC-1980
+  uuid: c569d4da-25d3-4cf2-b8cc-ab397223b059
+  subjects:
+  - entities:
+    - role: player
+      name: Kristian Cambpell
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: KC-2017
+  uuid: 23156d33-0278-4816-9309-f5a33917b516
+  subjects:
+  - entities:
+    - role: player
+      name: Kristian Cambpell
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: MM-90DP
+  uuid: 85e5a80c-1a97-4de4-bb73-0c7cfe978db5
+  subjects:
+  - entities:
+    - role: player
+      name: Marcelo Mayer
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: MM-93CA
+  uuid: 16526324-d2c7-4775-a566-626ac6174706
+  subjects:
+  - entities:
+    - role: player
+      name: Marcelo Mayer
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: MM-1964
+  uuid: afbc421c-2535-4fe0-8b4c-d6abec071bd9
+  subjects:
+  - entities:
+    - role: player
+      name: Marcelo Mayer
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: MM-1970
+  uuid: 0317e979-ceaf-4466-b8e9-b6a30148d5f3
+  subjects:
+  - entities:
+    - role: player
+      name: Marcelo Mayer
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: MM-2012
+  uuid: 2ff24a5c-90f4-4c58-94b4-fcfe0e6ca445
+  subjects:
+  - entities:
+    - role: player
+      name: Marcelo Mayer
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: MS-1964
+  uuid: fa968e91-f349-4af5-9126-7ea24d7f020c
+  subjects:
+  - entities:
+    - role: player
+      name: Matt Shaw
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: MS-1966
+  uuid: 54bc2ffb-165b-4bba-94b9-8f7b724f1e16
+  subjects:
+  - entities:
+    - role: player
+      name: Matt Shaw
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: MS-1970
+  uuid: 4b7d2670-c24f-4f84-b1ea-0e561aa74b9f
+  subjects:
+  - entities:
+    - role: player
+      name: Matt Shaw
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: MS-2012
+  uuid: 3f14a131-043f-4b23-974c-9bbe0b60ef30
+  subjects:
+  - entities:
+    - role: player
+      name: Matt Shaw
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: NK-90DP
+  uuid: 7d1b400d-465e-49d8-a905-2171e0dc2fb9
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Kurtz
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: NK-93CA
+  uuid: c9845700-aa1f-4334-b861-0d498f67c6b2
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Kurtz
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: NK-1964
+  uuid: '08a4f262-ef67-4ed3-9605-8d5d476e7d76'
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Kurtz
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: NK-2012
+  uuid: 7db4598d-4d50-41ac-886a-03ff30dcfcff
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Kurtz
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: RS-1957
+  uuid: 0362c2ba-19dc-47ed-8e91-1158c4d3cd9c
+  subjects:
+  - entities:
+    - role: player
+      name: Roki Sasaki
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: RS-1964
+  uuid: 53b97364-489e-4261-b731-d38caab5c8d7
+  subjects:
+  - entities:
+    - role: player
+      name: Roki Sasaki
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: RS-1965
+  uuid: 7cf3555f-a661-4c0d-b483-79f00942beb1
+  subjects:
+  - entities:
+    - role: player
+      name: Roki Sasaki
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: RS-1966
+  uuid: d118688c-1725-4ef5-969e-b49cd62149f6
+  subjects:
+  - entities:
+    - role: player
+      name: Roki Sasaki
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: RS-1969
+  uuid: 305ab3d4-8d00-4f95-85a9-96f0f2b9af07
+  subjects:
+  - entities:
+    - role: player
+      name: Roki Sasaki
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: RS-1991
+  uuid: f9911b34-2d5e-447d-b5df-5e74855cf586
+  subjects:
+  - entities:
+    - role: player
+      name: Roki Sasaki
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: RS-2003
+  uuid: 6772d8c2-2b00-4f86-b5e5-77450ee444a2
+  subjects:
+  - entities:
+    - role: player
+      name: Roki Sasaki
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: RS-2008
+  uuid: 15088d91-1364-4724-ad0a-25994c19d123
+  subjects:
+  - entities:
+    - role: player
+      name: Roki Sasaki
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: RS-2013
+  uuid: 4d7586c9-f5d1-4be3-a65b-0d23f6405c99
+  subjects:
+  - entities:
+    - role: player
+      name: Roki Sasaki
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: RS-2015
+  uuid: ee2690c6-dcf4-4edb-ba40-2668c8d2305b
+  subjects:
+  - entities:
+    - role: player
+      name: Roki Sasaki
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 

--- a/data/baseball/2025-26-topps-transcendent/checklists/base-set-image-variations.yaml
+++ b/data/baseball/2025-26-topps-transcendent/checklists/base-set-image-variations.yaml
@@ -1,0 +1,990 @@
+- number: '1'
+  uuid: 325ff6b4-db30-45fa-9cbb-ef0db01b649a
+  subjects:
+  - entities:
+    - role: player
+      name: Shohei Ohtani
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '2'
+  uuid: ce951ead-6bd8-436b-8930-3281fa920dd7
+  subjects:
+  - entities:
+    - role: player
+      name: Derek Jeter
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '3'
+  uuid: 16c3837a-d5a9-4696-bf75-09d3815bdbed
+  subjects:
+  - entities:
+    - role: player
+      name: Fernando Tatis Jr.
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: '4'
+  uuid: f9bec056-5330-49e8-bbe0-252498a47028
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Harper
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: '5'
+  uuid: a50df445-b35b-4aab-9c44-1df141233808
+  subjects:
+  - entities:
+    - role: player
+      name: Paul Skenes
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '6'
+  uuid: d936d8a9-b8ac-4ef0-a95a-c3811a0b9612
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Trout
+      ref: 
+    - role: team
+      name: Angels
+      ref: 
+- number: '7'
+  uuid: 7c5b21f4-80c7-4265-9ec6-af6a2cbbd11d
+  subjects:
+  - entities:
+    - role: player
+      name: Ronald Acuña Jr.
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: '8'
+  uuid: b0da762a-202d-4071-b69e-6278db0e70fb
+  subjects:
+  - entities:
+    - role: player
+      name: Bobby Witt Jr.
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: '9'
+  uuid: 6799fe53-dbd3-42e9-8b70-18c36d281a50
+  subjects:
+  - entities:
+    - role: player
+      name: Yoshinobu Yamamoto
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '10'
+  uuid: 5b403e4e-b773-44d9-8ab2-b5fbfe149e35
+  subjects:
+  - entities:
+    - role: player
+      name: Gunnar Henderson
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '11'
+  uuid: c8363692-bc30-402e-bc0b-f4094f4994b1
+  subjects:
+  - entities:
+    - role: player
+      name: Elly De La Cruz
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '12'
+  uuid: e6b942b3-0f46-481e-ad06-03afed6122a7
+  subjects:
+  - entities:
+    - role: player
+      name: Matt Shaw
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '13'
+  uuid: 555888f8-1ff8-4ae0-8e79-28c0a463865c
+  subjects:
+  - entities:
+    - role: player
+      name: Rafael Devers
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '14'
+  uuid: bc884c8d-fab7-459e-be38-cb9af658a6ca
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Tucker
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '15'
+  uuid: 9d3c55c7-5013-4c61-8bb0-d25005995199
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '16'
+  uuid: 73e91330-e135-4117-96ba-41f5df55e59c
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Alonso
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '17'
+  uuid: 988a3dfc-1c06-4ff6-a45f-5cad58aa0ef4
+  subjects:
+  - entities:
+    - role: player
+      name: Javier Báez
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '18'
+  uuid: f9bc69b8-39b3-47ef-8167-322ce1af605b
+  subjects:
+  - entities:
+    - role: player
+      name: Alex Rodriguez
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: '19'
+  uuid: c7bf2334-1856-473b-8935-902f1b9722a1
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan Arenado
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: '20'
+  uuid: bcdd4467-063c-45d4-852c-c73650af5ef4
+  subjects:
+  - entities:
+    - role: player
+      name: Robert Hassell III
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: '21'
+  uuid: 16edefc5-102f-4649-8f4e-e5caff77603e
+  subjects:
+  - entities:
+    - role: player
+      name: Adrian Beltré
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: '22'
+  uuid: 23d65077-ffd2-4e42-a7cc-9935abc4913b
+  subjects:
+  - entities:
+    - role: player
+      name: Clayton Kershaw
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '23'
+  uuid: 9ea5a53b-c47d-4e92-b595-d23d61709573
+  subjects:
+  - entities:
+    - role: player
+      name: David Ortiz
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '24'
+  uuid: 87bf1fbe-7d99-45a0-a7ec-6205a181c208
+  subjects:
+  - entities:
+    - role: player
+      name: Marcelo Mayer
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '25'
+  uuid: 52a937b9-5cc8-45f9-848c-f6caef67b846
+  subjects:
+  - entities:
+    - role: player
+      name: Randy Johnson
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: '26'
+  uuid: 59e93330-3b2d-43f9-9691-80b0a6fcccc6
+  subjects:
+  - entities:
+    - role: player
+      name: Mookie Betts
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '27'
+  uuid: 0b47d4d9-2f4a-44d0-ac81-51f09583e63a
+  subjects:
+  - entities:
+    - role: player
+      name: Corey Seager
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: '28'
+  uuid: 39f9d49e-71bc-4128-9655-e6d2c6f08a09
+  subjects:
+  - entities:
+    - role: player
+      name: Alex Bregman
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '29'
+  uuid: 62e10c23-a9d4-45ce-8792-583db8c5ac75
+  subjects:
+  - entities:
+    - role: player
+      name: Dalton Rushing
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '30'
+  uuid: 3b67e4b9-c393-48b6-bd4b-5d2b02ebf470
+  subjects:
+  - entities:
+    - role: player
+      name: Vladimir Guerrero Jr.
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '31'
+  uuid: 959057cf-9339-4e7e-ab9f-6e5cad74c11c
+  subjects:
+  - entities:
+    - role: player
+      name: Hideki Matsui
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '32'
+  uuid: a8840af6-6212-4501-a043-db7b23e236c1
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Piazza
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '33'
+  uuid: 2b1a758e-3491-496f-9626-f2b22ecd8d9d
+  subjects:
+  - entities:
+    - role: player
+      name: Ernie Banks
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '34'
+  uuid: 80d6e5db-be2f-4a21-b7f0-8472322b3a62
+  subjects:
+  - entities:
+    - role: player
+      name: Kirby Puckett
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: '35'
+  uuid: c56c9279-65ea-42d8-a279-4e8e2edce61e
+  subjects:
+  - entities:
+    - role: player
+      name: Chandler Simpson
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: '36'
+  uuid: 03c9338c-7766-4437-b3de-0cd119e2f82b
+  subjects:
+  - entities:
+    - role: player
+      name: Adley Rutschman
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '37'
+  uuid: 5860673b-115f-46e9-9a56-4603f65332ae
+  subjects:
+  - entities:
+    - role: player
+      name: Seiya Suzuki
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '38'
+  uuid: 2f568472-2502-4523-80cb-7090686ae8b6
+  subjects:
+  - entities:
+    - role: player
+      name: Jung Hoo Lee
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '39'
+  uuid: 996826b2-5962-4ac0-b7bd-79fad708269f
+  subjects:
+  - entities:
+    - role: player
+      name: Kristian Campbell
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '40'
+  uuid: e6b1b7de-5432-42bc-9bf5-9eec216acc52
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan Ryan
+      ref: 
+    - role: team
+      name: California Angels
+      ref: 
+- number: '41'
+  uuid: f4349ea9-f119-4c3a-b3e6-1b06e33734c9
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Kurtz
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: '42'
+  uuid: 186a5918-9869-4073-b817-de5eee225811
+  subjects:
+  - entities:
+    - role: player
+      name: Mariano Rivera
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '43'
+  uuid: 79d64c79-9903-4527-bfa5-6a97d3ac722a
+  subjects:
+  - entities:
+    - role: player
+      name: Coby Mayo
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '44'
+  uuid: 56e1a116-15af-4c6b-8278-9ae3e21703cb
+  subjects:
+  - entities:
+    - role: player
+      name: Corbin Carroll
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: '45'
+  uuid: 1d35d3ba-ce6e-4e4a-bf0a-daa2a2b2e48b
+  subjects:
+  - entities:
+    - role: player
+      name: Bo Bichette
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '46'
+  uuid: 55bfb90f-529e-415a-8e7d-678af08a24c6
+  subjects:
+  - entities:
+    - role: player
+      name: Agustín Ramírez
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: '47'
+  uuid: 3e86be3b-19d7-4280-8e0b-6c314f9b0031
+  subjects:
+  - entities:
+    - role: player
+      name: Chase Meidroth
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: '48'
+  uuid: 6442568f-bad4-44a0-95a9-93090ff08bdd
+  subjects:
+  - entities:
+    - role: player
+      name: Luisangel Acuña
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '49'
+  uuid: 0ca6cdd8-d711-48ec-9d6f-8dc8e9eb7701
+  subjects:
+  - entities:
+    - role: player
+      name: Manny Machado
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: '50'
+  uuid: 97182424-6b3d-4a7d-b631-58a25ef54eeb
+  subjects:
+  - entities:
+    - role: player
+      name: Barry Bonds
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '51'
+  uuid: 12ec8ab0-a12f-485b-b114-46c7ca33ec0b
+  subjects:
+  - entities:
+    - role: player
+      name: Francisco Lindor
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '52'
+  uuid: 70122099-bcd8-4b85-a7ac-8336bc2969fd
+  subjects:
+  - entities:
+    - role: player
+      name: Max Scherzer
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '53'
+  uuid: eccb430e-0029-4e62-ac21-d7ca66d6301e
+  subjects:
+  - entities:
+    - role: player
+      name: Ryne Sandberg
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '54'
+  uuid: 87d4b18d-b998-4c3f-a4ae-6793a6f82e78
+  subjects:
+  - entities:
+    - role: player
+      name: Julio Rodríguez
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: '55'
+  uuid: 7838dd20-42c8-4b89-b3c4-dc6dd8336bc6
+  subjects:
+  - entities:
+    - role: player
+      name: Carlos Correa
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: '56'
+  uuid: f3b758a5-0c46-4b30-bb52-b30bd450021c
+  subjects:
+  - entities:
+    - role: player
+      name: José Ramírez
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '57'
+  uuid: 8f34c0a5-447c-493c-bb25-8efdba8003ea
+  subjects:
+  - entities:
+    - role: player
+      name: Moisés Ballesteros
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '58'
+  uuid: f268f003-d092-42c5-baf1-efa98edbe2a8
+  subjects:
+  - entities:
+    - role: player
+      name: George Brett
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: '59'
+  uuid: 561cf894-8c77-4c42-99a0-39e32b1b9bdf
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Crow-Armstrong
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '60'
+  uuid: ce02530b-cc75-4c55-8136-66941c63d41f
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Jobe
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '61'
+  uuid: 07e3e3ee-d512-44e7-807e-30b60c0d94e9
+  subjects:
+  - entities:
+    - role: player
+      name: Sammy Sosa
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '62'
+  uuid: 823abf46-4938-473c-82c4-f85ae2ed7b0e
+  subjects:
+  - entities:
+    - role: player
+      name: Joey Votto
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '63'
+  uuid: e92af06f-30ef-4107-8333-ccada72e4329
+  subjects:
+  - entities:
+    - role: player
+      name: Chase Dollander
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: '64'
+  uuid: 4b5f3079-9d1f-4485-b09a-62e251c54d39
+  subjects:
+  - entities:
+    - role: player
+      name: Babe Ruth
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '65'
+  uuid: 6edc99e8-cfa4-40f0-98c6-e21ebb9328a6
+  subjects:
+  - entities:
+    - role: player
+      name: Chase Petty
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '66'
+  uuid: b019b1cd-4d65-4f86-8c8c-361c46aca28c
+  subjects:
+  - entities:
+    - role: player
+      name: Cal Ripken Jr.
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '67'
+  uuid: e896fecd-f3b2-45a2-8d5b-ef64528e7b66
+  subjects:
+  - entities:
+    - role: player
+      name: Pedro Martinez
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '68'
+  uuid: dc4e9586-6e4e-4fa5-b334-bac8f9569514
+  subjects:
+  - entities:
+    - role: player
+      name: Dylan Crews
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: '69'
+  uuid: d06fb193-a5e6-4bff-9a22-94072f72db59
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Holliday
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '70'
+  uuid: 0023731e-1e98-45bd-9e43-48092ee3b181
+  subjects:
+  - entities:
+    - role: player
+      name: Cam Smith
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '71'
+  uuid: bfb8f278-74b2-4174-87f6-70ce3d0723a1
+  subjects:
+  - entities:
+    - role: player
+      name: Greg Maddux
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: '72'
+  uuid: 899709f8-a8ce-4a6a-b128-f724b6218755
+  subjects:
+  - entities:
+    - role: player
+      name: Miguel Cabrera
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '73'
+  uuid: 5f07480d-5f46-459b-94e5-36926e5839f3
+  subjects:
+  - entities:
+    - role: player
+      name: Albert Pujols
+      ref: 
+    - role: team
+      name: Angels
+      ref: 
+- number: '74'
+  uuid: cff7153b-a0c0-46b0-8d61-46a7e060297b
+  subjects:
+  - entities:
+    - role: player
+      name: Cade Horton
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '75'
+  uuid: 0ac65954-e899-48b1-900c-c4dbb1ea9146
+  subjects:
+  - entities:
+    - role: player
+      name: Chase Utley
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: '76'
+  uuid: dd84d49f-eab9-466b-8fdb-b9fd81c37ea8
+  subjects:
+  - entities:
+    - role: player
+      name: Sandy Koufax
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '77'
+  uuid: 611b7bde-b442-4387-aa51-226cfd5bfa22
+  subjects:
+  - entities:
+    - role: player
+      name: Shota Imanaga
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '78'
+  uuid: 8f140d3d-3077-41e1-99f6-5f890b29de59
+  subjects:
+  - entities:
+    - role: player
+      name: Christian Yelich
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: '79'
+  uuid: bff4df95-2e71-472e-a82f-97133528924e
+  subjects:
+  - entities:
+    - role: player
+      name: Buster Posey
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '80'
+  uuid: a7468a8e-8f55-4753-a4f7-00bb04829575
+  subjects:
+  - entities:
+    - role: player
+      name: Luke Keaschall
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: '81'
+  uuid: 7b7894a8-6ec9-4b2a-be9c-36b6d1db1a05
+  subjects:
+  - entities:
+    - role: player
+      name: Gerrit Cole
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '82'
+  uuid: 469bc550-36d7-437c-a5f9-8c3c54f143c8
+  subjects:
+  - entities:
+    - role: player
+      name: Edgar Quero
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: '83'
+  uuid: 6175c9d9-ac3c-43ec-bc04-32bb305abc81
+  subjects:
+  - entities:
+    - role: player
+      name: Kevin Alcántara
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '84'
+  uuid: c80961a3-918b-44df-8470-69370b7f993f
+  subjects:
+  - entities:
+    - role: player
+      name: Freddie Freeman
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '85'
+  uuid: cddfc4d0-5405-4593-bc08-9859dd2b94b5
+  subjects:
+  - entities:
+    - role: player
+      name: James Wood
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: '86'
+  uuid: 990ed82f-0157-4aef-9745-2be47551785b
+  subjects:
+  - entities:
+    - role: player
+      name: Orel Hershiser
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '87'
+  uuid: aa840d6a-5252-40c2-bb1a-321921f040e1
+  subjects:
+  - entities:
+    - role: player
+      name: Connor Norby
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: '88'
+  uuid: 5b086cdb-1370-4631-8bfd-f66d74ed0265
+  subjects:
+  - entities:
+    - role: player
+      name: Rhett Lowder
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '89'
+  uuid: 934b2baa-fe77-43b3-8be8-3a89da23333d
+  subjects:
+  - entities:
+    - role: player
+      name: Ichiro
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: '90'
+  uuid: a937b57a-77a6-4675-adca-38a89e91231d
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Wilson
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: '91'
+  uuid: 99c98a9b-f1bd-4022-8d45-37018f37d1b2
+  subjects:
+  - entities:
+    - role: player
+      name: Andrew McCutchen
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '92'
+  uuid: 5e5a74c4-53a6-4d17-b8bd-b9b6b8de99d0
+  subjects:
+  - entities:
+    - role: player
+      name: Ozzie Smith
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: '93'
+  uuid: 1594bb81-52e9-420c-ad08-03787c7a0f01
+  subjects:
+  - entities:
+    - role: player
+      name: Yadier Molina
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: '94'
+  uuid: e8d969d7-3497-40e0-8403-c88bd2adf6cd
+  subjects:
+  - entities:
+    - role: player
+      name: Ken Griffey Jr.
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: '95'
+  uuid: e5f812d7-3afb-44d0-aee6-984b844c077a
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob deGrom
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: '96'
+  uuid: f5d03555-1f60-401c-a445-4b5e207f4a10
+  subjects:
+  - entities:
+    - role: player
+      name: Hyeseong Kim
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '97'
+  uuid: e1b22390-55df-4048-bf22-8be0fe818b14
+  subjects:
+  - entities:
+    - role: player
+      name: Reggie Jackson
+      ref: 
+    - role: team
+      name: Oakland Athletics
+      ref: 
+- number: '98'
+  uuid: 97ee1881-4d01-46d1-b71e-2f7aa440f29c
+  subjects:
+  - entities:
+    - role: player
+      name: Zac Veen
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: '99'
+  uuid: 3e154ac1-1f8b-4d3f-b3e6-449cc81d08e6
+  subjects:
+  - entities:
+    - role: player
+      name: Aaron Judge
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 

--- a/data/baseball/2025-26-topps-transcendent/checklists/base-set.yaml
+++ b/data/baseball/2025-26-topps-transcendent/checklists/base-set.yaml
@@ -1,0 +1,1027 @@
+- number: '1'
+  uuid: 9e9ffb5f-91f4-4f79-a574-82326ef1fd2b
+  subjects:
+  - entities:
+    - role: player
+      name: Shohei Ohtani
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '2'
+  uuid: e88376ba-82b2-496a-96ee-d63d25753e7b
+  subjects:
+  - entities:
+    - role: player
+      name: Derek Jeter
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '3'
+  uuid: a6ed4d45-5da1-40a9-834d-a9fe0b481cf9
+  subjects:
+  - entities:
+    - role: player
+      name: Fernando Tatis Jr.
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: '4'
+  uuid: a96504f6-066c-4e4e-8c24-5b94e0fa35b9
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Harper
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: '5'
+  uuid: 8dc2c32c-4ab8-4b84-94b0-d87a9f3f1078
+  subjects:
+  - entities:
+    - role: player
+      name: Paul Skenes
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '6'
+  uuid: fd574643-c27d-4a68-87f5-8538522b7498
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Trout
+      ref: 
+    - role: team
+      name: Angels
+      ref: 
+- number: '7'
+  uuid: 5816f443-2bbd-48f1-b8a5-c724e069bb91
+  subjects:
+  - entities:
+    - role: player
+      name: Ronald Acuña Jr.
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: '8'
+  uuid: e1a3bbd9-b129-4ebb-a590-09bdd920906d
+  subjects:
+  - entities:
+    - role: player
+      name: Bobby Witt Jr.
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: '9'
+  uuid: 4b535ec8-0be2-46b9-abdb-628a3992bcba
+  subjects:
+  - entities:
+    - role: player
+      name: Yoshinobu Yamamoto
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '10'
+  uuid: aeb04acc-44ba-4200-b201-a9e9d58719c7
+  subjects:
+  - entities:
+    - role: player
+      name: Gunnar Henderson
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '11'
+  uuid: 86996a8c-b42c-4023-8201-1a92eea1bd41
+  subjects:
+  - entities:
+    - role: player
+      name: Elly De La Cruz
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '12'
+  uuid: 2f1ce675-c1df-418e-a733-f926e6cbc156
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Matt Shaw
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '13'
+  uuid: d29988e5-a84e-4282-9aa5-143969c09e92
+  subjects:
+  - entities:
+    - role: player
+      name: Rafael Devers
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '14'
+  uuid: db461499-53ae-4003-98bf-db3dda6f0daf
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Tucker
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '15'
+  uuid: 826f4857-1b95-4e46-90ad-aaedc902456f
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '16'
+  uuid: 2f2b46db-de86-4450-a8b7-7435972b6482
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Alonso
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '17'
+  uuid: e654bf31-b901-4864-ac73-9e1b6d6e6ac0
+  subjects:
+  - entities:
+    - role: player
+      name: Javier Báez
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '18'
+  uuid: ef86ce94-daea-4198-8e6f-d8d2963f3d91
+  subjects:
+  - entities:
+    - role: player
+      name: Alex Rodriguez
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: '19'
+  uuid: 44d33514-a17f-4371-9d4c-cd01a43fa5a2
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan Arenado
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: '20'
+  uuid: b59488a5-2326-436f-a9ab-347c3dff558b
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Robert Hassell III
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: '21'
+  uuid: 34bf91a6-d628-4cf1-af8e-3a5b015743f8
+  subjects:
+  - entities:
+    - role: player
+      name: Adrian Beltré
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: '22'
+  uuid: feb7109e-ea14-4dc4-bbe7-3e71d22e2417
+  subjects:
+  - entities:
+    - role: player
+      name: Clayton Kershaw
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '23'
+  uuid: 8981d877-580d-410a-9e0e-5402653dc811
+  subjects:
+  - entities:
+    - role: player
+      name: David Ortiz
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '24'
+  uuid: 44c96ef4-9f51-4186-b911-447422eda0e0
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Marcelo Mayer
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '25'
+  uuid: 0a83e3dd-2bb6-4225-a653-2af904c3d143
+  subjects:
+  - entities:
+    - role: player
+      name: Randy Johnson
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: '26'
+  uuid: e018ce67-1c26-4a94-8052-972a7abd8354
+  subjects:
+  - entities:
+    - role: player
+      name: Mookie Betts
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '27'
+  uuid: 4dd40fa1-576d-4867-8725-28a6c0405d54
+  subjects:
+  - entities:
+    - role: player
+      name: Corey Seager
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: '28'
+  uuid: a15e7fd5-4bee-4b84-930b-71ad40b91c2f
+  subjects:
+  - entities:
+    - role: player
+      name: Alex Bregman
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '29'
+  uuid: e79ea0f1-efd6-4b1d-8a8b-0fc3b917e8b4
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Dalton Rushing
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '30'
+  uuid: 57d38aaa-d819-42e1-bf12-92822b540ede
+  subjects:
+  - entities:
+    - role: player
+      name: Vladimir Guerrero Jr.
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '31'
+  uuid: d5ffbf61-7049-4b12-b428-fd280921420b
+  subjects:
+  - entities:
+    - role: player
+      name: Hideki Matsui
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '32'
+  uuid: 1bfc7609-4dbd-471c-b348-a430a92459d0
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Piazza
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '33'
+  uuid: d240caf0-1588-4622-a475-2c09a1dd17e3
+  subjects:
+  - entities:
+    - role: player
+      name: Ernie Banks
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '34'
+  uuid: da98768e-1ba0-497d-a0d4-63dfafc41152
+  subjects:
+  - entities:
+    - role: player
+      name: Kirby Puckett
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: '35'
+  uuid: 67fabd8a-d977-4f8b-8299-c65c8f3fcd6a
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Chandler Simpson
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: '36'
+  uuid: cf91a4ce-fe4b-4b5f-a5ac-ea1b99915938
+  subjects:
+  - entities:
+    - role: player
+      name: Adley Rutschman
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '37'
+  uuid: 1da8cf49-edfc-4c97-a75f-145cc1f0638d
+  subjects:
+  - entities:
+    - role: player
+      name: Seiya Suzuki
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '38'
+  uuid: aefb0b94-c2f5-4896-b53d-3a8bcacfc9b7
+  subjects:
+  - entities:
+    - role: player
+      name: Jung Hoo Lee
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '39'
+  uuid: 06a9a62b-5b3b-41e9-93fd-9d1828a462ce
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Kristian Campbell
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '40'
+  uuid: e6b3995e-5b33-4fe6-93a2-6b472ad30a56
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan Ryan
+      ref: 
+    - role: team
+      name: California Angels
+      ref: 
+- number: '41'
+  uuid: 54d0afd5-0345-4bc2-9e21-dde0d81e8202
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Kurtz
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: '42'
+  uuid: 95b4e9c0-fc6f-4b2c-b083-89c4bcbcacba
+  subjects:
+  - entities:
+    - role: player
+      name: Mariano Rivera
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '43'
+  uuid: '0398a45d-4bbd-437f-8a09-b6c8dbd4d917'
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Coby Mayo
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '44'
+  uuid: d305d6fd-5e0d-4fa3-8b6b-5b5b656abdf1
+  subjects:
+  - entities:
+    - role: player
+      name: Corbin Carroll
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: '45'
+  uuid: f9d1bbc4-20a1-4a8e-ae4f-cef68cd91187
+  subjects:
+  - entities:
+    - role: player
+      name: Bo Bichette
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '46'
+  uuid: f76f7651-bcec-4fc7-a429-02bfda85f728
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Agustín Ramírez
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: '47'
+  uuid: 0e8eb9d5-bcf7-4b26-9ada-89e8862fb294
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Chase Meidroth
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: '48'
+  uuid: ca2c05bf-c02b-47c5-916d-bd1acbcfd1e1
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Luisangel Acuña
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '49'
+  uuid: db01c240-be42-4bc4-9cac-a59591eaa28d
+  subjects:
+  - entities:
+    - role: player
+      name: Manny Machado
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: '50'
+  uuid: 60830fd1-5ca1-4cbf-8a55-68ecc4b34195
+  subjects:
+  - entities:
+    - role: player
+      name: Barry Bonds
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '51'
+  uuid: 06000e11-e25b-4165-b6ab-901292c9038e
+  subjects:
+  - entities:
+    - role: player
+      name: Francisco Lindor
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '52'
+  uuid: 941ebc67-05ae-4b3b-b607-ba958318c9ce
+  subjects:
+  - entities:
+    - role: player
+      name: Max Scherzer
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '53'
+  uuid: 558e6187-5988-49fb-974f-ae160045b90a
+  subjects:
+  - entities:
+    - role: player
+      name: Ryne Sandberg
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '54'
+  uuid: 5f89d568-970b-4194-905b-8d78e577f21e
+  subjects:
+  - entities:
+    - role: player
+      name: Julio Rodríguez
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: '55'
+  uuid: 6f3c529e-55b7-4df7-b2ab-74845bf2be68
+  subjects:
+  - entities:
+    - role: player
+      name: Carlos Correa
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: '56'
+  uuid: 1a7eea75-4730-4c7f-b437-9a11846edfbd
+  subjects:
+  - entities:
+    - role: player
+      name: José Ramírez
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '57'
+  uuid: 97ca01fc-642d-48d1-adfa-a0bd504a358c
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Moisés Ballesteros
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '58'
+  uuid: 5eefce90-6fb7-4177-be58-8928ff3182c4
+  subjects:
+  - entities:
+    - role: player
+      name: George Brett
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: '59'
+  uuid: 62ce1448-c809-4528-a4d3-18de97087a75
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Crow-Armstrong
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '60'
+  uuid: aa0ff9ff-2a58-4fbe-a299-683b2b5cc3e1
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Jobe
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '61'
+  uuid: 25269484-cca3-421a-8200-4ab0f56fd834
+  subjects:
+  - entities:
+    - role: player
+      name: Sammy Sosa
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '62'
+  uuid: 9e8d6381-7907-4e78-b639-af41efede036
+  subjects:
+  - entities:
+    - role: player
+      name: Joey Votto
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '63'
+  uuid: 2780fc9d-7bcd-4f56-b86d-a5f835480482
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Chase Dollander
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: '64'
+  uuid: 38d7547e-59d7-4ae0-b7b8-617649ef329f
+  subjects:
+  - entities:
+    - role: player
+      name: Babe Ruth
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '65'
+  uuid: 538e8940-695a-49e0-9ecb-9f1076014111
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Chase Petty
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '66'
+  uuid: 81701c3d-9f63-413e-be22-71cfb0925529
+  subjects:
+  - entities:
+    - role: player
+      name: Cal Ripken Jr.
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '67'
+  uuid: e7925cff-ee1e-4a01-9995-97ac88ae68c2
+  subjects:
+  - entities:
+    - role: player
+      name: Pedro Martinez
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '68'
+  uuid: 579214b9-de90-4938-8188-59317153e286
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Dylan Crews
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: '69'
+  uuid: b4850461-60f3-4b28-a0e0-c7af21deaea6
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Holliday
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '70'
+  uuid: dc19723f-7704-4a3e-b32c-c60d2f8bfeac
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Cam Smith
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '71'
+  uuid: 7fa5177f-ea0d-4af8-97a2-b7737090de96
+  subjects:
+  - entities:
+    - role: player
+      name: Greg Maddux
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: '72'
+  uuid: 77d74522-9c39-4aa4-86e1-b40caf834460
+  subjects:
+  - entities:
+    - role: player
+      name: Miguel Cabrera
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '73'
+  uuid: d43f743a-8ee2-41d3-89f3-7d19413f59ba
+  subjects:
+  - entities:
+    - role: player
+      name: Albert Pujols
+      ref: 
+    - role: team
+      name: Angels
+      ref: 
+- number: '74'
+  uuid: 37bee28e-09a4-4bb8-aa83-5d86852e10e5
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Cade Horton
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '75'
+  uuid: 6f952395-fae5-461d-9f06-a4c0076716c7
+  subjects:
+  - entities:
+    - role: player
+      name: Chase Utley
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: '76'
+  uuid: 92c8a359-983e-467c-827a-be4cd75a7bd2
+  subjects:
+  - entities:
+    - role: player
+      name: Sandy Koufax
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '77'
+  uuid: 5b296a28-db59-411f-9cb5-320f4da685cb
+  subjects:
+  - entities:
+    - role: player
+      name: Shota Imanaga
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '78'
+  uuid: 62524f4d-2e74-4daa-a59d-f1b60fcae7f7
+  subjects:
+  - entities:
+    - role: player
+      name: Christian Yelich
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: '79'
+  uuid: f6e00db8-8b2d-4841-9be7-10cf1d5cbdb6
+  subjects:
+  - entities:
+    - role: player
+      name: Buster Posey
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '80'
+  uuid: a5b2b3c6-6c16-4783-b2bc-44180ec55123
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Luke Keaschall
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: '81'
+  uuid: 62cfb04f-bbb0-4b73-9337-4e9f2c8c5628
+  subjects:
+  - entities:
+    - role: player
+      name: Gerrit Cole
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '82'
+  uuid: 914f5162-72f9-4e86-8a34-d6f235951a72
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Edgar Quero
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: '83'
+  uuid: 076cc09a-d6ff-4fa1-8548-a10c59977299
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Kevin Alcántara
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '84'
+  uuid: 2bd70769-8137-46c0-b666-a0b14a0fc2ab
+  subjects:
+  - entities:
+    - role: player
+      name: Freddie Freeman
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '85'
+  uuid: f85fff5a-1e4f-45df-927c-f06ff32013ea
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: James Wood
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: '86'
+  uuid: 63602fd1-8d04-4706-b222-af30bf83fad6
+  subjects:
+  - entities:
+    - role: player
+      name: Orel Hershiser
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '87'
+  uuid: 2bdfdb4e-00c7-45e1-b94b-1e0afd26015a
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Connor Norby
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: '88'
+  uuid: 6e60f4f0-0dbc-45a8-ba41-9b632d68e45c
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Rhett Lowder
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '89'
+  uuid: c2cde1da-2034-4e70-bdea-b47fc2c24e19
+  subjects:
+  - entities:
+    - role: player
+      name: Ichiro
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: '90'
+  uuid: 1ae5a055-659c-4ed7-99b9-8277c2ae65cf
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Wilson
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: '91'
+  uuid: c36f7902-fa37-4be4-864a-0f3f3941f22c
+  subjects:
+  - entities:
+    - role: player
+      name: Andrew McCutchen
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '92'
+  uuid: ff63eab2-05c5-4d51-b007-d5d3e2a2699d
+  subjects:
+  - entities:
+    - role: player
+      name: Ozzie Smith
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: '93'
+  uuid: f5321ae7-2ad1-45bb-ad89-b40485021cc9
+  subjects:
+  - entities:
+    - role: player
+      name: Yadier Molina
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: '94'
+  uuid: 4c6ba9c4-ad56-47cd-8c26-4ade2874b08a
+  subjects:
+  - entities:
+    - role: player
+      name: Ken Griffey Jr.
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: '95'
+  uuid: 82e4d251-c3e9-4325-a932-55d40f9d30b6
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob deGrom
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: '96'
+  uuid: '08701878-44e2-4900-88a1-6306a9b15ef0'
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Hyeseong Kim
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '97'
+  uuid: d878a74b-e912-41d0-93d3-91bf74bf6660
+  subjects:
+  - entities:
+    - role: player
+      name: Reggie Jackson
+      ref: 
+    - role: team
+      name: Oakland Athletics
+      ref: 
+- number: '98'
+  uuid: 8c2792b8-100a-41d6-a5ee-cab5c1850774
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Zac Veen
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: '99'
+  uuid: 1bd04a82-608d-4e98-ad71-6fe2edd2ebf4
+  subjects:
+  - entities:
+    - role: player
+      name: Aaron Judge
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '100'
+  uuid: 52e5a857-e27c-4625-9ace-f9dc3334b912
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Chourio
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 

--- a/data/baseball/2025-26-topps-transcendent/checklists/cut-signature-booklets.yaml
+++ b/data/baseball/2025-26-topps-transcendent/checklists/cut-signature-booklets.yaml
@@ -1,0 +1,150 @@
+- number: CSRB-EM
+  uuid: d6ccd1bb-3e6e-471e-b51b-3e3ae53c41cf
+  subjects:
+  - entities:
+    - role: player
+      name: Eddie Mathews
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: CSRB-GP
+  uuid: a9963990-0c09-410e-90b4-833d35255880
+  subjects:
+  - entities:
+    - role: player
+      name: Gaylord Perry
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: CSRB-HA
+  uuid: da08b98e-c7f9-4ab7-9410-03b848a0010a
+  subjects:
+  - entities:
+    - role: player
+      name: Hank Aaron
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: CSRB-HK
+  uuid: 8ec20b3c-734b-4a10-aa91-0920bda65ffd
+  subjects:
+  - entities:
+    - role: player
+      name: Harmon Killebrew
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: CSRB-KP
+  uuid: f783f40e-bce1-459e-8378-e264dfc92a15
+  subjects:
+  - entities:
+    - role: player
+      name: Kirby Puckett
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: CSRB-LB
+  uuid: c8035ccf-3a84-4693-9eb0-fc26713da923
+  subjects:
+  - entities:
+    - role: player
+      name: Lou Brock
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: CSRB-MM
+  uuid: 2202c8ca-03cd-4b48-b6e2-41805cb5463a
+  subjects:
+  - entities:
+    - role: player
+      name: Mickey Mantle
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: CSRB-RC
+  uuid: 44f93b87-e84d-4d1c-a35f-d11fb594db76
+  subjects:
+  - entities:
+    - role: player
+      name: Roberto Clemente
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: CSRB-RH
+  uuid: 740ace21-fa46-4a58-9412-6cc4c55afb3f
+  subjects:
+  - entities:
+    - role: player
+      name: Rogers Hornsby
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: CSRB-RS
+  uuid: 8de51f4a-134a-4f83-8fad-6942eafad148
+  subjects:
+  - entities:
+    - role: player
+      name: Ron Santo
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: CSRB-RU
+  uuid: f27b3c9e-fefd-4fcc-961b-af250857cf6e
+  subjects:
+  - entities:
+    - role: player
+      name: Babe Ruth
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: CSRB-SM
+  uuid: cc3d97f2-9bda-4196-a558-e3e7a8cef3da
+  subjects:
+  - entities:
+    - role: player
+      name: Stan Musial
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: CSRB-TM
+  uuid: 19102592-2ee3-4474-b31f-ab0811220046
+  subjects:
+  - entities:
+    - role: player
+      name: Thurman Munson
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: CSRB-WM
+  uuid: 8352debe-b36c-4875-b1c4-eeaa95a6dab1
+  subjects:
+  - entities:
+    - role: player
+      name: Willie Mays
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: CSRB-WS
+  uuid: a5acbb1b-9a23-4020-8542-0d5afa3f1611
+  subjects:
+  - entities:
+    - role: player
+      name: Willie Stargell
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 

--- a/data/baseball/2025-26-topps-transcendent/checklists/cut-signatures.yaml
+++ b/data/baseball/2025-26-topps-transcendent/checklists/cut-signatures.yaml
@@ -1,0 +1,430 @@
+- number: CS-BD
+  uuid: ffc48977-2e29-490e-9f1d-60cf71004f52
+  subjects:
+  - entities:
+    - role: player
+      name: Bobby Doerr
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: CS-BG
+  uuid: 15898e71-a76e-454a-97ce-56a9d414f28a
+  subjects:
+  - entities:
+    - role: player
+      name: Bob Gibson
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: CS-BR2
+  uuid: f02e36e7-1984-433f-8bd7-b501287a3675
+  subjects:
+  - entities:
+    - role: player
+      name: Babe Ruth
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: CS-CH
+  uuid: f96982de-4e18-4df2-86df-cf8d190bcbf2
+  subjects:
+  - entities:
+    - role: player
+      name: Catfish Hunter
+      ref: 
+    - role: team
+      name: Oakland Athletics
+      ref: 
+- number: CS-CH2
+  uuid: 0ad38d4b-e9b5-404d-8ca2-d2f2cd605cd1
+  subjects:
+  - entities:
+    - role: player
+      name: Catfish Hunter
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: CS-CST
+  uuid: 7d866268-8480-47ef-97e3-c61e3de681da
+  subjects:
+  - entities:
+    - role: player
+      name: Casey Stengel
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: CS-CY
+  uuid: 8e02da83-e27a-484d-b3c1-1a36a633dc8b
+  subjects:
+  - entities:
+    - role: player
+      name: Cy Young
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: CS-DD
+  uuid: d7d048a3-f8ef-4073-acbc-283a1bf7cb25
+  subjects:
+  - entities:
+    - role: player
+      name: Dizzy Dean
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: CS-DL
+  uuid: 522da1d2-b3da-4d13-921a-604b2a7899c3
+  subjects:
+  - entities:
+    - role: player
+      name: Don Larsen
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: CS-DS
+  uuid: 6799dacf-a209-4769-9c56-37e653a55eeb
+  subjects:
+  - entities:
+    - role: player
+      name: Don Sutton
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: CS-DSN
+  uuid: 84689c86-86b2-445c-a843-e0b116b69e9e
+  subjects:
+  - entities:
+    - role: player
+      name: Duke Snider
+      ref: 
+    - role: team
+      name: Brooklyn Dodgers
+      ref: 
+- number: CS-EB
+  uuid: 4c5f6e22-6300-4def-ae1d-143e33f740c1
+  subjects:
+  - entities:
+    - role: player
+      name: Ernie Banks
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: CS-ES
+  uuid: 2ef3d763-531c-401a-a94b-5bbe3740ff55
+  subjects:
+  - entities:
+    - role: player
+      name: Enos Slaughter
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: CS-EW
+  uuid: 6da774fd-e6b2-4ef2-812e-0e7b15d7464c
+  subjects:
+  - entities:
+    - role: player
+      name: Earl Weaver
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: CS-GC
+  uuid: 5085f65a-b453-4af1-b793-d6d8791350ff
+  subjects:
+  - entities:
+    - role: player
+      name: Gary Carter
+      ref: 
+    - role: team
+      name: Montréal Expos
+      ref: 
+- number: CS-HA
+  uuid: cc7bcb85-94fb-498b-80ed-f8908827d505
+  subjects:
+  - entities:
+    - role: player
+      name: Hank Aaron
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: CS-HG
+  uuid: 3fe74771-ea13-426e-a1cc-5c355fd36be3
+  subjects:
+  - entities:
+    - role: player
+      name: Hank Greenberg
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: CS-HKI
+  uuid: 7d1f2c8d-dab8-4698-94c4-8cfb13023007
+  subjects:
+  - entities:
+    - role: player
+      name: Harmon Killebrew
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: CS-HN
+  uuid: cef845ab-bb0f-4c46-9ce9-1e091b1e5f47
+  subjects:
+  - entities:
+    - role: player
+      name: Hal Newhouser
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: CS-JB
+  uuid: 2424a4cc-f296-4e30-80e3-7665ab872356
+  subjects:
+  - entities:
+    - role: player
+      name: Jim Bunning
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: CS-JMI
+  uuid: 98bc6f57-c09b-4fcc-b0de-3a132a3f2055
+  subjects:
+  - entities:
+    - role: player
+      name: Johnny Mize
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: CS-JR
+  uuid: 6557214d-779e-401d-aa8f-b894b0b8b64d
+  subjects:
+  - entities:
+    - role: player
+      name: Jackie Robinson
+      ref: 
+    - role: team
+      name: Brooklyn Dodgers
+      ref: 
+- number: CS-KP
+  uuid: 45b3ff42-8cd6-4e14-939a-cfe28ac3cac3
+  subjects:
+  - entities:
+    - role: player
+      name: Kirby Puckett
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: CS-LB
+  uuid: b3e82225-97ab-48b4-85bb-21bc6a761532
+  subjects:
+  - entities:
+    - role: player
+      name: Lou Brock
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: CS-LT
+  uuid: a44d0195-be50-45c7-bc14-ae72033fb313
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Tiant
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: CS-MI
+  uuid: 1b8a185f-39ab-45a2-b383-d71cbeda2ea7
+  subjects:
+  - entities:
+    - role: player
+      name: Monte Irvin
+      ref: 
+    - role: team
+      name: New York Giants
+      ref: 
+- number: CS-NF
+  uuid: 8b56371d-d0b4-40cd-9372-7cd3540bbc8e
+  subjects:
+  - entities:
+    - role: player
+      name: Nellie Fox
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: CS-OC
+  uuid: f08457e7-487a-4b14-9534-e4bb216e4897
+  subjects:
+  - entities:
+    - role: player
+      name: Orlando Cepeda
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: CS-PRI
+  uuid: 002464e6-7364-4fbd-83dd-3e74d6075dc1
+  subjects:
+  - entities:
+    - role: player
+      name: Phil Rizzuto
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: CS-RC
+  uuid: 46bf34f9-ec5b-4e45-af86-a51d7b747187
+  subjects:
+  - entities:
+    - role: player
+      name: Roy Campanella
+      ref: 
+    - role: team
+      name: Brooklyn Dodgers
+      ref: 
+- number: CS-RK
+  uuid: 8ca5cb42-307b-4e03-8e69-2b0ca2b05d12
+  subjects:
+  - entities:
+    - role: player
+      name: Ralph Kiner
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: CS-RM
+  uuid: 1f344324-998d-42b0-9230-c61fbb5e3ae3
+  subjects:
+  - entities:
+    - role: player
+      name: Roger Maris
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: CS-RMA
+  uuid: b5eaa296-7c8a-4ead-b412-1287eba7dc56
+  subjects:
+  - entities:
+    - role: player
+      name: Roger Maris
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: CS-RS
+  uuid: 074f5184-b059-4fa2-afe2-d738d80017b7
+  subjects:
+  - entities:
+    - role: player
+      name: Red Schoendienst
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: CS-RSA
+  uuid: 7c9e9819-1902-4bd5-b177-fe029d6d040c
+  subjects:
+  - entities:
+    - role: player
+      name: Ron Santo
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: CS-SM
+  uuid: cd2e8689-86b9-4336-97a4-d0130eff5dd8
+  subjects:
+  - entities:
+    - role: player
+      name: Stan Musial
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: CS-TS
+  uuid: a307e254-643c-4717-9dea-1b835a570ebc
+  subjects:
+  - entities:
+    - role: player
+      name: Tom Seaver
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: CS-TSP
+  uuid: d20785af-3c3e-49a7-9739-7ff9426edb50
+  subjects:
+  - entities:
+    - role: player
+      name: Tris Speaker
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: CS-TW
+  uuid: bbc99db7-99ac-4f98-badb-050514f1d6f4
+  subjects:
+  - entities:
+    - role: player
+      name: Ted Williams
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: CS-WF
+  uuid: e3b6437b-f2e8-4f51-8208-2240ddec36db
+  subjects:
+  - entities:
+    - role: player
+      name: Whitey Ford
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: CS-WM
+  uuid: 3e937db2-d498-42e9-bb73-50d713d7e68e
+  subjects:
+  - entities:
+    - role: player
+      name: Willie Mays
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: CS-WSP
+  uuid: bd127746-3a0b-41f9-a2ee-9b3d539ee276
+  subjects:
+  - entities:
+    - role: player
+      name: Warren Spahn
+      ref: 
+    - role: team
+      name: Milwaukee Braves
+      ref: 
+- number: CS-YB
+  uuid: de60260b-90a7-4905-aba6-5d452b99e5d4
+  subjects:
+  - entities:
+    - role: player
+      name: Yogi Berra
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 

--- a/data/baseball/2025-26-topps-transcendent/checklists/dual-cut-signature-booklets.yaml
+++ b/data/baseball/2025-26-topps-transcendent/checklists/dual-cut-signature-booklets.yaml
@@ -1,0 +1,120 @@
+- number: DCSB-DJG
+  uuid: 1c0c0197-4d4b-4673-a39f-b43b597e6396
+  subjects:
+  - entities:
+    - role: player
+      name: Lou Gehrig
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+  - entities:
+    - role: player
+      name: Aaron Judge
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+  - entities:
+    - role: player
+      name: Joe DiMaggio
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: DCSB-KRR
+  uuid: 6f326904-fbaa-4866-ab8d-74c1e1449cf0
+  subjects:
+  - entities:
+    - role: player
+      name: Jackie Robinson
+      ref: 
+    - role: team
+      name: Brooklyn Dodgers
+      ref: 
+  - entities:
+    - role: player
+      name: Sandy Koufax
+      ref: 
+    - role: team
+      name: Brooklyn Dodgers
+      ref: 
+  - entities:
+    - role: player
+      name: Pee Wee Reese
+      ref: 
+    - role: team
+      name: Brooklyn Dodgers
+      ref: 
+- number: DCSB-PGY
+  uuid: 3e1481b4-b9d0-4f01-b768-400f3b95301e
+  subjects:
+  - entities:
+    - role: player
+      name: Lefty Grove
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+  - entities:
+    - role: player
+      name: Pedro Martínez
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+  - entities:
+    - role: player
+      name: Cy Young
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: DCSB-PMG
+  uuid: 88f23052-1577-4a26-8d39-847c43a30a0a
+  subjects:
+  - entities:
+    - role: player
+      name: Bob Gibson
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+  - entities:
+    - role: player
+      name: Stan Musial
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+  - entities:
+    - role: player
+      name: Albert Pujols
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: DCSB-SBC
+  uuid: 77838900-2b0f-4ed6-a3eb-85ba8f53ef82
+  subjects:
+  - entities:
+    - role: player
+      name: Barry Bonds
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+  - entities:
+    - role: player
+      name: Willie Stargell
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+  - entities:
+    - role: player
+      name: Roberto Clemente
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 

--- a/data/baseball/2025-26-topps-transcendent/checklists/gemstones.yaml
+++ b/data/baseball/2025-26-topps-transcendent/checklists/gemstones.yaml
@@ -1,0 +1,54 @@
+- number: CFCS
+  uuid: '08f0e5bc-0699-4c0b-80b6-0c6f7b9ff292'
+  subjects:
+  - entities:
+    - role: player
+      name: Carlton Fisk
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: CRCS
+  uuid: 90c3a7f3-ce01-453f-af35-aead08ac053b
+  subjects:
+  - entities:
+    - role: player
+      name: Lou Gehrig
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+  - entities:
+    - role: player
+      name: Cal Ripken Jr.
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: CYCS
+  uuid: 690e1638-afb7-4e54-9738-794b066baeac
+  subjects:
+  - entities:
+    - role: player
+      name: Cy Young
+      ref: 
+    - role: team
+      name: Cleveland Naps
+      ref: 
+- number: PRCS
+  uuid: 3e19b508-6a38-426b-9688-b95617ec1498
+  subjects:
+  - entities:
+    - role: player
+      name: Ty Cobb
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+  - entities:
+    - role: player
+      name: Pete Rose
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 

--- a/data/baseball/2025-26-topps-transcendent/checklists/mlb-logo-autograph-patch-card.yaml
+++ b/data/baseball/2025-26-topps-transcendent/checklists/mlb-logo-autograph-patch-card.yaml
@@ -1,0 +1,320 @@
+- number: MLBPA-AJ
+  uuid: e42243fd-9f59-407e-9ad6-523a394ca52d
+  subjects:
+  - entities:
+    - role: player
+      name: Aaron Judge
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: MLBPA-AP
+  uuid: 2aea1133-cd37-443d-9e82-7f624631fada
+  subjects:
+  - entities:
+    - role: player
+      name: Albert Pujols
+      ref: 
+    - role: team
+      name: Angels
+      ref: 
+- number: MLBPA-BL
+  uuid: 815ca959-a51a-4b6d-88e0-ff0db2094087
+  subjects:
+  - entities:
+    - role: player
+      name: Brooks Lee
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: MLBPA-CA
+  uuid: 8c0f0aa8-dc01-44b7-afcb-92ce7788d141
+  subjects:
+  - entities:
+    - role: player
+      name: Cam Smith
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: MLBPA-CC
+  uuid: 6c42d242-3db9-48f5-96c6-403e9db80511
+  subjects:
+  - entities:
+    - role: player
+      name: Corbin Carroll
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: MLBPA-CK
+  uuid: '09b20e96-13af-4f36-b236-946665bc5758'
+  subjects:
+  - entities:
+    - role: player
+      name: Clayton Kershaw
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: MLBPA-CR
+  uuid: 2bd343d6-42d3-4856-8612-0512ce37b49b
+  subjects:
+  - entities:
+    - role: player
+      name: Cal Raleigh
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: MLBPA-CS
+  uuid: a2e24dae-b71f-4ad4-846b-38dc9467b016
+  subjects:
+  - entities:
+    - role: player
+      name: Corey Seager
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: MLBPA-DC
+  uuid: 0b712ad8-12d8-4a38-839c-7e8837de18f5
+  subjects:
+  - entities:
+    - role: player
+      name: Dylan Crews
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: MLBPA-DJ
+  uuid: f678b8b2-9331-40e8-93b5-9d9c51230bdf
+  subjects:
+  - entities:
+    - role: player
+      name: Derek Jeter
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: MLBPA-DO
+  uuid: e4254148-60be-4d0e-98ba-15eb450e7820
+  subjects:
+  - entities:
+    - role: player
+      name: David Ortiz
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: MLBPA-FL
+  uuid: 3ba91d9d-81d1-4d86-ae30-ee661cd0b91f
+  subjects:
+  - entities:
+    - role: player
+      name: Francisco Lindor
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: MLBPA-GH
+  uuid: 9950acd2-1f57-451a-b3bd-730c81c8d914
+  subjects:
+  - entities:
+    - role: player
+      name: Gunnar Henderson
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: MLBPA-I
+  uuid: 072f563d-d453-4ec8-91fa-beadd35afeb9
+  subjects:
+  - entities:
+    - role: player
+      name: Ichiro
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: MLBPA-JR
+  uuid: b6d37e25-3d16-4f90-800d-878a2831c553
+  subjects:
+  - entities:
+    - role: player
+      name: José Ramírez
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: MLBPA-JS
+  uuid: 23118f0c-9850-4a5b-91f6-68721c8791b4
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: MLBPA-JV
+  uuid: c686ad22-bda8-4800-82b5-3a5326f517b6
+  subjects:
+  - entities:
+    - role: player
+      name: Joey Votto
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: MLBPA-JW
+  uuid: 5c96c88e-f7e3-4179-8eb9-0a29289ae477
+  subjects:
+  - entities:
+    - role: player
+      name: James Wood
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: MLBPA-JWI
+  uuid: 975ecff7-328f-496d-8b5d-d2b34c4cb28c
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Wilson
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: MLBPA-KC
+  uuid: 11fa0368-6aaf-4558-ae01-84e0a56e6220
+  subjects:
+  - entities:
+    - role: player
+      name: Kristian Campbell
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: MLBPA-MA
+  uuid: 55e496a3-d6e6-4b27-b736-ca98886f8132
+  subjects:
+  - entities:
+    - role: player
+      name: Matt Shaw
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: MLBPA-MM
+  uuid: badedb65-b3f7-4721-9230-6b39bd84fad6
+  subjects:
+  - entities:
+    - role: player
+      name: Manny Machado
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: MLBPA-MMY
+  uuid: aa32d001-cf85-4068-813d-deea5e64ac6a
+  subjects:
+  - entities:
+    - role: player
+      name: Marcelo Mayer
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: MLBPA-MR
+  uuid: 61c1bc98-d25f-4c95-8e5d-2d9fa342efc2
+  subjects:
+  - entities:
+    - role: player
+      name: Mariano Rivera
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: MLBPA-MT
+  uuid: f08b1649-ea92-4b0f-859c-8036188b78be
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Trout
+      ref: 
+    - role: team
+      name: Angels
+      ref: 
+- number: MLBPA-NA
+  uuid: 797c8465-e1c8-481c-a4d7-a9c9511cc8cb
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan Arenado
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: MLBPA-NK
+  uuid: 0e720dd4-79f0-4d89-a482-70e9fd004eb3
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Kurtz
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: MLBPA-PCA
+  uuid: 0a5e886f-74ef-4891-97f7-3953b5f0ae72
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Crow-Armstrong
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: MLBPA-RAJ
+  uuid: bf5373ce-53d2-4983-ae4d-342245ca4526
+  subjects:
+  - entities:
+    - role: player
+      name: Ronald Acuña Jr.
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: MLBPA-RJ
+  uuid: 40a8e96d-7934-42b8-878b-b386b52fbcdc
+  subjects:
+  - entities:
+    - role: player
+      name: Randy Johnson
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: MLBPA-RS
+  uuid: 66ec5968-e82c-40e4-a099-e8bb569074ee
+  subjects:
+  - entities:
+    - role: player
+      name: Roki Sasaki
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: MLBPA-SO
+  uuid: 48dfadf9-3ac9-4d92-8c18-f5f9e7677226
+  subjects:
+  - entities:
+    - role: player
+      name: Shohei Ohtani
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 

--- a/data/baseball/2025-26-topps-transcendent/checklists/oversized-quad-cut-signatures.yaml
+++ b/data/baseball/2025-26-topps-transcendent/checklists/oversized-quad-cut-signatures.yaml
@@ -1,0 +1,31 @@
+- number: OQCS-RACM
+  uuid: 17a8f466-0135-4286-a383-7048ed188644
+  subjects:
+  - entities:
+    - role: player
+      name: Roberto Clemente
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+  - entities:
+    - role: player
+      name: Hank Aaron
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+  - entities:
+    - role: player
+      name: Willie Mays
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+  - entities:
+    - role: player
+      name: Babe Ruth
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 

--- a/data/baseball/2025-26-topps-transcendent/checklists/record-breaking-autograph-relic.yaml
+++ b/data/baseball/2025-26-topps-transcendent/checklists/record-breaking-autograph-relic.yaml
@@ -1,0 +1,10 @@
+- number: RBA-NK
+  uuid: b92c263d-c016-43f9-ba61-75fb3511596a
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Kurtz
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 

--- a/data/baseball/2025-26-topps-transcendent/checklists/record-breaking-mlb-logo-patch-autographed-relic.yaml
+++ b/data/baseball/2025-26-topps-transcendent/checklists/record-breaking-mlb-logo-patch-autographed-relic.yaml
@@ -1,0 +1,10 @@
+- number: RBA-NK
+  uuid: 643052be-63f1-473c-8cc3-f411f66dd6db
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Kurtz
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 

--- a/data/baseball/2025-26-topps-transcendent/checklists/through-the-years-dual-autographs.yaml
+++ b/data/baseball/2025-26-topps-transcendent/checklists/through-the-years-dual-autographs.yaml
@@ -1,0 +1,136 @@
+- number: IG-1984
+  uuid: a89daf9a-f38b-415e-8482-4b7ded92eb4f
+  subjects:
+  - entities:
+    - role: player
+      name: Ken Griffey Jr.
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+  - entities:
+    - role: player
+      name: Ichiro
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: JJ-1971
+  uuid: 89bd72dd-32c6-4218-8981-4faeb3ea5144
+  subjects:
+  - entities:
+    - role: player
+      name: Derek Jeter
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+  - entities:
+    - role: player
+      name: Reggie Jackson
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: JJU-2004
+  uuid: 649a034e-e861-4261-817a-3b07048646fa
+  subjects:
+  - entities:
+    - role: player
+      name: Aaron Judge
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+  - entities:
+    - role: player
+      name: Derek Jeter
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: KK-1959
+  uuid: b483b8ff-4ac7-42f9-a2f1-02254818afbe
+  subjects:
+  - entities:
+    - role: player
+      name: Clayton Kershaw
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+  - entities:
+    - role: player
+      name: Sandy Koufax
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: OS-2019
+  uuid: 9e7abc54-e109-4aee-b3d5-9683c7c940fa
+  subjects:
+  - entities:
+    - role: player
+      name: Roki Sasaki
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+  - entities:
+    - role: player
+      name: Shohei Ohtani
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: PM-1966
+  uuid: cc774c4c-b845-46bb-bafe-fe279fcc2dc1
+  subjects:
+  - entities:
+    - role: player
+      name: Mark McGwire
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+  - entities:
+    - role: player
+      name: Albert Pujols
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: SP-1960
+  uuid: 469e14c4-93d2-4e65-bbb4-13303ef45f41
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Piazza
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: TP-1963
+  uuid: 9f3b4129-b456-4934-a668-6f950949d55d
+  subjects:
+  - entities:
+    - role: player
+      name: Albert Pujols
+      ref: 
+    - role: team
+      name: Angels
+      ref: 
+  - entities:
+    - role: player
+      name: Mike Trout
+      ref: 
+    - role: team
+      name: Angels
+      ref: 

--- a/data/baseball/2025-26-topps-transcendent/checklists/transcendent-autograph-relic.yaml
+++ b/data/baseball/2025-26-topps-transcendent/checklists/transcendent-autograph-relic.yaml
@@ -1,0 +1,510 @@
+- number: TCAR-AJ
+  uuid: 411a82f8-51a4-440d-8cdd-fa2a515a4a8d
+  subjects:
+  - entities:
+    - role: player
+      name: Aaron Judge
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: TCAR-AP
+  uuid: f6ef815c-43ed-4691-9c9f-1dee0ab94a59
+  subjects:
+  - entities:
+    - role: player
+      name: Albert Pujols
+      ref: 
+    - role: team
+      name: Angels
+      ref: 
+- number: TCAR-BAG
+  uuid: 371a0449-4688-40fb-9c8f-47091f45e3c1
+  subjects:
+  - entities:
+    - role: player
+      name: Jeff Bagwell
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: TCAR-BB
+  uuid: 514d8dda-4098-40a6-ab0a-ca6ad32ac295
+  subjects:
+  - entities:
+    - role: player
+      name: Barry Bonds
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: TCAR-BJ
+  uuid: f71d7732-7358-4ce2-98a4-91e679e90d73
+  subjects:
+  - entities:
+    - role: player
+      name: Bo Jackson
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: TCAR-BL
+  uuid: bd16e0ca-fa67-46d5-a21b-95deb0d79b5f
+  subjects:
+  - entities:
+    - role: player
+      name: Brooks Lee
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: TCAR-BR
+  uuid: a95b809a-3387-415e-9da4-049301c5ea66
+  subjects:
+  - entities:
+    - role: player
+      name: Ben Rice
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: TCAR-CCS
+  uuid: a16ac637-d79a-4b43-9f80-a5934d9791b0
+  subjects:
+  - entities:
+    - role: player
+      name: CC Sabathia
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: TCAR-CK
+  uuid: 68d8a228-e1fc-4e0b-8d72-158c650b1dc6
+  subjects:
+  - entities:
+    - role: player
+      name: Clayton Kershaw
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: TCAR-CM
+  uuid: b35266b4-b818-429b-a8e6-5059bfd32ab5
+  subjects:
+  - entities:
+    - role: player
+      name: Coby Mayo
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: TCAR-CS
+  uuid: 75cdad69-6ba2-4fa0-9d8c-bc3778139e75
+  subjects:
+  - entities:
+    - role: player
+      name: Corey Seager
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: TCAR-DC
+  uuid: d6967614-f6c4-41a1-ae44-02629f4adc35
+  subjects:
+  - entities:
+    - role: player
+      name: Dylan Crews
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: TCAR-DJ
+  uuid: a0b9ef7f-57b1-4801-92fe-242e3e01a9ed
+  subjects:
+  - entities:
+    - role: player
+      name: Derek Jeter
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: TCAR-DO
+  uuid: 4aafe9d7-d4cc-4a0d-bdac-223007aa4856
+  subjects:
+  - entities:
+    - role: player
+      name: David Ortiz
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: TCAR-EM
+  uuid: 80a16d07-5c00-4662-8339-346dc202adab
+  subjects:
+  - entities:
+    - role: player
+      name: Eddie Murray
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: TCAR-FL
+  uuid: 1e826de0-6f13-4e63-8db8-0ba487411402
+  subjects:
+  - entities:
+    - role: player
+      name: Francisco Lindor
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: TCAR-FT
+  uuid: 4688ce7b-3645-44a8-8ada-6f4e56d321e3
+  subjects:
+  - entities:
+    - role: player
+      name: Frank Thomas
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: TCAR-FTJ
+  uuid: 205e1822-c93e-4fe1-991e-89f60b705ba6
+  subjects:
+  - entities:
+    - role: player
+      name: Fernando Tatis Jr.
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: TCAR-GH
+  uuid: 5f60215c-3f0d-4fe4-9c9e-60a22da061d4
+  subjects:
+  - entities:
+    - role: player
+      name: Gunnar Henderson
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: TCAR-IR
+  uuid: a325fb80-efaf-415b-8973-9df4e843bbe0
+  subjects:
+  - entities:
+    - role: player
+      name: Ivan Rodriguez
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: TCAR-JB
+  uuid: d08ba1f2-377e-4877-a9c3-fc41c992128b
+  subjects:
+  - entities:
+    - role: player
+      name: Johnny Bench
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: TCAR-JH
+  uuid: a26150ac-0cde-46ec-81f6-a61f7263feda
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Holliday
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: TCAR-JJ
+  uuid: 03ce7ca0-2120-4733-8c84-788a929686bc
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Jobe
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: TCAR-JRA
+  uuid: 8a049641-916a-4480-ad26-8a2f35a7a851
+  subjects:
+  - entities:
+    - role: player
+      name: José Ramírez
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: TCAR-JS
+  uuid: 484f50db-a7ec-4e5d-8456-95725adc261e
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: TCAR-JSA
+  uuid: b263ede9-d576-42ed-ab38-8cf2957e7493
+  subjects:
+  - entities:
+    - role: player
+      name: Johan Santana
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: TCAR-JV
+  uuid: 65dc912e-d2db-4442-a713-68c8140c9c44
+  subjects:
+  - entities:
+    - role: player
+      name: Joey Votto
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: TCAR-JW
+  uuid: 78c0aea5-0546-430c-9659-677af24f55a1
+  subjects:
+  - entities:
+    - role: player
+      name: James Wood
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: TCAR-JWI
+  uuid: dea84f89-1639-4df7-90cb-b25f76777bdb
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Wilson
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: TCAR-KA
+  uuid: 5b40ca66-945f-4fa4-99de-103091a78203
+  subjects:
+  - entities:
+    - role: player
+      name: Kevin Alcántara
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: TCAR-KC
+  uuid: 3e88855a-a73b-4925-9a70-b14828709baa
+  subjects:
+  - entities:
+    - role: player
+      name: Kristian Campbell
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: TCAR-KG
+  uuid: 33f6a42a-2209-469d-b287-62529c79951b
+  subjects:
+  - entities:
+    - role: player
+      name: Ken Griffey Jr.
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: TCAR-KT
+  uuid: 000a3402-2759-446e-9f11-d7ab1f5a750d
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Tucker
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: TCAR-LAC
+  uuid: b023ab3c-57f0-4e11-9a24-2f27bc7af1ae
+  subjects:
+  - entities:
+    - role: player
+      name: Luisangel Acuña
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: TCAR-MM
+  uuid: d372be26-76cb-41f5-8a54-a18e809bf45d
+  subjects:
+  - entities:
+    - role: player
+      name: Marcelo Mayer
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: TCAR-MP
+  uuid: d71470fb-cab8-4d66-86a2-b00b1545c855
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Piazza
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: TCAR-MR
+  uuid: e1354068-ebe0-4ea3-987c-13b95d85528c
+  subjects:
+  - entities:
+    - role: player
+      name: Mariano Rivera
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: TCAR-MT
+  uuid: b5245625-daee-4c49-b5d9-13460b6bc105
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Trout
+      ref: 
+    - role: team
+      name: Angels
+      ref: 
+- number: TCAR-NA
+  uuid: b4cefe73-7510-498b-beb3-933b229673a6
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan Arenado
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: TCAR-NK
+  uuid: 2c9bc182-7986-413b-a83f-d6aed1570ed3
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Kurtz
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: TCAR-OH
+  uuid: 3b8c5bda-49e8-4398-bd33-b39b5ce9e274
+  subjects:
+  - entities:
+    - role: player
+      name: Orel Hershiser
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: TCAR-PA
+  uuid: 5758a22c-4707-432e-befb-ca6d9ab1566e
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Alonso
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: TCAR-PS
+  uuid: 5759b39d-d077-4db9-a940-0446eca491d9
+  subjects:
+  - entities:
+    - role: player
+      name: Paul Skenes
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: TCAR-RAJ
+  uuid: f8550c47-6716-49d7-9ee7-191f4b2b4145
+  subjects:
+  - entities:
+    - role: player
+      name: Ronald Acuña Jr.
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: TCAR-RC
+  uuid: c10136df-bdbd-4988-b598-80ce91175308
+  subjects:
+  - entities:
+    - role: player
+      name: Roger Clemens
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: TCAR-RJ
+  uuid: baa41998-f03b-4aff-a0fd-49d60bcf0e10
+  subjects:
+  - entities:
+    - role: player
+      name: Randy Johnson
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: TCAR-RS
+  uuid: 82cc0708-9029-4f4e-bb2d-855a5bd879dc
+  subjects:
+  - entities:
+    - role: player
+      name: Roki Sasaki
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: TCAR-SO
+  uuid: 9894aa27-b53c-49a9-b28d-7b3c90d4c750
+  subjects:
+  - entities:
+    - role: player
+      name: Shohei Ohtani
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: TCAR-SS
+  uuid: e3baf28a-76db-4267-bd5d-4c7a1122f04e
+  subjects:
+  - entities:
+    - role: player
+      name: Sammy Sosa
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: TCAR-TT
+  uuid: 3a7a2ba3-b2ae-4645-bb55-f7b7ca139a7c
+  subjects:
+  - entities:
+    - role: player
+      name: Trea Turner
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: TCAR-YY
+  uuid: 93401bd9-de89-4359-9d75-b0bc26cf7bbf
+  subjects:
+  - entities:
+    - role: player
+      name: Yoshinobu Yamamoto
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 

--- a/data/baseball/2025-26-topps-transcendent/checklists/transcendent-collection-dual-patch-autograph-variation.yaml
+++ b/data/baseball/2025-26-topps-transcendent/checklists/transcendent-collection-dual-patch-autograph-variation.yaml
@@ -1,0 +1,170 @@
+- number: DPA-HA
+  uuid: 0a867ff7-4b29-4d93-9943-725480f2ea38
+  subjects:
+  - entities:
+    - role: player
+      name: Michael Harris II
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+  - entities:
+    - role: player
+      name: Ozzie Albies
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: DPA-HH
+  uuid: 3ef182d1-da10-40a9-8bcf-dbb038712bb8
+  subjects:
+  - entities:
+    - role: player
+      name: Gunnar Henderson
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+  - entities:
+    - role: player
+      name: Jackson Holliday
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: DPA-HT
+  uuid: 3af91b03-5f7f-4519-8ff2-25eac6d51c59
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Harper
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+  - entities:
+    - role: player
+      name: Trea Turner
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: DPA-IGJ
+  uuid: f9ab0e9f-cd49-43d6-82d3-c41d788a72bc
+  subjects:
+  - entities:
+    - role: player
+      name: Ichiro
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+  - entities:
+    - role: player
+      name: Ken Griffey Jr.
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: DPA-JJU
+  uuid: 556ea6d7-6ef9-4b47-b1c2-8c9999e6ed81
+  subjects:
+  - entities:
+    - role: player
+      name: Jace Jung
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+  - entities:
+    - role: player
+      name: Josh Jung
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: DPA-JO
+  uuid: 7c5ec063-31a4-4d1e-97be-8edb90994d6d
+  subjects:
+  - entities:
+    - role: player
+      name: Aaron Judge
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+  - entities:
+    - role: player
+      name: Shohei Ohtani
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: DPA-OS
+  uuid: 9248703f-7959-4e8d-9155-8256272a00e3
+  subjects:
+  - entities:
+    - role: player
+      name: Roki Sasaki
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+  - entities:
+    - role: player
+      name: Shohei Ohtani
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: DPA-TP
+  uuid: 0ac502da-1357-4241-91ce-788c06de9819
+  subjects:
+  - entities:
+    - role: player
+      name: Albert Pujols
+      ref: 
+    - role: team
+      name: Angels
+      ref: 
+  - entities:
+    - role: player
+      name: Mike Trout
+      ref: 
+    - role: team
+      name: Angels
+      ref: 
+- number: DPA-WC
+  uuid: 549ce3c5-a68e-4d06-9205-f20e7caae3d0
+  subjects:
+  - entities:
+    - role: player
+      name: James Wood
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+  - entities:
+    - role: player
+      name: Dylan Crews
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: DPA-WK
+  uuid: 31aec18f-db0f-40df-8eb2-9b1e282eee9e
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Kurtz
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+  - entities:
+    - role: player
+      name: Jacob Wilson
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 

--- a/data/baseball/2025-26-topps-transcendent/checklists/transcendent-collection-dual-patches.yaml
+++ b/data/baseball/2025-26-topps-transcendent/checklists/transcendent-collection-dual-patches.yaml
@@ -1,0 +1,680 @@
+- number: TCDP-AA
+  uuid: 9c8ec4ef-ddd6-42ac-9662-9c4498da1f96
+  subjects:
+  - entities:
+    - role: player
+      name: Ozzie Albies
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+  - entities:
+    - role: player
+      name: Ronald Acuña Jr.
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: TCDP-AAL
+  uuid: 6111e1d7-e383-4e1b-acf2-19f752cfb0dc
+  subjects:
+  - entities:
+    - role: player
+      name: Jose Altuve
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+  - entities:
+    - role: player
+      name: Yordan Alvarez
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: TCDP-BB
+  uuid: e12f091a-5534-4441-ae1e-97b8723ed6fd
+  subjects:
+  - entities:
+    - role: player
+      name: Craig Biggio
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+  - entities:
+    - role: player
+      name: Jeff Bagwell
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: TCDP-BM
+  uuid: 6e4f331c-2406-4f59-a9c7-6a44069a0c10
+  subjects:
+  - entities:
+    - role: player
+      name: Yadier Molina
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+  - entities:
+    - role: player
+      name: Lou Brock
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: TCDP-BR
+  uuid: 0e658b22-a1b1-4075-8645-676d81d709c8
+  subjects:
+  - entities:
+    - role: player
+      name: Ivan Rodriguez
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+  - entities:
+    - role: player
+      name: Adrian Beltré
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: TCDP-BS
+  uuid: b47364e3-8fd2-4896-92a3-f242db1e63f8
+  subjects:
+  - entities:
+    - role: player
+      name: Moisés Ballesteros
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+  - entities:
+    - role: player
+      name: Matt Shaw
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: TCDP-CM
+  uuid: 842548d0-b917-4ef3-b000-e381701dc5cd
+  subjects:
+  - entities:
+    - role: player
+      name: Marcelo Mayer
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+  - entities:
+    - role: player
+      name: Kristian Campbell
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: TCDP-CP
+  uuid: 6b037445-d5fa-4162-8a5d-78614f1d2315
+  subjects:
+  - entities:
+    - role: player
+      name: Dustin Pedroia
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+  - entities:
+    - role: player
+      name: Kristian Campbell
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: TCDP-CTO
+  uuid: 980463db-51f0-4891-b1a0-f0b0fc4453cd
+  subjects:
+  - entities:
+    - role: player
+      name: Spencer Torkelson
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+  - entities:
+    - role: player
+      name: Miguel Cabrera
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: TCDP-CV
+  uuid: 96e407aa-32e8-4752-ac40-a3d380d1e5a3
+  subjects:
+  - entities:
+    - role: player
+      name: Jazz Chisholm Jr.
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+  - entities:
+    - role: player
+      name: Anthony Volpe
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: TCDP-DM
+  uuid: 2ca2ddd6-a877-4987-8bc8-97dd83653659
+  subjects:
+  - entities:
+    - role: player
+      name: Fred McGriff
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+  - entities:
+    - role: player
+      name: Johnny Damon
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: TCDP-DY
+  uuid: b64321e1-ec5c-4e78-a04e-112d7a7acab9
+  subjects:
+  - entities:
+    - role: player
+      name: Masataka Yoshida
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+  - entities:
+    - role: player
+      name: Jarren Duran
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: TCDP-GB
+  uuid: 66f54136-0dc5-45b0-bf40-96fa865779dd
+  subjects:
+  - entities:
+    - role: player
+      name: Bo Bichette
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+  - entities:
+    - role: player
+      name: Vladimir Guerrero Jr.
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: TCDP-HR
+  uuid: 751e6a8a-417e-4823-92e6-1098fb510573
+  subjects:
+  - entities:
+    - role: player
+      name: Gunnar Henderson
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+  - entities:
+    - role: player
+      name: Adley Rutschman
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: TCDP-JC
+  uuid: 315b2c37-4651-4c33-9486-f951102281a6
+  subjects:
+  - entities:
+    - role: player
+      name: Aaron Judge
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+  - entities:
+    - role: player
+      name: Gerrit Cole
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: TCDP-JJ
+  uuid: da254561-3fc6-4aa6-8959-ab847ac54b6b
+  subjects:
+  - entities:
+    - role: player
+      name: Jace Jung
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+  - entities:
+    - role: player
+      name: Josh Jung
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: TCDP-KB
+  uuid: '0696a580-5650-4473-bd33-1c6a06f6e98b'
+  subjects:
+  - entities:
+    - role: player
+      name: Mookie Betts
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+  - entities:
+    - role: player
+      name: Clayton Kershaw
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: TCDP-KW
+  uuid: fa30f613-617d-47b7-b338-e1b01a59a003
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Wilson
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+  - entities:
+    - role: player
+      name: Nick Kurtz
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: TCDP-LA
+  uuid: de86c3d2-8ccc-4862-8787-fca2b19e9924
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Alonso
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+  - entities:
+    - role: player
+      name: Francisco Lindor
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: TCDP-LY
+  uuid: f8351289-efe1-4cae-8455-3dd9d095c86e
+  subjects:
+  - entities:
+    - role: player
+      name: Jung Hoo Lee
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+  - entities:
+    - role: player
+      name: Mike Yastrzemski
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: TCDP-MA
+  uuid: 7433a560-5e85-403f-bd44-7ed4ff46e3a6
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Arraez
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+  - entities:
+    - role: player
+      name: Jackson Merrill
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: TCDP-MC
+  uuid: a147b838-8d21-4fad-b772-a09bb8799817
+  subjects:
+  - entities:
+    - role: player
+      name: Andrew McCutchen
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+  - entities:
+    - role: player
+      name: Oneil Cruz
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: TCDP-MCA
+  uuid: c8425f76-82aa-4ae9-b7b7-e7834bd6859d
+  subjects:
+  - entities:
+    - role: player
+      name: Corbin Carroll
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+  - entities:
+    - role: player
+      name: Ketel Marte
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: TCDP-MCC
+  uuid: b642a66b-de03-4c2d-9040-7edf91a9bf91
+  subjects:
+  - entities:
+    - role: player
+      name: Andrew McCutchen
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+  - entities:
+    - role: player
+      name: Roberto Clemente
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: TCDP-MM
+  uuid: cbdbed95-c984-473d-9d4f-de8f4395a12b
+  subjects:
+  - entities:
+    - role: player
+      name: Justin Morneau
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+  - entities:
+    - role: player
+      name: Joe Mauer
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: TCDP-MS
+  uuid: 30549c6d-acd3-4324-b893-dd930360d8c5
+  subjects:
+  - entities:
+    - role: player
+      name: Pedro Martinez
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+  - entities:
+    - role: player
+      name: Kodai Senga
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: TCDP-MT
+  uuid: 26b858ab-c554-4106-b0e3-e26760cd0a0c
+  subjects:
+  - entities:
+    - role: player
+      name: Manny Machado
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+  - entities:
+    - role: player
+      name: Fernando Tatis Jr.
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: TCDP-OR
+  uuid: 96ece97b-55a6-4c2a-92b1-6749a0eafab4
+  subjects:
+  - entities:
+    - role: player
+      name: Manny Ramirez
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+  - entities:
+    - role: player
+      name: David Ortiz
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: TCDP-OY
+  uuid: b0c94669-ebec-4543-8e9b-939d66307c5d
+  subjects:
+  - entities:
+    - role: player
+      name: Yoshinobu Yamamoto
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+  - entities:
+    - role: player
+      name: Shohei Ohtani
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: TCDP-RB
+  uuid: c9436b36-2905-43fe-9056-ad58c65bd584
+  subjects:
+  - entities:
+    - role: player
+      name: José Ramírez
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+  - entities:
+    - role: player
+      name: Shane Bieber
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: TCDP-RC
+  uuid: 158ce828-75c7-4d10-9ceb-2ab4cbd4a31f
+  subjects:
+  - entities:
+    - role: player
+      name: Miguel Cabrera
+      ref: 
+    - role: team
+      name: Florida Marlins
+      ref: 
+  - entities:
+    - role: player
+      name: Ivan Rodriguez
+      ref: 
+    - role: team
+      name: Florida Marlins
+      ref: 
+- number: TCDP-RD
+  uuid: 6e1ee87c-d750-462f-9692-4d3e79adeb0d
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob deGrom
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+  - entities:
+    - role: player
+      name: Kumar Rocker
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: TCDP-RO
+  uuid: 58545334-79fb-4ceb-abe3-09e4d922f1ef
+  subjects:
+  - entities:
+    - role: player
+      name: Matt Olson
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+  - entities:
+    - role: player
+      name: Austin Riley
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: TCDP-SD
+  uuid: ae07bc51-6078-4c79-bc03-a49f22f8a717
+  subjects:
+  - entities:
+    - role: player
+      name: Jasson Domínguez
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+  - entities:
+    - role: player
+      name: Giancarlo Stanton
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: TCDP-SI
+  uuid: 7d92c067-c11c-404e-8b26-7dd2a2534a28
+  subjects:
+  - entities:
+    - role: player
+      name: Seiya Suzuki
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+  - entities:
+    - role: player
+      name: Shota Imanaga
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: TCDP-SM
+  uuid: 36bd6662-cf53-49e2-b7c1-3c5c5920a434
+  subjects:
+  - entities:
+    - role: player
+      name: Greg Maddux
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+  - entities:
+    - role: player
+      name: John Smoltz
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: TCDP-SP
+  uuid: 545a2d34-ee01-4dc7-bee8-c3212738253d
+  subjects:
+  - entities:
+    - role: player
+      name: CC Sabathia
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+  - entities:
+    - role: player
+      name: Jorge Posada
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: TCDP-TB
+  uuid: b12718f4-3e16-4b6e-845f-e91c1950363f
+  subjects:
+  - entities:
+    - role: player
+      name: Mark Buehrle
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+  - entities:
+    - role: player
+      name: Jim Thome
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: TCDP-WC
+  uuid: efc48524-e5dd-401c-ac54-5ac07723a813
+  subjects:
+  - entities:
+    - role: player
+      name: James Wood
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+  - entities:
+    - role: player
+      name: Dylan Crews
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: TCDP-WP
+  uuid: a73f9316-f9bd-4510-a4bb-aa140de23844
+  subjects:
+  - entities:
+    - role: player
+      name: Bobby Witt Jr.
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+  - entities:
+    - role: player
+      name: Salvador Perez
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 

--- a/data/baseball/2025-26-topps-transcendent/checklists/transcendent-collection-gold-framed-autographs.yaml
+++ b/data/baseball/2025-26-topps-transcendent/checklists/transcendent-collection-gold-framed-autographs.yaml
@@ -1,0 +1,920 @@
+- number: TAC-AJ
+  uuid: eeaa34ea-3f08-41a9-b098-a7cba279fe1f
+  subjects:
+  - entities:
+    - role: player
+      name: Aaron Judge
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: TAC-AP
+  uuid: fb140966-e4f8-4589-82d9-1cef19889582
+  subjects:
+  - entities:
+    - role: player
+      name: Albert Pujols
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: TAC-AR
+  uuid: ff31adaa-960f-4166-b286-cac64876ab18
+  subjects:
+  - entities:
+    - role: player
+      name: Adley Rutschman
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: TAC-ARU
+  uuid: 14b89766-acfc-4e59-b605-f2aa5aae79fb
+  subjects:
+  - entities:
+    - role: player
+      name: Adley Rutschman
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: TAC-BB
+  uuid: 102ab914-33c4-45cb-b69e-f1a0ef6ac980
+  subjects:
+  - entities:
+    - role: player
+      name: Barry Bonds
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: TAC-BBO
+  uuid: 26fb24fc-c7d8-4dfa-92a6-acf02f78376e
+  subjects:
+  - entities:
+    - role: player
+      name: Barry Bonds
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: TAC-BH
+  uuid: 3f6c4c4b-72e2-44ae-afc3-fcefdc241400
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Harper
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: TAC-BHA
+  uuid: 7d85e9fb-ffc3-45c2-899f-9377b344a72d
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Harper
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: TAC-BJ
+  uuid: 63841468-c15f-4a09-a213-280bd7b2a2a9
+  subjects:
+  - entities:
+    - role: player
+      name: Bo Jackson
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: TAC-BL
+  uuid: 6f009279-1e4b-41db-bc9c-cb9dacb2f565
+  subjects:
+  - entities:
+    - role: player
+      name: Brooks Lee
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: TAC-BO
+  uuid: 4ffe9971-ac45-4017-b5ea-a4dc29692780
+  subjects:
+  - entities:
+    - role: player
+      name: Bo Jackson
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: TAC-BOB
+  uuid: b694b32a-320b-46fe-af25-85a7160077b9
+  subjects:
+  - entities:
+    - role: player
+      name: Bobby Witt Jr.
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: TAC-CA
+  uuid: 80dc8ebb-3a2c-414d-ad99-7221dd19a72c
+  subjects:
+  - entities:
+    - role: player
+      name: Cam Smith
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: TAC-CC
+  uuid: 60f1a423-1dad-4788-81e5-fb413beb2c20
+  subjects:
+  - entities:
+    - role: player
+      name: Corbin Carroll
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: TAC-CHP
+  uuid: 92f0fe7a-7c87-449a-8c5b-4d75d7107370
+  subjects:
+  - entities:
+    - role: player
+      name: Chan Ho Park
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: TAC-CJ
+  uuid: eb50daf6-4d96-44fc-98f4-b0e6f9a056c7
+  subjects:
+  - entities:
+    - role: player
+      name: Chipper Jones
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: TAC-CJO
+  uuid: bd1e0c24-1fc7-482d-b35f-f6094c04f9b9
+  subjects:
+  - entities:
+    - role: player
+      name: Chipper Jones
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: TAC-CK
+  uuid: e8ad872d-19c9-48f5-84c6-a04d197830b4
+  subjects:
+  - entities:
+    - role: player
+      name: Clayton Kershaw
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: TAC-CKE
+  uuid: 8bc960ff-99f3-41a2-9f2e-82b5dfda255c
+  subjects:
+  - entities:
+    - role: player
+      name: Clayton Kershaw
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: TAC-CP
+  uuid: 2ea01010-1482-4146-adac-eb7e670be986
+  subjects:
+  - entities:
+    - role: player
+      name: Chan Ho Park
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: TAC-CR
+  uuid: eea56fd0-97f6-4b3d-9ad0-154e54c443de
+  subjects:
+  - entities:
+    - role: player
+      name: Cal Ripken Jr.
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: TAC-CRJ
+  uuid: 46d79c55-006d-4df8-ae06-1405f704607e
+  subjects:
+  - entities:
+    - role: player
+      name: Cal Ripken Jr.
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: TAC-CS
+  uuid: ac1acb40-72f0-4e74-8cfb-fdf9e4322d58
+  subjects:
+  - entities:
+    - role: player
+      name: Corey Seager
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: TAC-CSE
+  uuid: d66a0675-1edd-4778-9b56-e5e870d57376
+  subjects:
+  - entities:
+    - role: player
+      name: Corey Seager
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: TAC-CU
+  uuid: 149f68a3-f513-467a-8762-29b3b3bd5ed7
+  subjects:
+  - entities:
+    - role: player
+      name: Chase Utley
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: TAC-DC
+  uuid: b9536079-7221-45ea-b40b-4b8785c4d56d
+  subjects:
+  - entities:
+    - role: player
+      name: Dylan Crews
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: TAC-DCR
+  uuid: a282f21f-08e8-48a2-ae7b-f470bd5bf962
+  subjects:
+  - entities:
+    - role: player
+      name: Dylan Crews
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: TAC-DJ
+  uuid: c65ec6d3-9e0e-46fd-920f-3585ba8b208c
+  subjects:
+  - entities:
+    - role: player
+      name: Derek Jeter
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: TAC-DJE
+  uuid: 8a460646-6600-42d9-a831-8b905d0490e1
+  subjects:
+  - entities:
+    - role: player
+      name: Derek Jeter
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: TAC-DM
+  uuid: 6bb2f800-6149-4e98-b6ad-9b936bbfb20a
+  subjects:
+  - entities:
+    - role: player
+      name: Don Mattingly
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: TAC-DO
+  uuid: 8cbc58ee-3743-44a4-83ee-ad881dcd14ca
+  subjects:
+  - entities:
+    - role: player
+      name: David Ortiz
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: TAC-EDLC
+  uuid: bbe16a52-7cf8-4a1c-81a4-e1052b5d7e5c
+  subjects:
+  - entities:
+    - role: player
+      name: Elly De La Cruz
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: TAC-EM
+  uuid: 2fc719ad-fce7-4570-9c52-3c43e9b689db
+  subjects:
+  - entities:
+    - role: player
+      name: Eddie Murray
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: TAC-FH
+  uuid: fdc54fc8-7a9d-46ba-9f3e-58ad34c4c7d8
+  subjects:
+  - entities:
+    - role: player
+      name: Félix Hernández
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: TAC-FL
+  uuid: 829075a8-c7ff-4519-b0bb-eb7d2df87bd7
+  subjects:
+  - entities:
+    - role: player
+      name: Francisco Lindor
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: TAC-FT
+  uuid: 65fe5d49-6d4d-42ca-a26a-2b72bbb223ba
+  subjects:
+  - entities:
+    - role: player
+      name: Frank Thomas
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: TAC-GB
+  uuid: 1d3c680b-121c-4add-94e9-616781bc2aa1
+  subjects:
+  - entities:
+    - role: player
+      name: George Brett
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: TAC-GBR
+  uuid: 45f70830-f887-4a9c-a1c7-cf7a280489f5
+  subjects:
+  - entities:
+    - role: player
+      name: George Brett
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: TAC-GH
+  uuid: 27a70df8-2930-4480-822d-c0ad1f4af16d
+  subjects:
+  - entities:
+    - role: player
+      name: Gunnar Henderson
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: TAC-GM
+  uuid: 9cbf3cad-8b49-4b5f-a012-1ed506b4b11d
+  subjects:
+  - entities:
+    - role: player
+      name: Greg Maddux
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: TAC-GMX
+  uuid: a055063b-0026-4b13-85dc-6572226ade14
+  subjects:
+  - entities:
+    - role: player
+      name: Greg Maddux
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: TAC-HM
+  uuid: 499362e8-f8bf-4ce0-9df4-2df37a77af5c
+  subjects:
+  - entities:
+    - role: player
+      name: Hideki Matsui
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: TAC-I
+  uuid: 5897eed3-8551-4e65-a476-666427a108e1
+  subjects:
+  - entities:
+    - role: player
+      name: Ichiro
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: TAC-I2
+  uuid: '0787969e-d011-4e0e-95de-82b780785db4'
+  subjects:
+  - entities:
+    - role: player
+      name: Ichiro
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: TAC-JB
+  uuid: 642502b3-dc9b-47b9-b33d-4450d7fd5a06
+  subjects:
+  - entities:
+    - role: player
+      name: Johnny Bench
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: TAC-JBE
+  uuid: 146b1125-efd4-44c3-a3d8-5af53098d824
+  subjects:
+  - entities:
+    - role: player
+      name: Johnny Bench
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: TAC-JH
+  uuid: 63c50803-ca6b-4902-b872-e423bc90a2bf
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Holliday
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: TAC-JJ
+  uuid: 2a3e805d-b046-4df5-9bfa-b765167474e1
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Jobe
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: TAC-JP
+  uuid: 2ef63749-e5c2-4e07-be6a-1c3230fbec4a
+  subjects:
+  - entities:
+    - role: player
+      name: Jorge Posada
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: TAC-JS
+  uuid: f6ae28e6-3fc2-40d2-b979-9c945acdeaac
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: TAC-JSO
+  uuid: f44dce26-74d9-41be-a8a5-754a479162b1
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: TAC-JT
+  uuid: 1f29814d-f5c5-4137-9e1d-68aba7f098f3
+  subjects:
+  - entities:
+    - role: player
+      name: Joe Torre
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: TAC-JTO
+  uuid: e17367c7-926a-45f5-826f-07a55c46c23b
+  subjects:
+  - entities:
+    - role: player
+      name: Joe Torre
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: TAC-JW
+  uuid: 2d71025a-4cae-4afc-906f-af2de23b05e0
+  subjects:
+  - entities:
+    - role: player
+      name: James Wood
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: TAC-JWI
+  uuid: 8dca0bee-52c6-4192-9b13-d9cfdbd78c20
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Wilson
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: TAC-KC
+  uuid: 50be0e82-c71f-439c-a555-c672e97ebbf2
+  subjects:
+  - entities:
+    - role: player
+      name: Kristian Campbell
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: TAC-KG
+  uuid: e14299b8-0c6d-4a01-96b5-3f72cf146ded
+  subjects:
+  - entities:
+    - role: player
+      name: Ken Griffey Jr.
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: TAC-KGJ
+  uuid: 6ef4f9b7-2c9c-4411-bb17-0b2d21a1a49e
+  subjects:
+  - entities:
+    - role: player
+      name: Ken Griffey Jr.
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: TAC-KU
+  uuid: 79b2c07b-b324-4afe-92e7-9f0bd6b4d82c
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Kurtz
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: TAC-MA
+  uuid: 95fedfe3-62d0-4ea3-a5b5-a80f6a95993f
+  subjects:
+  - entities:
+    - role: player
+      name: Matt Shaw
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: TAC-MAN
+  uuid: 7b0e9356-0775-4c2a-9316-efe6ce2abdde
+  subjects:
+  - entities:
+    - role: player
+      name: Manny Machado
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: TAC-MM
+  uuid: 73526ea1-3c62-46fc-a87d-8401a5b5cb2e
+  subjects:
+  - entities:
+    - role: player
+      name: Mark McGwire
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: TAC-MMC
+  uuid: d54e578d-2fbb-4200-b1d2-e18b1a893a48
+  subjects:
+  - entities:
+    - role: player
+      name: Mark McGwire
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: TAC-MMY
+  uuid: 63caf933-d5cd-4acf-81b1-ffc5771b8ef0
+  subjects:
+  - entities:
+    - role: player
+      name: Marcelo Mayer
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: TAC-MP
+  uuid: 89ba8fa4-74a1-45a6-9f83-a40c074449b9
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Piazza
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: TAC-MPZ
+  uuid: 83b3e60f-5f4a-4006-9c10-6480e5e321c5
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Piazza
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: TAC-MR
+  uuid: 514dcef6-7275-4a94-9f9e-d9733b07769b
+  subjects:
+  - entities:
+    - role: player
+      name: Mariano Rivera
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: TAC-MSC
+  uuid: aa45a0bc-abd3-485a-9239-9011db6ed3eb
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Schmidt
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: TAC-MT
+  uuid: 7dc1625d-b47a-41ef-a730-f9faf30560e1
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Trout
+      ref: 
+    - role: team
+      name: Angels
+      ref: 
+- number: TAC-MTR
+  uuid: 48f51d51-dd17-4beb-912a-1faff3dbe5db
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Trout
+      ref: 
+    - role: team
+      name: Angels
+      ref: 
+- number: TAC-NK
+  uuid: cefcaa33-6325-47c4-9716-bdbe8b90cffb
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Kurtz
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: TAC-NR
+  uuid: 9d421fca-f6f1-4069-88cc-344b0a653ec5
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan Ryan
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: TAC-OH
+  uuid: bb10b0c1-2414-4f52-b8ed-6e8063e7b264
+  subjects:
+  - entities:
+    - role: player
+      name: Orel Hershiser
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: TAC-PS
+  uuid: d00f25d6-2c35-47e3-8cf2-9a22b43918c6
+  subjects:
+  - entities:
+    - role: player
+      name: Paul Skenes
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: TAC-PUJ
+  uuid: 99944752-01f7-4b72-b432-79a6d2174082
+  subjects:
+  - entities:
+    - role: player
+      name: Albert Pujols
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: TAC-RC
+  uuid: 5b1af10c-dc33-4f1e-9492-f977b57320a5
+  subjects:
+  - entities:
+    - role: player
+      name: Roger Clemens
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: TAC-RCA
+  uuid: aae292fc-47be-4ee6-9103-0baee85dc62c
+  subjects:
+  - entities:
+    - role: player
+      name: Rod Carew
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: TAC-RCL
+  uuid: 326f445f-ce65-4d89-828c-5d985400c1b4
+  subjects:
+  - entities:
+    - role: player
+      name: Roger Clemens
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: TAC-REG
+  uuid: 370e01b8-c88c-40ac-a112-8a467debacc5
+  subjects:
+  - entities:
+    - role: player
+      name: Reggie Jackson
+      ref: 
+    - role: team
+      name: Oakland Athletics
+      ref: 
+- number: TAC-RJA
+  uuid: 9ea15a8e-79e2-4794-bbf2-013ec378cb6c
+  subjects:
+  - entities:
+    - role: player
+      name: Reggie Jackson
+      ref: 
+    - role: team
+      name: Oakland Athletics
+      ref: 
+- number: TAC-RJO
+  uuid: ad9d9ebc-3a21-4c9a-8148-e3a7ed8496bc
+  subjects:
+  - entities:
+    - role: player
+      name: Randy Johnson
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: TAC-RS
+  uuid: c70f5dbc-499c-4c3b-91c5-9bde0c04a95b
+  subjects:
+  - entities:
+    - role: player
+      name: Roki Sasaki
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: TAC-RSA
+  uuid: 17c93e44-f96b-45ed-bc5f-92bedc106ad5
+  subjects:
+  - entities:
+    - role: player
+      name: Roki Sasaki
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: TAC-SC
+  uuid: 74882ac7-adf8-4f06-9664-dfb977fc7d4f
+  subjects:
+  - entities:
+    - role: player
+      name: Steve Carlton
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: TAC-SHO
+  uuid: 13918fc5-7f09-4b23-9de1-8793c4ae266f
+  subjects:
+  - entities:
+    - role: player
+      name: Shohei Ohtani
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: TAC-SK
+  uuid: c27ed93a-1b23-4891-9328-d6cdbbc19bd2
+  subjects:
+  - entities:
+    - role: player
+      name: Sandy Koufax
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: TAC-SKO
+  uuid: 14b7af65-0117-4c0b-8081-7df03773bb42
+  subjects:
+  - entities:
+    - role: player
+      name: Sandy Koufax
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: TAC-SO
+  uuid: 2848eeb7-a9c0-436b-a51f-51407ad58f19
+  subjects:
+  - entities:
+    - role: player
+      name: Shohei Ohtani
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: TAC-TT
+  uuid: bba20cda-d562-460e-b1dd-037075cdef0c
+  subjects:
+  - entities:
+    - role: player
+      name: Trea Turner
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: TAC-VG
+  uuid: 54dc1bce-1385-4d30-8af2-1b0822e5829f
+  subjects:
+  - entities:
+    - role: player
+      name: Vladimir Guerrero
+      ref: 
+    - role: team
+      name: Angels
+      ref: 
+- number: TAC-WOO
+  uuid: cc639cf1-6417-4be6-bb59-428fe7362095
+  subjects:
+  - entities:
+    - role: player
+      name: James Wood
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: TAC-YY
+  uuid: b96749c3-d872-42bb-bb6d-6d5e525e5860
+  subjects:
+  - entities:
+    - role: player
+      name: Yoshinobu Yamamoto
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 

--- a/data/baseball/2025-26-topps-transcendent/checklists/transcendent-collection-jumbo-patch-autographs.yaml
+++ b/data/baseball/2025-26-topps-transcendent/checklists/transcendent-collection-jumbo-patch-autographs.yaml
@@ -1,0 +1,230 @@
+- number: JPCA-AJ
+  uuid: e5bceb76-791b-415d-b551-866578ac7027
+  subjects:
+  - entities:
+    - role: player
+      name: Aaron Judge
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: JPCA-AM
+  uuid: 96f2bb36-b51c-4b83-b22d-8c787e0fb874
+  subjects:
+  - entities:
+    - role: player
+      name: Andrew McCutchen
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: JPCA-BB
+  uuid: d20aa366-2f2a-46e9-86a7-2e0eb0949677
+  subjects:
+  - entities:
+    - role: player
+      name: Byron Buxton
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: JPCA-BH
+  uuid: 895b2be0-a43a-43b2-9172-f0a71e3e7515
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Harper
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: JPCA-BW
+  uuid: d4f2a362-654f-4e3b-8568-2e76b3177782
+  subjects:
+  - entities:
+    - role: player
+      name: Bobby Witt Jr.
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: JPCA-CK
+  uuid: 0a1b17b8-a9d8-4e8a-b253-85723e007517
+  subjects:
+  - entities:
+    - role: player
+      name: Clayton Kershaw
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: JPCA-CR
+  uuid: 15b6e02a-5b0a-4873-b5cb-a9dc4326372b
+  subjects:
+  - entities:
+    - role: player
+      name: Cal Raleigh
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: JPCA-CY
+  uuid: db477209-064c-4fc5-9420-84cc054b2d49
+  subjects:
+  - entities:
+    - role: player
+      name: Christian Yelich
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: JPCA-DC
+  uuid: 910cb3c7-a04d-4b89-9a86-3b01ef11fb77
+  subjects:
+  - entities:
+    - role: player
+      name: Dylan Crews
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: JPCA-FT
+  uuid: a1e90fa4-bbf5-4732-895a-46f9c3740350
+  subjects:
+  - entities:
+    - role: player
+      name: Fernando Tatis Jr.
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: JPCA-GH
+  uuid: fc0691db-00d2-44f8-8aac-00cbc584c57c
+  subjects:
+  - entities:
+    - role: player
+      name: Gunnar Henderson
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: JPCA-I
+  uuid: 2197309b-5c81-4ded-9b87-4e7fd7ab5235
+  subjects:
+  - entities:
+    - role: player
+      name: Ichiro
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: JPCA-IS
+  uuid: bd3da2db-0a18-458c-9ac2-19af81c9960e
+  subjects:
+  - entities:
+    - role: player
+      name: Ichiro
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: JPCA-JA
+  uuid: 143d1e90-6d86-4618-8268-05033c8dc86e
+  subjects:
+  - entities:
+    - role: player
+      name: Jose Altuve
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: JPCA-JS
+  uuid: ff4f473d-9d06-49ba-bf5a-f65b186666e1
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: JPCA-JW
+  uuid: 654229b9-9f2c-4747-89b4-d9368f0cb298
+  subjects:
+  - entities:
+    - role: player
+      name: James Wood
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: JPCA-MMA
+  uuid: 9f7c43dc-cbdd-4dab-a52a-17f7fb97613e
+  subjects:
+  - entities:
+    - role: player
+      name: Manny Machado
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: JPCA-MT
+  uuid: c453fd6d-5b89-480f-822a-1d7a39496bb1
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Trout
+      ref: 
+    - role: team
+      name: Angels
+      ref: 
+- number: JPCA-NH
+  uuid: cc546a14-5ef6-4c2d-918a-050722ca7c76
+  subjects:
+  - entities:
+    - role: player
+      name: Nico Hoerner
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: JPCA-OA
+  uuid: a3e2f8c8-caec-42aa-93d8-3147a8a536c5
+  subjects:
+  - entities:
+    - role: player
+      name: Ozzie Albies
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: JPCA-PA
+  uuid: a829e327-3c72-4a31-b4ba-c046b1b69c81
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Alonso
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: JPCA-RA
+  uuid: e8608766-d553-4fbd-abef-966569885df1
+  subjects:
+  - entities:
+    - role: player
+      name: Ronald Acuña Jr.
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: JPCA-SO
+  uuid: 9739a654-e80b-4dc0-bd4f-22c89b41a48b
+  subjects:
+  - entities:
+    - role: player
+      name: Shohei Ohtani
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 

--- a/data/baseball/2025-26-topps-transcendent/checklists/transcendent-collection-legendary-relic-cards.yaml
+++ b/data/baseball/2025-26-topps-transcendent/checklists/transcendent-collection-legendary-relic-cards.yaml
@@ -1,0 +1,150 @@
+- number: TCLR-AK
+  uuid: 7bf0001b-e86c-4a9a-bd3d-4e457f42cbb8
+  subjects:
+  - entities:
+    - role: player
+      name: Al Kaline
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: TCLR-BR
+  uuid: a84934df-aa8c-46f0-899e-906574cf54c2
+  subjects:
+  - entities:
+    - role: player
+      name: Babe Ruth
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: TCLR-CY
+  uuid: 6c961eb1-70ac-4898-9225-5aa2844f8b50
+  subjects:
+  - entities:
+    - role: player
+      name: Carl Yastrzemski
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: TCLR-DJ
+  uuid: 76e0e5d1-e6c4-4f59-bfad-f74e932054ed
+  subjects:
+  - entities:
+    - role: player
+      name: Derek Jeter
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: TCLR-EB
+  uuid: 92041481-020c-428b-8a8f-67d7fa3aea37
+  subjects:
+  - entities:
+    - role: player
+      name: Ernie Banks
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: TCLR-HA
+  uuid: b59e1211-c0cd-4ffd-8bd2-f8bd2b637547
+  subjects:
+  - entities:
+    - role: player
+      name: Hank Aaron
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: TCLR-JB
+  uuid: 614e8bb2-30e3-4bab-9d88-4f2710141671
+  subjects:
+  - entities:
+    - role: player
+      name: Johnny Bench
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: TCLR-JD
+  uuid: 594cf570-8370-449b-8f20-173887ecb92e
+  subjects:
+  - entities:
+    - role: player
+      name: Joe DiMaggio
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: TCLR-MM
+  uuid: eda1d791-f91f-440b-8ae4-e87862f7c21c
+  subjects:
+  - entities:
+    - role: player
+      name: Mickey Mantle
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: TCLR-RC
+  uuid: 20604ca2-01fe-402f-918d-b04f674b6f46
+  subjects:
+  - entities:
+    - role: player
+      name: Roberto Clemente
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: TCLR-RH
+  uuid: 750ec6bb-5eeb-41a6-a550-fe40561b4887
+  subjects:
+  - entities:
+    - role: player
+      name: Rogers Hornsby
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: TCLR-RJ
+  uuid: d2739047-a8b8-4c90-a161-9d056ee45bd8
+  subjects:
+  - entities:
+    - role: player
+      name: Reggie Jackson
+      ref: 
+    - role: team
+      name: California Angels
+      ref: 
+- number: TCLR-SM
+  uuid: ba51440c-8f15-40c7-b338-66fc56b6fbfd
+  subjects:
+  - entities:
+    - role: player
+      name: Stan Musial
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: TCLR-WM
+  uuid: 11e1c00c-fe69-4b8a-8e46-7d592509ce71
+  subjects:
+  - entities:
+    - role: player
+      name: Willie Mays
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: TCLR-YB
+  uuid: 961ca5ad-08d8-4da1-a353-0f54e5e11bf1
+  subjects:
+  - entities:
+    - role: player
+      name: Yogi Berra
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 

--- a/data/baseball/2025-26-topps-transcendent/checklists/transcendent-collection-mlb-logo-patches.yaml
+++ b/data/baseball/2025-26-topps-transcendent/checklists/transcendent-collection-mlb-logo-patches.yaml
@@ -1,0 +1,480 @@
+- number: MLP-AJ
+  uuid: 2d4a333d-1c02-40bf-9014-2ed1d02f7c34
+  subjects:
+  - entities:
+    - role: player
+      name: Aaron Judge
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: MLP-AP
+  uuid: 607fdd2f-3876-4ba4-9b52-cebf3dd849bc
+  subjects:
+  - entities:
+    - role: player
+      name: Albert Pujols
+      ref: 
+    - role: team
+      name: Angels
+      ref: 
+- number: MLP-AR
+  uuid: e6bdf5c4-8d2a-4c8b-bfc7-3cccdf8c5ec4
+  subjects:
+  - entities:
+    - role: player
+      name: Austin Riley
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: MLP-BH
+  uuid: cc7dfac5-801a-4703-bff8-0a86c07b5f40
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Harper
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: MLP-BL
+  uuid: 47fc935f-584b-4672-8628-40699c885989
+  subjects:
+  - entities:
+    - role: player
+      name: Brooks Lee
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: MLP-BR
+  uuid: e6a227a8-a773-4ead-a9d0-31535ef363a5
+  subjects:
+  - entities:
+    - role: player
+      name: Ben Rice
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: MLP-BW
+  uuid: 37172933-f876-4b72-bd88-1df56078ce70
+  subjects:
+  - entities:
+    - role: player
+      name: Bobby Witt Jr.
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: MLP-CC
+  uuid: 101a9382-7272-4096-bd7e-eb09f5ae4d4f
+  subjects:
+  - entities:
+    - role: player
+      name: Corbin Carroll
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: MLP-CH
+  uuid: 45661293-8311-49eb-b468-cece54f43c35
+  subjects:
+  - entities:
+    - role: player
+      name: Cade Horton
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: MLP-CHS
+  uuid: a3f85a87-9e27-4f2c-9691-b5cf9abad88d
+  subjects:
+  - entities:
+    - role: player
+      name: Chandler Simpson
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: MLP-CK
+  uuid: 9b7dfb4b-f91c-4be1-85b6-8d9f16163421
+  subjects:
+  - entities:
+    - role: player
+      name: Clayton Kershaw
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: MLP-CSM
+  uuid: 5ff2b98d-0834-4ca4-bb71-274d5ef2ef2c
+  subjects:
+  - entities:
+    - role: player
+      name: Cam Smith
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: MLP-DB
+  uuid: 0ba11fb6-4ae8-451a-a742-ed84fe344f6f
+  subjects:
+  - entities:
+    - role: player
+      name: Drake Baldwin
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: MLP-DC
+  uuid: 414e3334-eee7-4635-be7e-863218da4a6a
+  subjects:
+  - entities:
+    - role: player
+      name: Dylan Crews
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: MLP-FF
+  uuid: 5988d4c9-10f7-40d0-a55d-d2575999652b
+  subjects:
+  - entities:
+    - role: player
+      name: Freddie Freeman
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: MLP-FL
+  uuid: 456471d2-97ef-4835-bd59-39ef4763aa95
+  subjects:
+  - entities:
+    - role: player
+      name: Francisco Lindor
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: MLP-FT
+  uuid: 6ddcd1d5-322e-4db1-b8a5-7854b2816311
+  subjects:
+  - entities:
+    - role: player
+      name: Fernando Tatis Jr.
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: MLP-GM
+  uuid: 22482bc8-83d0-4349-8aa1-ad597478b129
+  subjects:
+  - entities:
+    - role: player
+      name: Greg Maddux
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: MLP-JC
+  uuid: 2bd16b4a-b244-4ed8-be7d-c910cd533ba9
+  subjects:
+  - entities:
+    - role: player
+      name: Junior Caminero
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: MLP-JD
+  uuid: 28ac3544-b805-4723-af42-c8525f9f226d
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob deGrom
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: MLP-JH
+  uuid: f733de82-e350-4c38-aebc-cdfff76078a6
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Holliday
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: MLP-JM
+  uuid: 4c15c077-fdd8-4c4f-b5a2-6bb4c5861f23
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Merrill
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: MLP-JR
+  uuid: e7e63238-4de5-493a-b68f-c10e259e2215
+  subjects:
+  - entities:
+    - role: player
+      name: Julio Rodríguez
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: MLP-JS
+  uuid: 8c7a8954-9ba9-4162-bb07-639174743ee9
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: MLP-JV
+  uuid: 24b9574d-fec6-4338-a32a-5bb5906235e7
+  subjects:
+  - entities:
+    - role: player
+      name: Joey Votto
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: MLP-JW
+  uuid: 6cba2f58-7a4e-4aba-ae40-05e679e4266a
+  subjects:
+  - entities:
+    - role: player
+      name: James Wood
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: MLP-JWI
+  uuid: bbdc1d9f-bfed-4e0e-95f5-3307cf95413d
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Wilson
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: MLP-KC
+  uuid: 20e333e9-84e6-4997-964d-5567dba30e80
+  subjects:
+  - entities:
+    - role: player
+      name: Kristian Campbell
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: MLP-KS
+  uuid: f909a3d1-f28d-4d58-8c85-4450e95f1f18
+  subjects:
+  - entities:
+    - role: player
+      name: Kodai Senga
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: MLP-KT
+  uuid: c3fd7784-7772-41a1-a0fc-5980e2ac1e13
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Tucker
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: MLP-LA
+  uuid: e3279f5f-819a-41bc-8053-d0f59670c1cc
+  subjects:
+  - entities:
+    - role: player
+      name: Luisangel Acuña
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: MLP-MB
+  uuid: e92c9e2f-f26b-40bb-80ca-86e14d382ec4
+  subjects:
+  - entities:
+    - role: player
+      name: Mookie Betts
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: MLP-MC
+  uuid: 42428187-8391-40e5-8f04-1a240acd2aa7
+  subjects:
+  - entities:
+    - role: player
+      name: Miguel Cabrera
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: MLP-MM
+  uuid: 21228ecb-55b4-4a02-b5be-b3e16ea86828
+  subjects:
+  - entities:
+    - role: player
+      name: Manny Machado
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: MLP-MMA
+  uuid: 515b5c1d-848a-455f-96d1-8187fc2001b5
+  subjects:
+  - entities:
+    - role: player
+      name: Marcelo Mayer
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: MLP-MS
+  uuid: 21e64799-a3fd-46a3-9aa6-8369ed966a72
+  subjects:
+  - entities:
+    - role: player
+      name: Matt Shaw
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: MLP-MT
+  uuid: be47654b-73c6-4569-bdec-6b1454fef21a
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Trout
+      ref: 
+    - role: team
+      name: Angels
+      ref: 
+- number: MLP-NA
+  uuid: c1b4cad1-c86c-4207-9ea8-ee1079d7f5aa
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan Arenado
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: MLP-NK
+  uuid: 239ff681-0b03-44ae-a6fe-315048d13011
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Kurtz
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: MLP-PA
+  uuid: 7f85cf00-2cb1-43d7-a03b-16aee0e5fce8
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Alonso
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: MLP-PC
+  uuid: 367054ca-7da5-4a9c-a85e-f7d2e13b2548
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Crow-Armstrong
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: MLP-RA
+  uuid: 8789e772-54c1-411f-8e07-9e6b0334aec1
+  subjects:
+  - entities:
+    - role: player
+      name: Ronald Acuña Jr.
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: MLP-RH
+  uuid: f81a632f-e325-4573-ba0e-170ed2dec7d5
+  subjects:
+  - entities:
+    - role: player
+      name: Rickey Henderson
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: MLP-SI
+  uuid: d2d25971-304e-4ced-a30c-de935c8ae9e9
+  subjects:
+  - entities:
+    - role: player
+      name: Shota Imanaga
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: MLP-SO
+  uuid: 9154f96d-3cae-4ca9-a4c2-c00bc999cb0e
+  subjects:
+  - entities:
+    - role: player
+      name: Shohei Ohtani
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: MLP-TT
+  uuid: 24ec468f-290d-46b7-a740-a7dc08a15141
+  subjects:
+  - entities:
+    - role: player
+      name: Trea Turner
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: MLP-VG
+  uuid: 9613c0e5-2ab8-4d51-85e0-0f792a6ee72f
+  subjects:
+  - entities:
+    - role: player
+      name: Vladimir Guerrero Jr.
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: MLP-YM
+  uuid: 9fb7e6a0-2dc2-4299-83ca-8c252f0a30f2
+  subjects:
+  - entities:
+    - role: player
+      name: Yadier Molina
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 

--- a/data/baseball/2025-26-topps-transcendent/checklists/transcendent-collection-patch-autographs.yaml
+++ b/data/baseball/2025-26-topps-transcendent/checklists/transcendent-collection-patch-autographs.yaml
@@ -1,0 +1,500 @@
+- number: PCA-ABR
+  uuid: 2803e9c9-317e-4f97-99a0-f771556770c5
+  subjects:
+  - entities:
+    - role: player
+      name: Alex Bregman
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: PCA-AJ
+  uuid: bcc4dbd1-4f77-4770-9ad1-0ea58b85f718
+  subjects:
+  - entities:
+    - role: player
+      name: Aaron Judge
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: PCA-AM
+  uuid: 44df360b-5458-44a5-a572-451c91cd4aab
+  subjects:
+  - entities:
+    - role: player
+      name: Andrew McCutchen
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: PCA-APU
+  uuid: 0db7a7cb-dee1-4bb0-9518-e67b43adef7b
+  subjects:
+  - entities:
+    - role: player
+      name: Albert Pujols
+      ref: 
+    - role: team
+      name: Angels
+      ref: 
+- number: PCA-AR
+  uuid: a603b399-092b-4466-85c4-56ca1e54ea60
+  subjects:
+  - entities:
+    - role: player
+      name: Austin Riley
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: PCA-AV
+  uuid: 6ea5a352-ca7a-4f21-a190-c981bb4c6768
+  subjects:
+  - entities:
+    - role: player
+      name: Anthony Volpe
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: PCA-BL
+  uuid: c29c47a2-4445-4e75-b593-2e297ea90897
+  subjects:
+  - entities:
+    - role: player
+      name: Barry Larkin
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: PCA-CC
+  uuid: 86411297-cc04-4bb6-98a0-cad6f31fb569
+  subjects:
+  - entities:
+    - role: player
+      name: Corbin Carroll
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: PCA-CJ
+  uuid: a7b2e9eb-db9d-4756-af15-15003ef7394d
+  subjects:
+  - entities:
+    - role: player
+      name: Chipper Jones
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: PCA-CK
+  uuid: 1eb90762-bfa7-4b88-938d-d789b9f3d130
+  subjects:
+  - entities:
+    - role: player
+      name: Clayton Kershaw
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: PCA-CS
+  uuid: 583b3ef8-05d4-4466-a44e-8e5face1cda0
+  subjects:
+  - entities:
+    - role: player
+      name: Corey Seager
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: PCA-CY
+  uuid: 63ddce3a-7eb8-4509-8beb-6bafd3478cf2
+  subjects:
+  - entities:
+    - role: player
+      name: Christian Yelich
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: PCA-DC
+  uuid: bf577900-f788-46fd-b030-9a9ede3afede
+  subjects:
+  - entities:
+    - role: player
+      name: Dylan Crews
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: PCA-DJ
+  uuid: ce5a6af4-c4d0-4f47-9e45-c4a09a36f4aa
+  subjects:
+  - entities:
+    - role: player
+      name: Derek Jeter
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: PCA-DO
+  uuid: c3683426-cc76-4269-8f9b-25f44b6e0b54
+  subjects:
+  - entities:
+    - role: player
+      name: David Ortiz
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: PCA-DOR
+  uuid: dc08b872-3a41-45ed-843d-f390b89ccf0f
+  subjects:
+  - entities:
+    - role: player
+      name: David Ortiz
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: PCA-FL
+  uuid: ef17abd5-5796-4429-80d4-6dbbe1e17035
+  subjects:
+  - entities:
+    - role: player
+      name: Francisco Lindor
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: PCA-FT
+  uuid: a50629ea-139d-445e-8110-6f57cc9649b6
+  subjects:
+  - entities:
+    - role: player
+      name: Fernando Tatis Jr.
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: PCA-GH
+  uuid: a246c4d5-85d0-4378-bfe7-bc53e7bbf1c9
+  subjects:
+  - entities:
+    - role: player
+      name: Gunnar Henderson
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: PCA-I
+  uuid: 361c4371-e587-474e-a7a4-acfb3a9c6e8a
+  subjects:
+  - entities:
+    - role: player
+      name: Ichiro
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: PCA-JA
+  uuid: 159108d1-da73-41ce-8cfa-06df0c79891e
+  subjects:
+  - entities:
+    - role: player
+      name: Jose Altuve
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: PCA-JC
+  uuid: 5be76c6d-3b8f-4118-b048-3e5df1241ec3
+  subjects:
+  - entities:
+    - role: player
+      name: Junior Caminero
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: PCA-JCJ
+  uuid: 6775828a-0707-4acf-b681-5868b4dcf402
+  subjects:
+  - entities:
+    - role: player
+      name: Jazz Chisholm Jr.
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: PCA-JM
+  uuid: 929373d7-bf07-41b9-8c91-201a104bc6e8
+  subjects:
+  - entities:
+    - role: player
+      name: Joe Mauer
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: PCA-JRA
+  uuid: 73051bee-ac88-4743-82c9-0faeb8bba599
+  subjects:
+  - entities:
+    - role: player
+      name: José Ramírez
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: PCA-JS
+  uuid: cd1dce4e-f565-4d9e-95fc-87e94bd82489
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: PCA-JSA
+  uuid: e89c9aa0-07bf-41c3-a0c8-83283c833138
+  subjects:
+  - entities:
+    - role: player
+      name: Johan Santana
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: PCA-JW
+  uuid: f6c86341-fdfd-4791-9819-38e0e6559125
+  subjects:
+  - entities:
+    - role: player
+      name: James Wood
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: PCA-KG
+  uuid: fcf92532-72be-4ef7-9d6f-238e6d8776d4
+  subjects:
+  - entities:
+    - role: player
+      name: Ken Griffey Jr.
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: PCA-LB
+  uuid: eec42d20-760a-4cf8-ba31-839a3daf9a5b
+  subjects:
+  - entities:
+    - role: player
+      name: Lawrence Butler
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: PCA-LEE
+  uuid: 1fb4d812-0e76-41c1-b363-15338073ea33
+  subjects:
+  - entities:
+    - role: player
+      name: Brooks Lee
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: PCA-LW
+  uuid: 651744c7-a3eb-44f7-97dd-3440882f8fa0
+  subjects:
+  - entities:
+    - role: player
+      name: Larry Walker
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: PCA-MMA
+  uuid: 9425da81-fc72-4d38-a502-ea13827ddb72
+  subjects:
+  - entities:
+    - role: player
+      name: Manny Machado
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: PCA-MT
+  uuid: 77d2496d-e862-4873-ac35-bc19bd0f6f1f
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Trout
+      ref: 
+    - role: team
+      name: Angels
+      ref: 
+- number: PCA-MTX
+  uuid: 6a331918-7aa2-4ae1-95f0-b379b7746bd5
+  subjects:
+  - entities:
+    - role: player
+      name: Mark Teixeira
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: PCA-NA
+  uuid: f57c3b5b-d703-49d2-9b3b-a89635935572
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan Arenado
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: PCA-OA
+  uuid: 8758d29c-a769-4c58-92c9-eb7d48891289
+  subjects:
+  - entities:
+    - role: player
+      name: Ozzie Albies
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: PCA-OH
+  uuid: 92ee16ac-2738-42cd-a5b3-1f9055565265
+  subjects:
+  - entities:
+    - role: player
+      name: Orel Hershiser
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: PCA-PA
+  uuid: 6d2c24ca-e082-4597-be4a-cf5fd8171258
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Alonso
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: PCA-PCA
+  uuid: '081fbcd7-4d1d-4df6-bfb4-04b6ac2544a3'
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Crow-Armstrong
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: PCA-PF
+  uuid: 19d728e8-0e22-4f28-afa6-a85ddc59d124
+  subjects:
+  - entities:
+    - role: player
+      name: Prince Fielder
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: PCA-PS
+  uuid: 04b25a24-fc18-4cbc-83fd-9ce418957aa3
+  subjects:
+  - entities:
+    - role: player
+      name: Paul Skenes
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: PCA-RA
+  uuid: 8164eca5-726f-4002-b93e-c3f11599eb4f
+  subjects:
+  - entities:
+    - role: player
+      name: Ronald Acuña Jr.
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: PCA-RJA
+  uuid: 43ca6f24-dab8-49fc-afdb-06526a2a8b78
+  subjects:
+  - entities:
+    - role: player
+      name: Reggie Jackson
+      ref: 
+    - role: team
+      name: California Angels
+      ref: 
+- number: PCA-SC
+  uuid: 11035bc6-af56-49a1-a380-ee771a936d11
+  subjects:
+  - entities:
+    - role: player
+      name: Steve Carlton
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: PCA-SHO
+  uuid: 3eb141e6-e3f1-4775-a994-7604b78066b2
+  subjects:
+  - entities:
+    - role: player
+      name: Shohei Ohtani
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: PCA-SI
+  uuid: eb89a5c3-459d-4542-9022-72855d679c78
+  subjects:
+  - entities:
+    - role: player
+      name: Shota Imanaga
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: PCA-SO
+  uuid: 78446bfb-846a-447d-bba3-b71d73f30062
+  subjects:
+  - entities:
+    - role: player
+      name: Shohei Ohtani
+      ref: 
+    - role: team
+      name: Angels
+      ref: 
+- number: PCA-TH
+  uuid: 5b09ba6e-8437-4786-beb6-9eeed0fda424
+  subjects:
+  - entities:
+    - role: player
+      name: Torii Hunter
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: PCA-YY
+  uuid: 66ab5528-328c-4bad-a3b9-b017aaf1db5c
+  subjects:
+  - entities:
+    - role: player
+      name: Yoshinobu Yamamoto
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 

--- a/data/baseball/2025-26-topps-transcendent/checklists/transcendent-collection-patches.yaml
+++ b/data/baseball/2025-26-topps-transcendent/checklists/transcendent-collection-patches.yaml
@@ -1,0 +1,780 @@
+- number: TCP-AJ
+  uuid: 03225f0e-15d7-445c-80a5-1a2073a6c1c8
+  subjects:
+  - entities:
+    - role: player
+      name: Aaron Judge
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: TCP-AM
+  uuid: b33fc061-1e1b-40cb-ba66-a87a527fc29f
+  subjects:
+  - entities:
+    - role: player
+      name: Andrew McCutchen
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: TCP-AN
+  uuid: 3e067b56-0652-4320-b6ac-bce5ca93f159
+  subjects:
+  - entities:
+    - role: player
+      name: Aaron Nola
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: TCP-ARA
+  uuid: c1e36fe9-657b-4969-b5c7-6bf79627155f
+  subjects:
+  - entities:
+    - role: player
+      name: Agustín Ramírez
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: TCP-ARI
+  uuid: 721cdccd-9f5a-4364-a85c-0215b20d2eb1
+  subjects:
+  - entities:
+    - role: player
+      name: Austin Riley
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: TCP-ARU
+  uuid: 6367f914-928a-4674-b1c2-8343776687de
+  subjects:
+  - entities:
+    - role: player
+      name: Adley Rutschman
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: TCP-AV
+  uuid: 7479566b-9971-4650-ba41-16fcbe67b64f
+  subjects:
+  - entities:
+    - role: player
+      name: Anthony Volpe
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: TCP-BB
+  uuid: 90e044c2-d7d0-4cbc-918e-eaa7628353ab
+  subjects:
+  - entities:
+    - role: player
+      name: Bo Bichette
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: TCP-BBU
+  uuid: ea99cba4-6acf-44fc-a982-7bd5e774adfd
+  subjects:
+  - entities:
+    - role: player
+      name: Byron Buxton
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: TCP-BH
+  uuid: f7c4e281-517c-4dfc-b92d-3824863bb194
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Harper
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: TCP-BL
+  uuid: 3639186d-62f0-40a9-915c-8b503fa26690
+  subjects:
+  - entities:
+    - role: player
+      name: Brooks Lee
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: TCP-BRE
+  uuid: f7762a33-1f77-4679-a184-9225542becb1
+  subjects:
+  - entities:
+    - role: player
+      name: Ben Rice
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: TCP-BW
+  uuid: 84d1da92-929b-49ba-b4d6-38275d7c7dc3
+  subjects:
+  - entities:
+    - role: player
+      name: Bobby Witt Jr.
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: TCP-CA
+  uuid: 59c8b39b-ef74-476b-98cd-2bca8a5c8808
+  subjects:
+  - entities:
+    - role: player
+      name: CJ Abrams
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: TCP-CC
+  uuid: 704c2c05-1fa2-4ff7-a755-9e85658b4958
+  subjects:
+  - entities:
+    - role: player
+      name: Corbin Carroll
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: TCP-CCO
+  uuid: e302c36d-1ae3-4df7-bdd7-46c8784f9069
+  subjects:
+  - entities:
+    - role: player
+      name: Carlos Correa
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: TCP-CD
+  uuid: db29302f-73b7-4c7b-bec7-023192f5e621
+  subjects:
+  - entities:
+    - role: player
+      name: Chase Dollander
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: TCP-CM
+  uuid: 3a148fa5-673e-4961-b7f6-313aa24332fa
+  subjects:
+  - entities:
+    - role: player
+      name: Coby Mayo
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: TCP-CR
+  uuid: df640436-33b1-4892-b7c0-4a8fddc913f5
+  subjects:
+  - entities:
+    - role: player
+      name: Cal Raleigh
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: TCP-CSA
+  uuid: 89580f8a-74dc-462b-a365-1aba55213105
+  subjects:
+  - entities:
+    - role: player
+      name: Chris Sale
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: TCP-CSI
+  uuid: 52db8ed0-98c9-40d0-aba6-d121603d48b0
+  subjects:
+  - entities:
+    - role: player
+      name: Chandler Simpson
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: TCP-CSM
+  uuid: cab1368d-d425-41d2-b254-072e162ff33c
+  subjects:
+  - entities:
+    - role: player
+      name: Cam Smith
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: TCP-CY
+  uuid: fbb84ad8-6d05-4d95-a45a-3ad9358b0eae
+  subjects:
+  - entities:
+    - role: player
+      name: Christian Yelich
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: TCP-DB
+  uuid: 2bc9b7e1-1725-45b0-a520-7dac89277296
+  subjects:
+  - entities:
+    - role: player
+      name: Drake Baldwin
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: TCP-DC
+  uuid: 1cfd02b9-93a6-46b3-b232-7a411d4c37ae
+  subjects:
+  - entities:
+    - role: player
+      name: Dylan Crews
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: TCP-DS
+  uuid: 629e35fd-4b44-4e93-842d-9bade631a8fb
+  subjects:
+  - entities:
+    - role: player
+      name: Dansby Swanson
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: TCP-EQ
+  uuid: d15a91ab-15c3-423c-b1dc-f716d51f8785
+  subjects:
+  - entities:
+    - role: player
+      name: Edgar Quero
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: TCP-FL
+  uuid: bd8db6a5-5791-48d9-8bd8-e51495e317cd
+  subjects:
+  - entities:
+    - role: player
+      name: Francisco Lindor
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: TCP-FT
+  uuid: 34ca1104-53e8-484c-b4f5-5580ca2f2266
+  subjects:
+  - entities:
+    - role: player
+      name: Fernando Tatis Jr.
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: TCP-GC
+  uuid: 382181ae-fc49-434b-ae61-63ff01abacd5
+  subjects:
+  - entities:
+    - role: player
+      name: Gerrit Cole
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: TCP-GH
+  uuid: 0226061e-d093-487f-944d-ee473934dbbc
+  subjects:
+  - entities:
+    - role: player
+      name: Gunnar Henderson
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: TCP-GS
+  uuid: 4ce8d1b9-5a71-4e2e-9457-eb5ea0195287
+  subjects:
+  - entities:
+    - role: player
+      name: Giancarlo Stanton
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: TCP-HG
+  uuid: 5a566d01-1857-41c9-8b68-bd90213924c4
+  subjects:
+  - entities:
+    - role: player
+      name: Hunter Greene
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: TCP-I
+  uuid: 25d6cbc4-8614-4452-b2a5-1ffe240fd334
+  subjects:
+  - entities:
+    - role: player
+      name: Ichiro
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: TCP-JAJ
+  uuid: a3285b56-a940-46fa-bc1f-8dba37826639
+  subjects:
+  - entities:
+    - role: player
+      name: Jace Jung
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: TCP-JB
+  uuid: abb55f70-aabf-43f4-801b-a929682b39cf
+  subjects:
+  - entities:
+    - role: player
+      name: Javier Báez
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: TCP-JCJ
+  uuid: ca0e08dd-07c9-407d-ad1f-38cd6c61c9e1
+  subjects:
+  - entities:
+    - role: player
+      name: Jazz Chisholm Jr.
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: TCP-JD
+  uuid: c732d217-fcc1-4a40-99cb-4e2725f354c3
+  subjects:
+  - entities:
+    - role: player
+      name: Jarren Duran
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: TCP-JH
+  uuid: bf40a277-68c9-487c-a0d5-81a8e6122533
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Holliday
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: TCP-JJ
+  uuid: 3a75d99d-aea9-4473-b27f-e1bdb0c15828
+  subjects:
+  - entities:
+    - role: player
+      name: Josh Jung
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: TCP-JM
+  uuid: 21eac6c3-9392-499d-ae05-77b2e7edbd7d
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Merrill
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: TCP-JP
+  uuid: 80d11269-06bd-40bd-9d6e-8be4a20e003b
+  subjects:
+  - entities:
+    - role: player
+      name: Jeremy Peña
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: TCP-JR
+  uuid: 895def7c-29c5-4e0d-8a66-06dc810eee72
+  subjects:
+  - entities:
+    - role: player
+      name: José Ramírez
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: TCP-JRE
+  uuid: 43d4fb97-d222-41d8-8836-107857f9dde0
+  subjects:
+  - entities:
+    - role: player
+      name: J.T. Realmuto
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: TCP-JRO
+  uuid: 9069a072-ba4a-49e2-a69e-3708cd35f227
+  subjects:
+  - entities:
+    - role: player
+      name: Julio Rodríguez
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: TCP-JS
+  uuid: ed234345-5ae2-4e7b-a22e-af1d5f39973f
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: TCP-JW
+  uuid: 010ba7e8-6bec-444f-8bb7-a8a0cefac3d5
+  subjects:
+  - entities:
+    - role: player
+      name: James Wood
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: TCP-JWI
+  uuid: 25faf32c-41af-4429-8f03-4247243c63d5
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Wilson
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: TCP-KB
+  uuid: 415c1a0c-5c38-46e0-9c3c-e018e5843c76
+  subjects:
+  - entities:
+    - role: player
+      name: Kris Bryant
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: TCP-KC
+  uuid: 845a01e1-50d3-4dcb-88f8-889db1978cd2
+  subjects:
+  - entities:
+    - role: player
+      name: Kristian Campbell
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: TCP-KM
+  uuid: 51031508-bde1-4aad-8422-2599f0a19a09
+  subjects:
+  - entities:
+    - role: player
+      name: Ketel Marte
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: TCP-KR
+  uuid: f5ede386-a71c-4f7d-ba35-da12f9a1bd97
+  subjects:
+  - entities:
+    - role: player
+      name: Kumar Rocker
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: TCP-LA
+  uuid: aca6238c-36f7-465a-b786-253199ad8ae2
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Arraez
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: TCP-LAC
+  uuid: 0ae98f2a-df85-4a0d-90d9-10b563faceb6
+  subjects:
+  - entities:
+    - role: player
+      name: Luisangel Acuña
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: TCP-LB
+  uuid: c3c317c8-9ce7-4c96-adca-a93112b5af5e
+  subjects:
+  - entities:
+    - role: player
+      name: Lawrence Butler
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: TCP-LG
+  uuid: 0c0d0a86-65e6-4298-9298-78671810cedc
+  subjects:
+  - entities:
+    - role: player
+      name: Logan Gilbert
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: TCP-LR
+  uuid: d5d2ebc0-ea42-486d-b1e0-36d69dcd55bd
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Robert Jr.
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: TCP-MM
+  uuid: 57bce032-503e-4fdb-80db-987a3cd6a94a
+  subjects:
+  - entities:
+    - role: player
+      name: Manny Machado
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: TCP-MMA
+  uuid: 60060806-6980-45d2-b27e-477bbe0ca9b0
+  subjects:
+  - entities:
+    - role: player
+      name: Marcelo Mayer
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: TCP-MO
+  uuid: f2328bf9-b6aa-4fd0-a61b-1bc284a788ee
+  subjects:
+  - entities:
+    - role: player
+      name: Matt Olson
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: TCP-MT
+  uuid: cb99e09e-8c37-413e-b348-d3b8dce4ea6c
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Trout
+      ref: 
+    - role: team
+      name: Angels
+      ref: 
+- number: TCP-MW
+  uuid: 2dbd62aa-8d1f-46fc-8434-ac634844aea3
+  subjects:
+  - entities:
+    - role: player
+      name: Masyn Winn
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: TCP-NA
+  uuid: 9ef457e1-7599-487b-b058-966a57ec135c
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan Arenado
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: TCP-NK
+  uuid: 3737be07-dddc-47f2-892e-7856f1d9b488
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Kurtz
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: TCP-OA
+  uuid: 8d1cff8d-14ea-4728-b8bd-96838e301a84
+  subjects:
+  - entities:
+    - role: player
+      name: Ozzie Albies
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: TCP-OC
+  uuid: 485d9473-b1fa-4f5f-988b-539f39fca8a3
+  subjects:
+  - entities:
+    - role: player
+      name: Oneil Cruz
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: TCP-PA
+  uuid: fd88a93e-6ba6-49b1-be1f-f0efcc9f222f
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Alonso
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: TCP-PC
+  uuid: f9b72670-2fce-4f6b-8c1d-cfc88be4ff5f
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Crow-Armstrong
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: TCP-PS
+  uuid: 5dd3029e-edeb-4dc0-aa12-29c8f3610bf2
+  subjects:
+  - entities:
+    - role: player
+      name: Paul Skenes
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: TCP-RA
+  uuid: 7e8c1849-ba7e-4116-8eb7-9ecf8216e525
+  subjects:
+  - entities:
+    - role: player
+      name: Ronald Acuña Jr.
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: TCP-RL
+  uuid: 23610d87-cc26-45b0-8866-5422c5e018b3
+  subjects:
+  - entities:
+    - role: player
+      name: Rhett Lowder
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: TCP-SS
+  uuid: e79c3f3f-9661-4413-8886-6a9f014c845a
+  subjects:
+  - entities:
+    - role: player
+      name: Seiya Suzuki
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: TCP-ST
+  uuid: 955e4d64-763c-4036-9e37-708642d8dbd2
+  subjects:
+  - entities:
+    - role: player
+      name: Spencer Torkelson
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: TCP-TG
+  uuid: aacc375a-27c9-4736-99d2-32c2952673df
+  subjects:
+  - entities:
+    - role: player
+      name: Tony Gwynn
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: TCP-VG
+  uuid: 1aca14ef-4a30-42a4-a6e6-3b6959d54921
+  subjects:
+  - entities:
+    - role: player
+      name: Vladimir Guerrero Jr.
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: TCP-XB
+  uuid: df94a2db-09ad-4c05-bed1-6fc269c2b995
+  subjects:
+  - entities:
+    - role: player
+      name: Xander Bogaerts
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: TCP-YA
+  uuid: ed418201-0873-41bf-b97b-6fa0e02260ad
+  subjects:
+  - entities:
+    - role: player
+      name: Yordan Alvarez
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: TCP-YD
+  uuid: 9e77261f-5265-4157-97cd-1d40cd5675ed
+  subjects:
+  - entities:
+    - role: player
+      name: Yu Darvish
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 

--- a/data/baseball/2025-26-topps-transcendent/checklists/transcendent-collection-rookie-showcase-autographs.yaml
+++ b/data/baseball/2025-26-topps-transcendent/checklists/transcendent-collection-rookie-showcase-autographs.yaml
@@ -1,0 +1,410 @@
+- number: TCRSA-AR
+  uuid: 12badb9c-357f-4ea7-b5db-590b64b4a448
+  subjects:
+  - entities:
+    - role: player
+      name: Agustín Ramírez
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: TCRSA-ARA
+  uuid: 23c16cd9-0ce0-4353-92b4-c8655b052d0f
+  subjects:
+  - entities:
+    - role: player
+      name: Agustín Ramírez
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: TCRSA-BEN
+  uuid: da219356-83ac-441c-b265-e41beb18ca36
+  subjects:
+  - entities:
+    - role: player
+      name: Ben Rice
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: TCRSA-BL
+  uuid: 98d164b7-06f5-4363-b47c-d90871518317
+  subjects:
+  - entities:
+    - role: player
+      name: Brooks Lee
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: TCRSA-BR
+  uuid: f750fcef-e4d5-4df6-8a45-cde2f06a5dde
+  subjects:
+  - entities:
+    - role: player
+      name: Ben Rice
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: TCRSA-CA
+  uuid: 5dcd2d7f-31ee-44b1-a176-4392ac69c500
+  subjects:
+  - entities:
+    - role: player
+      name: Cam Smith
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: TCRSA-CH
+  uuid: 7a923b52-5ea7-421e-9e1e-b946ee29871d
+  subjects:
+  - entities:
+    - role: player
+      name: Cade Horton
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: TCRSA-CN
+  uuid: 2d412cca-536d-4536-92b0-307811fe8eb3
+  subjects:
+  - entities:
+    - role: player
+      name: Connor Norby
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: TCRSA-CNO
+  uuid: 8f5f2abf-0df9-453e-a17c-f300826fb170
+  subjects:
+  - entities:
+    - role: player
+      name: Connor Norby
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: TCRSA-CS
+  uuid: 86781408-ba4e-49b9-8056-19f9fd515640
+  subjects:
+  - entities:
+    - role: player
+      name: Cam Smith
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: TCRSA-CSI
+  uuid: 54e959a5-b5e9-4cf7-b3e7-f1f03ad9d105
+  subjects:
+  - entities:
+    - role: player
+      name: Chandler Simpson
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: TCRSA-DC
+  uuid: bb8422c5-459a-48e4-962e-4502203591e8
+  subjects:
+  - entities:
+    - role: player
+      name: Dylan Crews
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: TCRSA-DCR
+  uuid: 6b3bf981-ec2c-42fc-9e9e-49fbea6aeffc
+  subjects:
+  - entities:
+    - role: player
+      name: Dylan Crews
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: TCRSA-DR
+  uuid: f9d1d176-f2f4-48e2-ab73-6b94258057d5
+  subjects:
+  - entities:
+    - role: player
+      name: Dalton Rushing
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: TCRSA-DRU
+  uuid: '0469782c-dc72-4287-894f-32110e6b4f9b'
+  subjects:
+  - entities:
+    - role: player
+      name: Dalton Rushing
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: TCRSA-EQ
+  uuid: f262c3fe-c67f-4316-ae46-c77e41cca3e2
+  subjects:
+  - entities:
+    - role: player
+      name: Edgar Quero
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: TCRSA-HK
+  uuid: cad54e02-985f-4a80-a107-fb4d273c2450
+  subjects:
+  - entities:
+    - role: player
+      name: Hyeseong Kim
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: TCRSA-JA
+  uuid: 64b8403e-6d5f-4578-aa78-0f1b9dfdc188
+  subjects:
+  - entities:
+    - role: player
+      name: Jace Jung
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: TCRSA-JJ
+  uuid: be59a7fe-6087-4c72-a056-31543dbe1579
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Jobe
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: TCRSA-JJO
+  uuid: d2b48f6f-ba59-4357-91da-0f1d2699b7fc
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Jobe
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: TCRSA-JJU
+  uuid: d18636cf-9b64-4bc4-a94e-e319bd15e4dd
+  subjects:
+  - entities:
+    - role: player
+      name: Jace Jung
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: TCRSA-JW
+  uuid: 82eca56e-1dad-47b1-ad04-d232d2f2542d
+  subjects:
+  - entities:
+    - role: player
+      name: James Wood
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: TCRSA-JWI
+  uuid: 4094582f-7264-4631-9042-34421c58f0b7
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Wilson
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: TCRSA-JWO
+  uuid: b8839fc8-b61e-450e-9077-68371adfe5b4
+  subjects:
+  - entities:
+    - role: player
+      name: James Wood
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: TCRSA-KC
+  uuid: dce62150-f94c-483a-9d69-e92505f5dc00
+  subjects:
+  - entities:
+    - role: player
+      name: Kristian Campbell
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: TCRSA-KCA
+  uuid: a752a66a-63ba-4f5d-bee2-8de5d5234828
+  subjects:
+  - entities:
+    - role: player
+      name: Kristian Campbell
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: TCRSA-KU
+  uuid: '0759b35b-101c-4752-ad62-f5444b9a2337'
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Kurtz
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: TCRSA-LEE
+  uuid: 9b0ae24c-8d26-430e-a8c8-d4aebf08c9fe
+  subjects:
+  - entities:
+    - role: player
+      name: Brooks Lee
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: TCRSA-LK
+  uuid: bd87522c-5229-44b8-aa5c-381a18b821f7
+  subjects:
+  - entities:
+    - role: player
+      name: Luke Keaschall
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: TCRSA-MM
+  uuid: cb0b6a2a-a84b-4743-aea4-0cf7e584e14a
+  subjects:
+  - entities:
+    - role: player
+      name: Marcelo Mayer
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: TCRSA-MMY
+  uuid: ef8c0d1f-9558-46bd-b53a-e23ba9f024a4
+  subjects:
+  - entities:
+    - role: player
+      name: Marcelo Mayer
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: TCRSA-MS
+  uuid: 00773f25-63a2-4fb8-9e3d-72e8d75eef46
+  subjects:
+  - entities:
+    - role: player
+      name: Matt Shaw
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: TCRSA-MSH
+  uuid: e711626b-af1d-4a7d-b47d-29e319b4cf6c
+  subjects:
+  - entities:
+    - role: player
+      name: Matt Shaw
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: TCRSA-NK
+  uuid: 94faad89-a15b-4d8c-8507-6e1913cc5028
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Kurtz
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: TCRSA-RL
+  uuid: 55d078ec-6006-42f7-9eb9-e7d859ec80c7
+  subjects:
+  - entities:
+    - role: player
+      name: Rhett Lowder
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: TCRSA-RLO
+  uuid: 5a5784fa-c49d-4649-86de-49b444719d29
+  subjects:
+  - entities:
+    - role: player
+      name: Rhett Lowder
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: TCRSA-RS
+  uuid: '08afe35b-50e0-4d0b-9397-56b3cc97c1e8'
+  subjects:
+  - entities:
+    - role: player
+      name: Roki Sasaki
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: TCRSA-RSA
+  uuid: 5aa0c1a1-dec6-4f94-a447-b4680e3be39c
+  subjects:
+  - entities:
+    - role: player
+      name: Roki Sasaki
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: TCRSA-TS
+  uuid: af35c5f9-bc88-42e0-ba57-44e9263e8711
+  subjects:
+  - entities:
+    - role: player
+      name: Thomas Saggese
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: TCRSA-TSA
+  uuid: 4b3e19e0-ce9a-4183-b6d1-cbe027527e96
+  subjects:
+  - entities:
+    - role: player
+      name: Thomas Saggese
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: TCRSA-WIL
+  uuid: 97f02f9f-4218-4fc5-9121-6c8cadd4a519
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Wilson
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 

--- a/data/baseball/2025-26-topps-transcendent/checklists/transcendent-collection-rookie-showcase-patch-autographs.yaml
+++ b/data/baseball/2025-26-topps-transcendent/checklists/transcendent-collection-rookie-showcase-patch-autographs.yaml
@@ -1,0 +1,330 @@
+- number: RSPA-AR
+  uuid: 82cb4a11-045c-4563-bf43-253595381406
+  subjects:
+  - entities:
+    - role: player
+      name: Agustin Ramírez
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: RSPA-BEN
+  uuid: 9698a09c-335b-46cd-9bf0-4df160bab072
+  subjects:
+  - entities:
+    - role: player
+      name: Ben Rice
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: RSPA-BL
+  uuid: c3b9994b-210d-49b6-9190-f182e38bd3d1
+  subjects:
+  - entities:
+    - role: player
+      name: Brooks Lee
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: RSPA-BR
+  uuid: dd3145c6-ffe2-4ea3-abe8-53b6d7524233
+  subjects:
+  - entities:
+    - role: player
+      name: Ben Rice
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: RSPA-CH
+  uuid: 8dec6960-12ef-4861-955d-96c11c0f7588
+  subjects:
+  - entities:
+    - role: player
+      name: Cade Horton
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: RSPA-CM
+  uuid: 1045faac-3d3f-4ce6-9061-8a5a586eb620
+  subjects:
+  - entities:
+    - role: player
+      name: Coby Mayo
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: RSPA-CME
+  uuid: ddbc3d7c-0dac-488f-a3f5-bc1b0fd81852
+  subjects:
+  - entities:
+    - role: player
+      name: Chase Meidroth
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: RSPA-CN
+  uuid: 82cf74ee-6b97-4b7c-94f7-9d04c6dd9c1d
+  subjects:
+  - entities:
+    - role: player
+      name: Connor Norby
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: RSPA-CNO
+  uuid: b799fbcc-194c-42b2-b66f-aa2e89269941
+  subjects:
+  - entities:
+    - role: player
+      name: Connor Norby
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: RSPA-CS
+  uuid: e37be994-484c-4f9c-8301-62110abdfe82
+  subjects:
+  - entities:
+    - role: player
+      name: Cam Smith
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: RSPA-CSI
+  uuid: 4f9c8804-919c-4e01-8399-70ff375f9b4c
+  subjects:
+  - entities:
+    - role: player
+      name: Chandler Simpson
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: RSPA-DC
+  uuid: 4a4f8375-9b39-4d17-bb0d-0014811aaeb9
+  subjects:
+  - entities:
+    - role: player
+      name: Dylan Crews
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: RSPA-DCR
+  uuid: a410401d-cad4-4e72-a69f-7f134e14056a
+  subjects:
+  - entities:
+    - role: player
+      name: Dylan Crews
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: RSPA-EQ
+  uuid: 12ed87b5-8a02-405e-a9b9-2f91b67858dc
+  subjects:
+  - entities:
+    - role: player
+      name: Edgar Quero
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: RSPA-JJ
+  uuid: db05e374-ae99-4932-97b5-91d902e4f5b8
+  subjects:
+  - entities:
+    - role: player
+      name: Jace Jung
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: RSPA-JJU
+  uuid: d707b408-d01e-4f8b-b157-aabd81f5f3d9
+  subjects:
+  - entities:
+    - role: player
+      name: Jace Jung
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: RSPA-JW
+  uuid: 17913bd4-9fd1-413e-9a21-52fe1f341785
+  subjects:
+  - entities:
+    - role: player
+      name: James Wood
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: RSPA-JWI
+  uuid: 9f11ba48-46ac-4a23-8382-213f4504eefd
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Wilson
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: RSPA-JWO
+  uuid: cfad1ea5-ef53-4c73-88c6-458392632b31
+  subjects:
+  - entities:
+    - role: player
+      name: James Wood
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: RSPA-KC
+  uuid: d0d7aba8-82c5-4c2a-8ca0-9e25267fc433
+  subjects:
+  - entities:
+    - role: player
+      name: Kristian Campbell
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: RSPA-KCA
+  uuid: 5e2fb57f-24ea-45c2-a6ce-a683c488da99
+  subjects:
+  - entities:
+    - role: player
+      name: Kristian Campbell
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: RSPA-LEE
+  uuid: 9e7c5cf0-7a85-46a8-a2ea-3734d6569d5e
+  subjects:
+  - entities:
+    - role: player
+      name: Brooks Lee
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: RSPA-LK
+  uuid: d0aade7c-ba99-437d-a9db-e884003060f8
+  subjects:
+  - entities:
+    - role: player
+      name: Luke Keaschall
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: RSPA-MB
+  uuid: b6f005c0-d035-4d60-bf58-91279aaa7069
+  subjects:
+  - entities:
+    - role: player
+      name: Moisés Ballesteros
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: RSPA-MM
+  uuid: 148d6687-a2e7-48e6-a555-ed56ad13d7fd
+  subjects:
+  - entities:
+    - role: player
+      name: Marcelo Mayer
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: RSPA-MMY
+  uuid: 681e751e-c4e4-46e1-8b37-c7ddac5e1d64
+  subjects:
+  - entities:
+    - role: player
+      name: Marcelo Mayer
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: RSPA-MS
+  uuid: 7acd799d-dd67-4de0-93e0-a297cccb92de
+  subjects:
+  - entities:
+    - role: player
+      name: Matt Shaw
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: RSPA-MSH
+  uuid: 212c0aff-4f03-43f6-9e7a-4d5ca41a242d
+  subjects:
+  - entities:
+    - role: player
+      name: Matt Shaw
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: RSPA-NK
+  uuid: ecb63387-873b-4cdf-8f95-76900f5d7603
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Kurtz
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: RSPA-RH
+  uuid: e7740bd2-49e0-4b11-bd8b-4266db05d382
+  subjects:
+  - entities:
+    - role: player
+      name: Robert Hassell III
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: RSPA-RS
+  uuid: 7cefcd6b-4e50-4627-8829-9deed7318239
+  subjects:
+  - entities:
+    - role: player
+      name: Roki Sasaki
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: RSPA-SM
+  uuid: 78a13032-dd7b-4a2c-917c-5aeb7cf1fb3c
+  subjects:
+  - entities:
+    - role: player
+      name: Cam Smith
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: RSPA-WIL
+  uuid: 13152b47-f3b3-4595-9635-2e9262780340
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Wilson
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 

--- a/data/baseball/2025-26-topps-transcendent/checklists/transcendent-collection-triple-patches.yaml
+++ b/data/baseball/2025-26-topps-transcendent/checklists/transcendent-collection-triple-patches.yaml
@@ -1,0 +1,928 @@
+- number: TCTP-AAS
+  uuid: c6cb53e1-6a1c-4ff6-bcba-d5601a7f8cca
+  subjects:
+  - entities:
+    - role: player
+      name: Cam Smith
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+  - entities:
+    - role: player
+      name: Yordan Alvarez
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+  - entities:
+    - role: player
+      name: Jose Altuve
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: TCTP-AGT
+  uuid: 38748fe9-00fc-4779-9cef-6b4df0d44b84
+  subjects:
+  - entities:
+    - role: player
+      name: Fernando Tatis Jr.
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+  - entities:
+    - role: player
+      name: Ronald Acuña Jr.
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+  - entities:
+    - role: player
+      name: Vladimir Guerrero Jr.
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: TCTP-ALS
+  uuid: bb524f7d-7c31-4849-a3fa-ec9e772a4c66
+  subjects:
+  - entities:
+    - role: player
+      name: Francisco Lindor
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+  - entities:
+    - role: player
+      name: Pete Alonso
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: TCTP-APA
+  uuid: 1cca9645-22c2-4bf4-9913-be5b3be2b237
+  subjects:
+  - entities:
+    - role: player
+      name: Jeremy Peña
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+  - entities:
+    - role: player
+      name: Yordan Alvarez
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+  - entities:
+    - role: player
+      name: Jose Altuve
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: TCTP-BGS
+  uuid: e7262232-0125-40d7-bcff-1708f11c5584
+  subjects:
+  - entities:
+    - role: player
+      name: Javier Báez
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+  - entities:
+    - role: player
+      name: Riley Greene
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+  - entities:
+    - role: player
+      name: Tarik Skubal
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: TCTP-BMM
+  uuid: 9af65c5d-a661-41b2-b183-7a6be04296e4
+  subjects:
+  - entities:
+    - role: player
+      name: Ketel Marte
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+  - entities:
+    - role: player
+      name: Corbin Carroll
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+  - entities:
+    - role: player
+      name: Corbin Burnes
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: TCTP-BTJ
+  uuid: 3437a0a0-86b5-428b-ad4e-e87327b0bb3c
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Trout
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+  - entities:
+    - role: player
+      name: Reggie Jackson
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+  - entities:
+    - role: player
+      name: Bery Blyleven
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: TCTP-CCM
+  uuid: b1675f78-8285-4a1e-b6ec-817f3157e7dd
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Crow-Armstrong
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+  - entities:
+    - role: player
+      name: Jackson Merrill
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+  - entities:
+    - role: player
+      name: Corbin Carroll
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: TCTP-CMD
+  uuid: 0d9259ab-e806-47c5-87ee-7680f9d4e102
+  subjects:
+  - entities:
+    - role: player
+      name: Rafael Devers
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+  - entities:
+    - role: player
+      name: Marcelo Mayer
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+  - entities:
+    - role: player
+      name: Kristian Campbell
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: TCTP-FAO
+  uuid: 61c06c10-16fd-4a4b-b949-3a47f49db4ce
+  subjects:
+  - entities:
+    - role: player
+      name: Freddie Freeman
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+  - entities:
+    - role: player
+      name: Matt Olson
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+  - entities:
+    - role: player
+      name: Pete Alonso
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: TCTP-GBS
+  uuid: de79a180-3346-4075-a6a9-45b626ab921f
+  subjects:
+  - entities:
+    - role: player
+      name: Vladimir Guerrero Jr.
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+  - entities:
+    - role: player
+      name: Bo Bichette
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+  - entities:
+    - role: player
+      name: George Springer
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: TCTP-GTM
+  uuid: 1be51f10-402d-4891-b43d-464de6d1dbd5
+  subjects:
+  - entities:
+    - role: player
+      name: Fernando Tatis Jr.
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+  - entities:
+    - role: player
+      name: Jackson Merrill
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+  - entities:
+    - role: player
+      name: Tony Gwynn
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: TCTP-ICR
+  uuid: ccbd4bdb-1afb-4ea4-bc4e-70349c4418f0
+  subjects:
+  - entities:
+    - role: player
+      name: Ichiro
+      ref: 
+    - role: team
+      name: Florida Marlins
+      ref: 
+  - entities:
+    - role: player
+      name: Miguel Cabrera
+      ref: 
+    - role: team
+      name: Florida Marlins
+      ref: 
+  - entities:
+    - role: player
+      name: Ivan Rodriguez
+      ref: 
+    - role: team
+      name: Florida Marlins
+      ref: 
+- number: TCTP-IRR
+  uuid: 13fee90a-6244-44c1-8231-4f259761fa97
+  subjects:
+  - entities:
+    - role: player
+      name: Julio Rodríguez
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+  - entities:
+    - role: player
+      name: Alex Rodriguez
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+  - entities:
+    - role: player
+      name: Ichiro
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: TCTP-JAS
+  uuid: e5d5bef4-a8b5-4279-99b7-9fdc76f61864
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+  - entities:
+    - role: player
+      name: Aaron Judge
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+  - entities:
+    - role: player
+      name: Ronald Acuña Jr.
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: TCTP-JPT
+  uuid: 01c1db37-5d6d-4fb1-a673-d0bd6cf7f060
+  subjects:
+  - entities:
+    - role: player
+      name: Albert Pujols
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+  - entities:
+    - role: player
+      name: Reggie Jackson
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+  - entities:
+    - role: player
+      name: Mike Trout
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: TCTP-JSB
+  uuid: 041740ce-5c63-47f0-90d8-49d5e3ae2bbb
+  subjects:
+  - entities:
+    - role: player
+      name: Aaron Judge
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+  - entities:
+    - role: player
+      name: Giancarlo Stanton
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+  - entities:
+    - role: player
+      name: Cody Bellinger
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: TCTP-KBF
+  uuid: cede545e-dc69-4e2c-9c25-b05681c91e85
+  subjects:
+  - entities:
+    - role: player
+      name: Freddie Freeman
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+  - entities:
+    - role: player
+      name: Clayton Kershaw
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+  - entities:
+    - role: player
+      name: Mookie Betts
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: TCTP-KCG
+  uuid: f2af23d8-1fb0-40c9-8a15-fb8d60ee5fd2
+  subjects:
+  - entities:
+    - role: player
+      name: Riley Greene
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+  - entities:
+    - role: player
+      name: Al Kaline
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+  - entities:
+    - role: player
+      name: Miguel Cabrera
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: TCTP-LCA
+  uuid: bc03b532-f2af-4aca-9668-98b2f8a01bfd
+  subjects:
+  - entities:
+    - role: player
+      name: Matt Chapman
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+  - entities:
+    - role: player
+      name: Jung Hoo Lee
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+  - entities:
+    - role: player
+      name: Willy Adames
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: TCTP-MJA
+  uuid: 5f925131-9ecb-4dea-9c1f-bd7bfec1ba8b
+  subjects:
+  - entities:
+    - role: player
+      name: Chipper Jones
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+  - entities:
+    - role: player
+      name: Eddie Mathews
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+  - entities:
+    - role: player
+      name: Ronald Acuña Jr.
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: TCTP-MLS
+  uuid: 76336fd8-a44c-495f-a181-1ca37fb4aa33
+  subjects:
+  - entities:
+    - role: player
+      name: Willie Mays
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+  - entities:
+    - role: player
+      name: Francisco Lindor
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: TCTP-MMM
+  uuid: 7b641874-7603-4878-9c95-d3d32d240bc6
+  subjects:
+  - entities:
+    - role: player
+      name: Andrew McCutchen
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: TCTP-MSW
+  uuid: 7076b0f0-4044-4991-ae3a-5f8c71b91b74
+  subjects:
+  - entities:
+    - role: player
+      name: Marcelo Mayer
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+  - entities:
+    - role: player
+      name: Jacob Wilson
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+  - entities:
+    - role: player
+      name: Matt Shaw
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: TCTP-MWK
+  uuid: 6f539431-f788-4609-8ecf-e90247fe5c3e
+  subjects:
+  - entities:
+    - role: player
+      name: Mark McGwire
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+  - entities:
+    - role: player
+      name: Nick Kurtz
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+  - entities:
+    - role: player
+      name: Jacob Wilson
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: TCTP-ODB
+  uuid: 5f9e79d8-2ba0-4d9d-98d2-cc4aa736d63a
+  subjects:
+  - entities:
+    - role: player
+      name: Alex Bregman
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+  - entities:
+    - role: player
+      name: David Ortiz
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+  - entities:
+    - role: player
+      name: Rafael Devers
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: TCTP-ODS
+  uuid: 1d3ffdbf-2d1a-4893-ac42-78e4dd0a8071
+  subjects:
+  - entities:
+    - role: player
+      name: Shohei Ohtani
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+  - entities:
+    - role: player
+      name: Yu Darvish
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+  - entities:
+    - role: player
+      name: Seiya Suzuki
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: TCTP-PWO
+  uuid: 1fbf34b7-b633-43f9-af92-4074465e166a
+  subjects:
+  - entities:
+    - role: player
+      name: Kirby Puckett
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+  - entities:
+    - role: player
+      name: Dave Winfield
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+  - entities:
+    - role: player
+      name: David Ortiz
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: TCTP-RAA
+  uuid: 4a808179-214c-410e-aa3c-77ac084a8e2f
+  subjects:
+  - entities:
+    - role: player
+      name: Ozzie Albies
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+  - entities:
+    - role: player
+      name: Austin Riley
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+  - entities:
+    - role: player
+      name: Ronald Acuña Jr.
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: TCTP-RHH
+  uuid: 4d0eec3c-0807-48b9-a999-5949de4e96f6
+  subjects:
+  - entities:
+    - role: player
+      name: Gunnar Henderson
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+  - entities:
+    - role: player
+      name: Jackson Holliday
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+  - entities:
+    - role: player
+      name: Adley Rutschman
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: TCTP-RJT
+  uuid: fafb725c-0574-4275-a62f-74a59ffa30bf
+  subjects:
+  - entities:
+    - role: player
+      name: Julio Rodríguez
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+  - entities:
+    - role: player
+      name: Aaron Judge
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+  - entities:
+    - role: player
+      name: Mike Trout
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: TCTP-RRA
+  uuid: f7648b3c-328b-482f-9b63-29fef8bb0d94
+  subjects:
+  - entities:
+    - role: player
+      name: Randy Arozarena
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+  - entities:
+    - role: player
+      name: Cal Raleigh
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+  - entities:
+    - role: player
+      name: Julio Rodríguez
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: TCTP-RRM
+  uuid: 05b3f108-7bad-44fc-80aa-bcb09a6f69b1
+  subjects:
+  - entities:
+    - role: player
+      name: José Ramírez
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+  - entities:
+    - role: player
+      name: Austin Riley
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+  - entities:
+    - role: player
+      name: Manny Machado
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: TCTP-SCF
+  uuid: 5763be33-8c08-45bd-af58-def9271ae58f
+  subjects:
+  - entities:
+    - role: player
+      name: CC Sabathia
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+  - entities:
+    - role: player
+      name: Gerrit Cole
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+  - entities:
+    - role: player
+      name: Max Fried
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: TCTP-SSS
+  uuid: 57ea2060-9f5f-4d28-ae8b-7f1b4e8c895b
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: TCTP-SSSC
+  uuid: 614d2744-d4c5-4162-ac4c-027c4f466c96
+  subjects:
+  - entities:
+    - role: player
+      name: Max Scherzer
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: TCTP-STS
+  uuid: 7bbb18a4-1dab-4006-af6d-4cc094d7f483
+  subjects:
+  - entities:
+    - role: player
+      name: Max Scherzer
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+  - entities:
+    - role: player
+      name: Trea Turner
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: TCTP-TBH
+  uuid: 010f26f3-1c09-4734-be19-120617937af0
+  subjects:
+  - entities:
+    - role: player
+      name: Mookie Betts
+      ref: 
+    - role: team
+      name: Angels
+      ref: 
+  - entities:
+    - role: player
+      name: Mike Trout
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+  - entities:
+    - role: player
+      name: Bryce Harper
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: TCTP-TMB
+  uuid: afaf17cc-5cb5-4626-9b5d-4248f92e9697
+  subjects:
+  - entities:
+    - role: player
+      name: Xander Bogaerts
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+  - entities:
+    - role: player
+      name: Fernando Tatis Jr.
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+  - entities:
+    - role: player
+      name: Manny Machado
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: TCTP-VVV
+  uuid: 957801cc-93e0-4749-b825-036eb580a591
+  subjects:
+  - entities:
+    - role: player
+      name: Justin Verlander
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: TCTP-YIS
+  uuid: ac15ec9c-288a-4726-bc07-4a41d42d1bd2
+  subjects:
+  - entities:
+    - role: player
+      name: Shota Imanaga
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+  - entities:
+    - role: player
+      name: Yoshinobu Yamamoto
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+  - entities:
+    - role: player
+      name: Kodai Senga
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 

--- a/data/baseball/2025-26-topps-transcendent/checklists/transcendent-collection-world-series-logo-patch-autograph.yaml
+++ b/data/baseball/2025-26-topps-transcendent/checklists/transcendent-collection-world-series-logo-patch-autograph.yaml
@@ -1,0 +1,50 @@
+- number: WSMLB-AV
+  uuid: 3d0c6083-df9e-4af3-b3b6-478705a04745
+  subjects:
+  - entities:
+    - role: player
+      name: Anthony Volpe
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: WSMLB-AW
+  uuid: e7be5a5d-d5a9-42e9-9808-1697875fb800
+  subjects:
+  - entities:
+    - role: player
+      name: Austin Wells
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: WSMLB-JS
+  uuid: 004a38cc-41ae-44bf-aed8-3e1e7bcf3ca7
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: WSMLB-JT
+  uuid: 33388f20-4df0-4e66-a7bd-e701e4fd1f0d
+  subjects:
+  - entities:
+    - role: player
+      name: Jose Trevino
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: WSMLB-TI
+  uuid: 1cf28f8a-cfcc-42e9-ab59-2b0b648f4b49
+  subjects:
+  - entities:
+    - role: player
+      name: Tim Hill
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 

--- a/data/baseball/2025-26-topps-transcendent/checklists/transcendent-collection-world-series-patch-autograph.yaml
+++ b/data/baseball/2025-26-topps-transcendent/checklists/transcendent-collection-world-series-patch-autograph.yaml
@@ -1,0 +1,50 @@
+- number: WSPA-AV
+  uuid: 4e89c572-744d-4959-aee2-9acba5564fec
+  subjects:
+  - entities:
+    - role: player
+      name: Anthony Volpe
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: WSPA-AW
+  uuid: c5aee90e-c047-4df4-bfec-47a4fa2b3495
+  subjects:
+  - entities:
+    - role: player
+      name: Austin Wells
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: WSPA-JS
+  uuid: 264b8fd8-e27a-4125-b9ea-afed5620989c
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: WSPA-JT
+  uuid: 77adf76e-5c85-48d2-8d6f-9986141e1703
+  subjects:
+  - entities:
+    - role: player
+      name: Jose Trevino
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: WSPA-TI
+  uuid: de1ca472-a6a3-44eb-b274-d4a6316cc014
+  subjects:
+  - entities:
+    - role: player
+      name: Tim Hill
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 

--- a/data/baseball/2025-26-topps-transcendent/checklists/transcendent-collection-world-series-relic-autograph.yaml
+++ b/data/baseball/2025-26-topps-transcendent/checklists/transcendent-collection-world-series-relic-autograph.yaml
@@ -1,0 +1,60 @@
+- number: WSAR-AV
+  uuid: a350ba81-f3ac-4819-a74f-69ae62bf09c1
+  subjects:
+  - entities:
+    - role: player
+      name: Anthony Volpe
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: WSAR-AVO
+  uuid: db36cfb0-fac0-47ff-a9e3-de0f0580d5b1
+  subjects:
+  - entities:
+    - role: player
+      name: Anthony Volpe
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: WSAR-AW
+  uuid: 0d6d3314-6407-419b-a7ea-f9163949d611
+  subjects:
+  - entities:
+    - role: player
+      name: Austin Wells
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: WSAR-AWE
+  uuid: 0d871de8-b74f-4742-9131-e6601ad420a3
+  subjects:
+  - entities:
+    - role: player
+      name: Austin Wells
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: WSAR-JS
+  uuid: dc888b29-80ce-4753-a8bb-ef71da21421f
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: WSAR-JSO
+  uuid: 6c7d2db5-c3bb-4335-99bc-6147dec64705
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 

--- a/data/baseball/2025-26-topps-transcendent/checklists/transcendent-icons-chrome-autograph.yaml
+++ b/data/baseball/2025-26-topps-transcendent/checklists/transcendent-icons-chrome-autograph.yaml
@@ -1,0 +1,610 @@
+- number: TAIC-AP
+  uuid: f17436e7-7eee-4bbf-9fe0-65e542e7c38f
+  subjects:
+  - entities:
+    - role: player
+      name: Andy Pettitte
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: TAIC-APU
+  uuid: a85efeb6-70ab-4b87-998d-438e083db6e0
+  subjects:
+  - entities:
+    - role: player
+      name: Albert Pujols
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: TAIC-AV
+  uuid: 3a6cdbcf-3387-4eec-99ce-f00af2b983e3
+  subjects:
+  - entities:
+    - role: player
+      name: Anthony Volpe
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: TAIC-BAG
+  uuid: 29825ba7-56c7-4977-9faf-9117f30209ab
+  subjects:
+  - entities:
+    - role: player
+      name: Jeff Bagwell
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: TAIC-BB
+  uuid: c6eb9706-8f8f-4bb1-a3a0-b416e5661bea
+  subjects:
+  - entities:
+    - role: player
+      name: Barry Bonds
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: TAIC-BH
+  uuid: 8741e9be-c621-49d9-8ad9-cd41dd241b6b
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Harper
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: TAIC-BJ
+  uuid: 48633a3d-0bab-4ea6-87b7-2c5eea4d0132
+  subjects:
+  - entities:
+    - role: player
+      name: Bo Jackson
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: TAIC-BL
+  uuid: 6a9dcb0b-f2a9-4ffd-ac7b-c7adaed015e4
+  subjects:
+  - entities:
+    - role: player
+      name: Barry Larkin
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: TAIC-BP
+  uuid: 3695a2f8-acb8-4bdf-a157-862cedb031c8
+  subjects:
+  - entities:
+    - role: player
+      name: Buster Posey
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: TAIC-BW
+  uuid: ef58c28b-fb66-49d9-8e13-c4dd00ad264f
+  subjects:
+  - entities:
+    - role: player
+      name: Bobby Witt Jr.
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: TAIC-CA
+  uuid: dcea1f48-29f9-4d6f-a24f-67d6dcaa9dde
+  subjects:
+  - entities:
+    - role: player
+      name: Cam Smith
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: TAIC-CC
+  uuid: da91184c-4772-409b-b084-4fb89f6eabd1
+  subjects:
+  - entities:
+    - role: player
+      name: Corbin Carroll
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: TAIC-CF
+  uuid: cced3e99-ca79-49c9-aacf-0a768c01b4f8
+  subjects:
+  - entities:
+    - role: player
+      name: Carlton Fisk
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: TAIC-CJ
+  uuid: 6ea25b1b-d98b-43d4-8219-012e7e3d9316
+  subjects:
+  - entities:
+    - role: player
+      name: Chipper Jones
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: TAIC-CK
+  uuid: d91c995b-592b-4082-a801-b1e199780c9d
+  subjects:
+  - entities:
+    - role: player
+      name: Clayton Kershaw
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: TAIC-CR
+  uuid: 944af537-c3ce-4fad-b120-f3e5d1de2709
+  subjects:
+  - entities:
+    - role: player
+      name: Cal Ripken Jr.
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: TAIC-CU
+  uuid: 1584d956-1653-4c2b-9b08-d78325ae6977
+  subjects:
+  - entities:
+    - role: player
+      name: Chase Utley
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: TAIC-DJ
+  uuid: a2e6f018-8260-4ce5-bf92-559334bf8181
+  subjects:
+  - entities:
+    - role: player
+      name: Derek Jeter
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: TAIC-EM
+  uuid: 15c62fd8-fb67-4bae-a9ef-9313119989d4
+  subjects:
+  - entities:
+    - role: player
+      name: Eddie Murray
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: TAIC-FT
+  uuid: acb4c54c-cac0-4d67-8c94-3a7aaf66d9b3
+  subjects:
+  - entities:
+    - role: player
+      name: Frank Thomas
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: TAIC-FTJ
+  uuid: 2369873e-5f3f-45fa-9834-979172811ded
+  subjects:
+  - entities:
+    - role: player
+      name: Fernando Tatis Jr.
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: TAIC-GB
+  uuid: d797419d-9a96-401e-9879-a1649af0f154
+  subjects:
+  - entities:
+    - role: player
+      name: George Brett
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: TAIC-GM
+  uuid: 5e1c9272-8221-4ae8-9668-aa259d5e177d
+  subjects:
+  - entities:
+    - role: player
+      name: Greg Maddux
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: TAIC-HM
+  uuid: 674cc8a4-5f91-48ea-b352-15c3e4291f7c
+  subjects:
+  - entities:
+    - role: player
+      name: Hideki Matsui
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: TAIC-I
+  uuid: 75ef2c12-7640-46fd-91c1-40188695d337
+  subjects:
+  - entities:
+    - role: player
+      name: Ichiro
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: TAIC-IR
+  uuid: e8b38574-7a36-48ec-8095-aeafa4d3fb3d
+  subjects:
+  - entities:
+    - role: player
+      name: Ivan Rodriguez
+      ref: 
+    - role: team
+      name: Florida Marlins
+      ref: 
+- number: TAIC-JB
+  uuid: 8197a182-1809-4284-9683-4572821f4dae
+  subjects:
+  - entities:
+    - role: player
+      name: Johnny Bench
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: TAIC-JC
+  uuid: 4eddf365-1c76-49a5-9be6-fbffe967e898
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Chourio
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: TAIC-JH
+  uuid: 5c567790-a74d-43e4-a503-248c0cc68516
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Holliday
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: TAIC-JP
+  uuid: ad9f697e-1848-459f-80d0-b69883fb930c
+  subjects:
+  - entities:
+    - role: player
+      name: Jorge Posada
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: TAIC-JRA
+  uuid: 357e8d9b-4848-494c-8d35-701aad458e70
+  subjects:
+  - entities:
+    - role: player
+      name: José Ramírez
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: TAIC-JS
+  uuid: fc7dd472-04ce-4b73-a7b0-af0c60fb0962
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: TAIC-JW
+  uuid: d10ea4f0-0bf7-44e0-aa2a-baa107ac21ae
+  subjects:
+  - entities:
+    - role: player
+      name: James Wood
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: TAIC-KA
+  uuid: d8898a31-7624-4ca5-bcf4-b61fd5c57406
+  subjects:
+  - entities:
+    - role: player
+      name: Kevin Alcántara
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: TAIC-KC
+  uuid: 27ddff32-f7d2-4489-8faf-e40dcad0c823
+  subjects:
+  - entities:
+    - role: player
+      name: Kristian Campbell
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: TAIC-KG
+  uuid: 149d71a5-9f9e-4a1e-9e60-0128900a3b19
+  subjects:
+  - entities:
+    - role: player
+      name: Ken Griffey Jr.
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: TAIC-LEE
+  uuid: c302db91-379f-4ef6-b9f3-5b7c007c024b
+  subjects:
+  - entities:
+    - role: player
+      name: Brooks Lee
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: TAIC-MA
+  uuid: fb22f7ea-3862-4159-b53d-4d3293ff2b29
+  subjects:
+  - entities:
+    - role: player
+      name: Matt Shaw
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: TAIC-MMG
+  uuid: 9234095b-3941-4d7e-a7a8-500844ce475d
+  subjects:
+  - entities:
+    - role: player
+      name: Mark McGwire
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: TAIC-MP
+  uuid: 93304fba-fa2d-4117-998e-3d7581329a14
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Piazza
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: TAIC-MS
+  uuid: abefd5dd-e4c7-4850-8ecb-1acb36549599
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Schmidt
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: TAIC-MT
+  uuid: ac463822-8815-4051-9aa3-6582ebadc1f7
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Trout
+      ref: 
+    - role: team
+      name: Angels
+      ref: 
+- number: TAIC-NA
+  uuid: 82c021cc-bbc4-4403-822f-fb2dd729191f
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan Arenado
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: TAIC-OH
+  uuid: 2259e56c-557d-44a3-bd56-420bb72d66aa
+  subjects:
+  - entities:
+    - role: player
+      name: Orel Hershiser
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: TAIC-OS
+  uuid: 959ebab6-5c4d-41e0-ad4d-ee5f663e0909
+  subjects:
+  - entities:
+    - role: player
+      name: Ozzie Smith
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: TAIC-PCA
+  uuid: 4597d048-ecbe-47d9-8cfc-b2dfd6dbcd67
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Crow-Armstrong
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: TAIC-PMO
+  uuid: 82e56c8f-e675-42fd-b49d-37509df2e5dc
+  subjects:
+  - entities:
+    - role: player
+      name: Paul Molitor
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: TAIC-PS
+  uuid: a435e22c-cbd3-4e34-8289-d06652ba1b80
+  subjects:
+  - entities:
+    - role: player
+      name: Paul Skenes
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: TAIC-RC
+  uuid: 43aed64c-01f1-42df-9451-20f32a80cb72
+  subjects:
+  - entities:
+    - role: player
+      name: Roger Clemens
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: TAIC-RJ
+  uuid: 82a879ec-d8b7-4097-b42e-5c1d33e08df7
+  subjects:
+  - entities:
+    - role: player
+      name: Randy Johnson
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: TAIC-RJA
+  uuid: 6131d78b-6986-43cf-afe2-6f6253321d46
+  subjects:
+  - entities:
+    - role: player
+      name: Reggie Jackson
+      ref: 
+    - role: team
+      name: Oakland Athletics
+      ref: 
+- number: TAIC-RL
+  uuid: 2c48d5ad-3997-4ec0-aec6-8e38ae3686f8
+  subjects:
+  - entities:
+    - role: player
+      name: Rhett Lowder
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: TAIC-ROD
+  uuid: b6147c0c-c85e-44fd-9dae-e3b4ea22176c
+  subjects:
+  - entities:
+    - role: player
+      name: Rod Carew
+      ref: 
+    - role: team
+      name: California Angels
+      ref: 
+- number: TAIC-RS
+  uuid: 6d064756-f70e-4bbc-9e9a-8c0b9197e4bf
+  subjects:
+  - entities:
+    - role: player
+      name: Roki Sasaki
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: TAIC-RY
+  uuid: 2609cfad-d966-4c97-a1b2-b276c22d8870
+  subjects:
+  - entities:
+    - role: player
+      name: Robin Yount
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: TAIC-SO
+  uuid: 864b7cac-cf60-44f5-b716-756bef37bf69
+  subjects:
+  - entities:
+    - role: player
+      name: Shohei Ohtani
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: TAIC-SS
+  uuid: 680ecce5-dd48-4b1c-9fb1-1e612a0a992f
+  subjects:
+  - entities:
+    - role: player
+      name: Sammy Sosa
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: TAIC-TT
+  uuid: 83878591-8174-47f6-b37e-3c5c0f95aa33
+  subjects:
+  - entities:
+    - role: player
+      name: Trea Turner
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: TAIC-VG
+  uuid: ce48d12a-ce49-4c36-b4c1-28646d27f035
+  subjects:
+  - entities:
+    - role: player
+      name: Vladimir Guerrero
+      ref: 
+    - role: team
+      name: Angels
+      ref: 
+- number: TAIC-WC
+  uuid: a4e6b232-5c23-43fc-b345-507240446152
+  subjects:
+  - entities:
+    - role: player
+      name: Will Clark
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: TAIC-YY
+  uuid: 6d5fd751-ea63-42a4-9b05-311880842ff4
+  subjects:
+  - entities:
+    - role: player
+      name: Yoshinobu Yamamoto
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 

--- a/data/baseball/2025-26-topps-transcendent/manifest.yaml
+++ b/data/baseball/2025-26-topps-transcendent/manifest.yaml
@@ -1,0 +1,329 @@
+set_id: 2025-26-topps-transcendent
+base_sets:
+- id: base-set
+  name: Base Set
+  uuid: 0a66f1c5-0c82-50e7-b89c-edd19714d55a
+  declared_card_count: 100
+  parallels:
+  - name: Gold Refractor
+    print_run: 10
+    serial_numbered: true
+  - name: Orange Refractor
+    print_run: 25
+    serial_numbered: true
+  - name: Red Refractor
+    print_run: 5
+    serial_numbered: true
+  - name: SuperFractor
+    print_run: 1
+    serial_numbered: true
+  subsets:
+  - id: base-set-image-variations
+    name: Base Set - Image Variations
+    uuid: 7fa0df72-7ea4-5db9-80ac-1f72460aaed3
+    type:
+    - variation
+    declared_card_count: 99
+    parallels:
+    - name: Gold Refractor
+      print_run: 10
+      serial_numbered: true
+    - name: Orange Refractor
+      print_run: 25
+      serial_numbered: true
+    - name: Red Refractor
+      print_run: 5
+      serial_numbered: true
+    - name: SuperFractor
+      print_run: 1
+      serial_numbered: true
+subsets:
+- id: 1961-topps-all-star-superfractor-autographs
+  name: 1961 Topps All Star Superfractor Autographs
+  uuid: b84fafde-58fd-5a8b-a87a-43cf8d5f9cb2
+  type:
+  - autograph
+  declared_card_count: 27
+- id: 1961-topps-combos-superfractor-autographs
+  name: 1961 Topps Combos Superfractor Autographs
+  uuid: 2f998f46-baa7-50e7-afa0-5a77aa6374f1
+  type:
+  - autograph
+  declared_card_count: 7
+- id: 1961-topps-mvp-superfractor-autographs
+  name: 1961 Topps MVP Superfractor Autographs
+  uuid: fe150c55-601d-5d83-a7dc-e71e5a6654ac
+  type:
+  - autograph
+  declared_card_count: 40
+- id: 1961-topps-superfractor-autographs
+  name: 1961 Topps Superfractor Autographs
+  uuid: 2d56ec8f-87a0-5e0e-9d94-a3b633462932
+  type:
+  - autograph
+  declared_card_count: 77
+- id: 2025-rookies-through-the-years-autographs
+  name: 2025 Rookies Through the Years Autographs
+  uuid: 7f0333d0-1fbe-5120-b2d2-7665b44afa11
+  type:
+  - autograph
+  declared_card_count: 81
+- id: cut-signature-booklets
+  name: Cut Signature Booklets
+  uuid: f47b88e1-7d4c-568e-ab1a-ee54d4aad89b
+  type:
+  - autograph
+  declared_card_count: 15
+- id: cut-signatures
+  name: Cut Signatures
+  uuid: 49fab868-7f0b-52cd-80e0-1795a08c42c0
+  type:
+  - autograph
+  declared_card_count: 43
+- id: dual-cut-signature-booklets
+  name: Dual Cut Signature Booklets
+  uuid: b6764dbc-8bf6-57a5-bef3-bc48ed1ffa3f
+  type:
+  - autograph
+  declared_card_count: 5
+- id: gemstones
+  name: Gemstones
+  uuid: ade183a9-8fad-5c81-9d41-2bd8af04ab9c
+  type:
+  - insert
+  declared_card_count: 4
+- id: mlb-logo-autograph-patch-card
+  name: MLB Logo Autograph Patch Card
+  uuid: '0959b902-d58f-5ecd-a98a-f0d53447adf5'
+  type:
+  - autograph
+  - relic
+  declared_card_count: 32
+  parallels:
+  - name: Black Refractor
+    print_run: 10
+    serial_numbered: true
+  - name: Red Refractor
+    print_run: 5
+    serial_numbered: true
+  - name: SuperFractor
+    print_run: 1
+    serial_numbered: true
+- id: oversized-quad-cut-signatures
+  name: Oversized Quad Cut Signatures
+  uuid: 3ed3b636-af47-5358-ba6d-485a07820a5e
+  type:
+  - autograph
+  declared_card_count: 1
+- id: record-breaking-autograph-relic
+  name: Record Breaking Autograph Relic
+  uuid: 5fabd8bd-b21e-55ee-8334-937d5319b1b4
+  type:
+  - autograph
+  - relic
+  declared_card_count: 1
+  parallels:
+  - name: MLB Logo Patch
+    print_run: 1
+    serial_numbered: true
+- id: record-breaking-mlb-logo-patch-autographed-relic
+  name: Record Breaking MLB Logo Patch Autographed Relic
+  uuid: b60cf707-e62e-56a0-8261-0e6ea968639e
+  type:
+  - autograph
+  - relic
+  declared_card_count: 1
+- id: through-the-years-dual-autographs
+  name: Through the Years Dual Autographs
+  uuid: 5e5657d4-be4f-5c55-ba0c-c1f870016ad8
+  type:
+  - autograph
+  declared_card_count: 8
+- id: transcendent-autograph-relic
+  name: Transcendent Autograph Relic
+  uuid: e82a01c4-eeee-59bd-ba5c-377cb02bb85d
+  type:
+  - autograph
+  - relic
+  declared_card_count: 51
+  parallels:
+  - name: Blue
+    print_run: 10
+    serial_numbered: true
+  - name: Emerald
+    print_run: 5
+    serial_numbered: true
+  - name: Platinum
+    print_run: 1
+    serial_numbered: true
+- id: transcendent-collection-dual-patch-autograph-variation
+  name: Transcendent Collection Dual Patch Autograph Variation
+  uuid: 3fd3425d-d747-56ca-8b89-d84b84015308
+  type:
+  - autograph
+  - relic
+  - variation
+  declared_card_count: 10
+  parallels:
+  - name: Emerald
+    print_run: 5
+    serial_numbered: true
+  - name: Platinum
+    print_run: 1
+    serial_numbered: true
+- id: transcendent-collection-dual-patches
+  name: Transcendent Collection Dual Patches
+  uuid: 40b5b6bf-a046-5718-bd01-5227fc5bb8b5
+  type:
+  - relic
+  declared_card_count: 40
+- id: transcendent-collection-gold-framed-autographs
+  name: Transcendent Collection Gold Framed Autographs
+  uuid: d3fd2635-1233-5bd3-9516-7530c17d79a9
+  type:
+  - autograph
+  declared_card_count: 92
+- id: transcendent-collection-jumbo-patch-autographs
+  name: Transcendent Collection Jumbo Patch Autographs
+  uuid: 5dd47c67-9e5a-5aeb-a64e-b81c4ecddd8e
+  type:
+  - autograph
+  - relic
+  declared_card_count: 23
+  parallels:
+  - name: Platinum
+    print_run: 1
+    serial_numbered: true
+- id: transcendent-collection-legendary-relic-cards
+  name: Transcendent Collection Legendary Relic Cards
+  uuid: 9aff94d6-bdce-51ca-9c42-19352a1f07a1
+  type:
+  - relic
+  declared_card_count: 15
+  parallels:
+  - name: Platinum
+    print_run: 1
+    serial_numbered: true
+- id: transcendent-collection-mlb-logo-patches
+  name: Transcendent Collection MLB Logo Patches
+  uuid: c04e88c5-df7a-575d-811f-fd14d96c239b
+  type:
+  - relic
+  declared_card_count: 48
+- id: transcendent-collection-patch-autographs
+  name: Transcendent Collection Patch Autographs
+  uuid: 4d8e205e-38fa-5684-b5cf-732e6ea58c30
+  type:
+  - autograph
+  - relic
+  declared_card_count: 50
+  parallels:
+  - name: Blue
+    print_run: 10
+    serial_numbered: true
+  - name: Emerald
+    print_run: 5
+    serial_numbered: true
+  - name: Platinum
+    print_run: 1
+    serial_numbered: true
+- id: transcendent-collection-patches
+  name: Transcendent Collection Patches
+  uuid: caac377e-50e4-5dc0-97aa-c33ced96241f
+  type:
+  - relic
+  declared_card_count: 78
+- id: transcendent-collection-rookie-showcase-autographs
+  name: Transcendent Collection Rookie Showcase Autographs
+  uuid: 0ddc57c7-4150-5913-b954-8b6b15fcca09
+  type:
+  - autograph
+  declared_card_count: 41
+  parallels:
+  - name: Blue
+    print_run: 10
+    serial_numbered: true
+  - name: Emerald
+    print_run: 5
+    serial_numbered: true
+  - name: Platinum
+    print_run: 1
+    serial_numbered: true
+- id: transcendent-collection-rookie-showcase-patch-autographs
+  name: Transcendent Collection Rookie Showcase Patch Autographs
+  uuid: 42f20cbb-323d-58ac-b8d0-47f35738873b
+  type:
+  - autograph
+  - relic
+  declared_card_count: 33
+  parallels:
+  - name: Platinum
+    print_run: 1
+    serial_numbered: true
+- id: transcendent-collection-triple-patches
+  name: Transcendent Collection Triple Patches
+  uuid: 6742e64c-7d04-5369-95cc-e83b1402315e
+  type:
+  - relic
+  declared_card_count: 41
+- id: transcendent-collection-world-series-logo-patch-autograph
+  name: Transcendent Collection World Series Logo Patch Autograph
+  uuid: fe7de106-d77c-5ea9-a474-8646364bfabb
+  type:
+  - autograph
+  - relic
+  declared_card_count: 5
+  parallels:
+  - name: Platinum
+    print_run: 1
+    serial_numbered: true
+- id: transcendent-collection-world-series-patch-autograph
+  name: Transcendent Collection World Series Patch Autograph
+  uuid: ece6c2e5-1c0e-5c31-8483-f77c6b2bae08
+  type:
+  - autograph
+  - relic
+  declared_card_count: 5
+  parallels:
+  - name: Blue
+    print_run: 10
+    serial_numbered: true
+  - name: Emerald
+    print_run: 5
+    serial_numbered: true
+  - name: Platinum
+    print_run: 1
+    serial_numbered: true
+- id: transcendent-collection-world-series-relic-autograph
+  name: Transcendent Collection World Series Relic Autograph
+  uuid: 781e504f-3b3f-51eb-9672-ec0a6afe216d
+  type:
+  - autograph
+  - relic
+  declared_card_count: 6
+  parallels:
+  - name: Blue
+    print_run: 10
+    serial_numbered: true
+  - name: Emerald
+    print_run: 5
+    serial_numbered: true
+  - name: Platinum
+    print_run: 1
+    serial_numbered: true
+- id: transcendent-icons-chrome-autograph
+  name: Transcendent Icons Chrome Autograph
+  uuid: 3dad0d45-293f-5f1f-9941-9e91e408fff3
+  type:
+  - autograph
+  declared_card_count: 61
+  parallels:
+  - name: Blue
+    print_run: 10
+    serial_numbered: true
+  - name: Emerald
+    print_run: 5
+    serial_numbered: true
+  - name: Platinum
+    print_run: 1
+    serial_numbered: true

--- a/data/baseball/2025-26-topps-transcendent/set.yaml
+++ b/data/baseball/2025-26-topps-transcendent/set.yaml
@@ -1,0 +1,21 @@
+uuid: 0bc90d45-1dd1-49f7-b77b-340d3dd5ab48
+set_id: 2025-26-topps-transcendent
+name: 2025-26 Topps Transcendent
+genre: Sports
+category:
+- MLB
+sports:
+- Baseball
+season: 2025-26
+years:
+- 2025
+- 2026
+manufacturer: Topps
+release_date: '2026-04-01'
+description: '2025-26 Topps Transcendent was released April 1st, 2026. Each box contains
+  eight packs of four cards, plus ten additional cards. Each box will also contain
+  the following:'
+source:
+  name: BaseballCardpedia
+  url: https://baseballcardpedia.com/index.php/2025-26_Topps_Transcendent#Checklist
+  file: import/2025-Topps-Transcendent-Baseball-Checklist.xlsx


### PR DESCRIPTION
Converts jmurphyrum's **2025-26 Topps Transcendent** (#18, exploded) to the **v0.3 manifest form**. Same data, compact and reviewable. Passes the v0.3 validator. Supersedes #18.

1 base set (100) + Image Variations; the rest are product-level autograph/relic subsets (auto-relics typed `[autograph, relic]`); 1961 Topps family flat.

⚠️ Draft — leaving open so @jmurphyrum can review the structure before merge.