### PR TITLE
feat(data): 2026 Panini Stars & Stripes Prizm in v0.3 manifest form (converted from #21)

### DIFF
--- a/data/baseball/2026-panini-prizm-stars-stripes/checklists/13u-14u-national-team-signatures.yaml
+++ b/data/baseball/2026-panini-prizm-stars-stripes/checklists/13u-14u-national-team-signatures.yaml
@@ -1,0 +1,500 @@
+- number: '1'
+  uuid: c0a0a226-0017-447b-87bb-c8d21d46f133
+  subjects:
+  - entities:
+    - role: player
+      name: Zaylon Johnson
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '2'
+  uuid: e61064a3-07d0-46b4-ae82-dab7ad865812
+  subjects:
+  - entities:
+    - role: player
+      name: Brenner Brown
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '3'
+  uuid: b02f00fa-e6a9-49ae-a70e-eb5c83aabb0f
+  subjects:
+  - entities:
+    - role: player
+      name: Amani Tuiasosopo
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '4'
+  uuid: 04e1fa47-6bb2-421c-b656-18fd4c7fd2a5
+  subjects:
+  - entities:
+    - role: player
+      name: Noah Burt
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '5'
+  uuid: 15484278-8b7c-43a2-bfce-ca5ac8b589cd
+  subjects:
+  - entities:
+    - role: player
+      name: Fielder Grebert
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '6'
+  uuid: ba8073cc-a2cf-4fd3-b4c8-47a4521c2f23
+  subjects:
+  - entities:
+    - role: player
+      name: Tyler Early
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '7'
+  uuid: afbb0507-7d95-4f69-a975-e07377d3ca9c
+  subjects:
+  - entities:
+    - role: player
+      name: Cooper Hutton
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '8'
+  uuid: c06517d7-a07c-4954-b3a9-59e10aaee353
+  subjects:
+  - entities:
+    - role: player
+      name: Christian Choe
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '9'
+  uuid: 0db98772-7c70-4460-b559-f661ae7830c5
+  subjects:
+  - entities:
+    - role: player
+      name: Levi Wolf
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '10'
+  uuid: 63d88c22-3e0b-4e77-9ff4-c3cf8154549a
+  subjects:
+  - entities:
+    - role: player
+      name: Kade Valdivia
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '11'
+  uuid: d11a70d3-9e51-4c54-8ef6-9114f1a5bd76
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan Bingham
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '12'
+  uuid: 306bc04a-f8d8-4e11-83b5-23dfa948c88e
+  subjects:
+  - entities:
+    - role: player
+      name: Bowen Landry
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '13'
+  uuid: 96f2bfe9-da24-4a16-a6e3-96fe88ff26c2
+  subjects:
+  - entities:
+    - role: player
+      name: Nathan Handley-White
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '14'
+  uuid: 3ec4608b-b814-4d6b-86c8-c90e8cc9f1cf
+  subjects:
+  - entities:
+    - role: player
+      name: Carlo Rivero
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '15'
+  uuid: a971d90c-2867-40ef-abb8-de6512fd0584
+  subjects:
+  - entities:
+    - role: player
+      name: Colt Carter
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '16'
+  uuid: 9bddde58-d8f3-4fb5-bfab-f5fff453ac96
+  subjects:
+  - entities:
+    - role: player
+      name: Noah Vrzal
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '17'
+  uuid: 9a37c574-e50d-4616-b4c7-0a22c4b6bf06
+  subjects:
+  - entities:
+    - role: player
+      name: Enzi-Yaw Otieku
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '18'
+  uuid: 2a1269fd-503c-4e0f-8547-cc8eaf135718
+  subjects:
+  - entities:
+    - role: player
+      name: Ethan Palacios
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '19'
+  uuid: b102a28c-2349-468b-9e84-b6f66c2ff4e7
+  subjects:
+  - entities:
+    - role: player
+      name: Jayden Portes
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '20'
+  uuid: bc25388e-251c-4663-8e09-cff1d43a9a2e
+  subjects:
+  - entities:
+    - role: player
+      name: Sean Simon
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '21'
+  uuid: 1b772415-7ef3-481b-a855-82297130fe1d
+  subjects:
+  - entities:
+    - role: player
+      name: Mattias DiMaggio
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '22'
+  uuid: 99f372ed-fa2c-484d-92e3-720c96fa412b
+  subjects:
+  - entities:
+    - role: player
+      name: Devin Urena
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '23'
+  uuid: 42b8b710-7e63-4b39-b0e6-d341791b7e64
+  subjects:
+  - entities:
+    - role: player
+      name: Mason Miller
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '24'
+  uuid: 546621a4-302b-4f00-ba2d-1d76de5d6827
+  subjects:
+  - entities:
+    - role: player
+      name: Cooper Gear
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '25'
+  uuid: 1956d505-497c-493e-96fa-d389550c7f80
+  subjects:
+  - entities:
+    - role: player
+      name: Wyatt Peabody
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '26'
+  uuid: 9586752f-2c73-4d3a-8b7e-9b6918aec5ee
+  subjects:
+  - entities:
+    - role: player
+      name: CJ Dornfeld
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '27'
+  uuid: 465edf32-c3b3-4bc5-81f0-b2cc43a61f5c
+  subjects:
+  - entities:
+    - role: player
+      name: Jake Mercado
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '28'
+  uuid: 90e8cc80-17e8-430d-a38e-8b4e58c35c96
+  subjects:
+  - entities:
+    - role: player
+      name: Alex Pena
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '29'
+  uuid: 506c5353-b338-4486-a95d-77ceebbfe60f
+  subjects:
+  - entities:
+    - role: player
+      name: Paris Head
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '30'
+  uuid: 713e5c84-e119-4df9-a3ad-360e4520f027
+  subjects:
+  - entities:
+    - role: player
+      name: Emmric Alapa
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '31'
+  uuid: bd2d3088-689a-4b73-941c-7ebe7baab71e
+  subjects:
+  - entities:
+    - role: player
+      name: Mason Devine
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '32'
+  uuid: e0c46670-8c67-4a3e-8541-5878bdf9513b
+  subjects:
+  - entities:
+    - role: player
+      name: Ty Glaus
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '33'
+  uuid: 5461e91e-9e78-4fa5-bb04-bc263d561764
+  subjects:
+  - entities:
+    - role: player
+      name: DJ Lee II
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '34'
+  uuid: 6a70196d-2c2c-41bb-9ae0-8ab074bb7554
+  subjects:
+  - entities:
+    - role: player
+      name: Calvin Madenspacher
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '35'
+  uuid: e816c300-0dcb-4369-ad35-6cc80e990a75
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson McAneeley
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '36'
+  uuid: 9e40e3a5-013c-4fdb-9fee-c93b8327f3cd
+  subjects:
+  - entities:
+    - role: player
+      name: Joshua Pierre
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '37'
+  uuid: 11330534-dcf4-423f-86cb-ce2b70008c00
+  subjects:
+  - entities:
+    - role: player
+      name: Lucas Diaz
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '38'
+  uuid: dbb1abd0-52b3-474d-b3d9-17a92cfc7731
+  subjects:
+  - entities:
+    - role: player
+      name: Michael Ohman
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '39'
+  uuid: 662d05ad-bd09-4260-bed8-e5da77f82e58
+  subjects:
+  - entities:
+    - role: player
+      name: Jesse Maddox
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '40'
+  uuid: e5cdf4e3-5dac-4f90-a22e-c7e80367bdf8
+  subjects:
+  - entities:
+    - role: player
+      name: Clayton Ratliff
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '41'
+  uuid: 57d5f092-c95d-4e42-a03c-64bc71c0f631
+  subjects:
+  - entities:
+    - role: player
+      name: Boston Targac
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '42'
+  uuid: '0378cff1-ad9a-418d-82d4-43777226760e'
+  subjects:
+  - entities:
+    - role: player
+      name: Brandon Sweeney
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '43'
+  uuid: 4c9ff896-3275-4fa4-9362-76cb442e496d
+  subjects:
+  - entities:
+    - role: player
+      name: Lucca Bacigalupi
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '44'
+  uuid: e62dbda8-fdd5-4c91-bffe-55c847f1df55
+  subjects:
+  - entities:
+    - role: player
+      name: Miles Lockridge
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '45'
+  uuid: 6c26faab-fb98-4cfd-8e68-3ee27c2b37cc
+  subjects:
+  - entities:
+    - role: player
+      name: Carson Schoener
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '46'
+  uuid: 694b3b18-9783-409d-943d-ce09df2a64c7
+  subjects:
+  - entities:
+    - role: player
+      name: Jack Mattingly
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '47'
+  uuid: 10382558-fe11-485c-9857-fa12c44c66a4
+  subjects:
+  - entities:
+    - role: player
+      name: William Miller
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '48'
+  uuid: 38b30ae2-e917-435d-ad8d-42c483192dc5
+  subjects:
+  - entities:
+    - role: player
+      name: Kingston George
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '49'
+  uuid: 1a0af81e-bfc1-4c3c-b013-4279179dfcd0
+  subjects:
+  - entities:
+    - role: player
+      name: Micah Delos Reyes
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '50'
+  uuid: 88d12298-5f80-4cc4-ac2c-6f7167110fc1
+  subjects:
+  - entities:
+    - role: player
+      name: Bryant Ju
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 

--- a/data/baseball/2026-panini-prizm-stars-stripes/checklists/15u-national-team-signatures.yaml
+++ b/data/baseball/2026-panini-prizm-stars-stripes/checklists/15u-national-team-signatures.yaml
@@ -1,0 +1,200 @@
+- number: '1'
+  uuid: 9580d889-e9c6-4e0f-af90-7505fbb29607
+  subjects:
+  - entities:
+    - role: player
+      name: Nateo Victorio
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '2'
+  uuid: 74d48f04-2f28-4929-b72b-2b3e08479684
+  subjects:
+  - entities:
+    - role: player
+      name: Colin Anderson
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '3'
+  uuid: 0b204e3d-4b7d-4407-9c8b-80bb7835f2ed
+  subjects:
+  - entities:
+    - role: player
+      name: Macgraw VanWormer
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '4'
+  uuid: a765521d-eea3-4739-b0f0-67040f7b7426
+  subjects:
+  - entities:
+    - role: player
+      name: Greyson Bell
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '5'
+  uuid: c23cc38f-e038-4c0c-ac2d-e3a449f8e5f4
+  subjects:
+  - entities:
+    - role: player
+      name: Cullen Scott
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '6'
+  uuid: 32b1bb85-b74e-40a5-899a-61ff3c9d1402
+  subjects:
+  - entities:
+    - role: player
+      name: Gavin Chakar
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '7'
+  uuid: 488a6c73-ce6c-4038-924f-09b22f5fe99c
+  subjects:
+  - entities:
+    - role: player
+      name: Xavier Rodriguez
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '8'
+  uuid: eeb87781-7545-47b0-adda-639da14f4f3d
+  subjects:
+  - entities:
+    - role: player
+      name: Kekoa Delatori
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '9'
+  uuid: c2cd1e91-83b8-4893-96f3-0a9a0fffdaee
+  subjects:
+  - entities:
+    - role: player
+      name: Yariel Diaz
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '10'
+  uuid: 6e66c9e7-1996-46e2-9a5e-9bf74a4f38f0
+  subjects:
+  - entities:
+    - role: player
+      name: Anthony Frausto III
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '11'
+  uuid: ff782c44-21b4-44a3-8641-f599c41a0102
+  subjects:
+  - entities:
+    - role: player
+      name: Jaden Freeze
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '12'
+  uuid: 83b56797-7a3c-4518-a5c7-8deea46206e7
+  subjects:
+  - entities:
+    - role: player
+      name: Tristin Gaines
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '13'
+  uuid: c3ee31b6-c529-470d-934d-0b44edef98a9
+  subjects:
+  - entities:
+    - role: player
+      name: Noah Jarolimek
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '14'
+  uuid: 75ebc84d-840f-402c-a586-3f4a91b05028
+  subjects:
+  - entities:
+    - role: player
+      name: Landon King
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '15'
+  uuid: '09b9771d-d3ca-422c-9029-7398b4a6329b'
+  subjects:
+  - entities:
+    - role: player
+      name: Louis Lappe
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '16'
+  uuid: 42a79217-f1d2-43b9-8da5-72706be38e4d
+  subjects:
+  - entities:
+    - role: player
+      name: Nathan Malone
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '17'
+  uuid: de6ca705-5145-4d3d-938e-f113804639d6
+  subjects:
+  - entities:
+    - role: player
+      name: Jason Marll Jr.
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '18'
+  uuid: e9216229-b972-48df-b12b-0e4096beab23
+  subjects:
+  - entities:
+    - role: player
+      name: Mateo Mier
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '19'
+  uuid: b783da2d-eade-4fb4-a155-d39c9a379dbd
+  subjects:
+  - entities:
+    - role: player
+      name: Nolyn Nickels
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '20'
+  uuid: f4e926db-1bcf-4e18-a428-9b619a746b29
+  subjects:
+  - entities:
+    - role: player
+      name: Trent O'Malley
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 

--- a/data/baseball/2026-panini-prizm-stars-stripes/checklists/16u-17u-national-team-signatures.yaml
+++ b/data/baseball/2026-panini-prizm-stars-stripes/checklists/16u-17u-national-team-signatures.yaml
@@ -1,0 +1,710 @@
+- number: '1'
+  uuid: 8670ccfd-2719-446e-9cb2-fc56b65bc8b1
+  subjects:
+  - entities:
+    - role: player
+      name: Derek Vazquez
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '2'
+  uuid: 6adaf376-7f03-4720-baae-efeac71b6d29
+  subjects:
+  - entities:
+    - role: player
+      name: Logan Bristol
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '3'
+  uuid: 39676f15-260c-4f0d-93b3-ca9e2b5aad98
+  subjects:
+  - entities:
+    - role: player
+      name: Jose Partida
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '4'
+  uuid: 8634ab46-6e70-4a30-bf5a-b0fb98675a69
+  subjects:
+  - entities:
+    - role: player
+      name: Bryan Ravelo
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '5'
+  uuid: cce455ae-b8d6-4505-ac7e-d2699d813aff
+  subjects:
+  - entities:
+    - role: player
+      name: Colton Petersmith
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '6'
+  uuid: '083cd011-23f7-4ae9-8d74-c915115b95ca'
+  subjects:
+  - entities:
+    - role: player
+      name: Matthew Fernandez
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '7'
+  uuid: c1938433-bab3-435d-91e8-acd80538443c
+  subjects:
+  - entities:
+    - role: player
+      name: Banks Addison
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '8'
+  uuid: 75e82669-4c49-40d2-bce8-d09e2c4edb10
+  subjects:
+  - entities:
+    - role: player
+      name: Luke Esquivel
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '9'
+  uuid: a4183dae-121d-437c-96d3-abf943ff3776
+  subjects:
+  - entities:
+    - role: player
+      name: Valentin Ceballos
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '10'
+  uuid: 6361018d-9124-4b49-9e80-f001cf10b3ad
+  subjects:
+  - entities:
+    - role: player
+      name: Charlie Sarsfield
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '11'
+  uuid: a0bac631-b041-4115-9e5e-81d6f079e041
+  subjects:
+  - entities:
+    - role: player
+      name: Brennan McLaughlin
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '12'
+  uuid: 8ed02b0c-2823-428d-88b3-8c207be9500c
+  subjects:
+  - entities:
+    - role: player
+      name: Keelan Zumwalt
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '13'
+  uuid: ba653c2c-ea8d-4993-b6f8-79e8623d2c4d
+  subjects:
+  - entities:
+    - role: player
+      name: Ethan Gustus
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '14'
+  uuid: d5a00147-a00b-435c-8140-bd0311afdf9a
+  subjects:
+  - entities:
+    - role: player
+      name: Chase Gockenbach
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '15'
+  uuid: 71deb090-bbf2-47d5-9b68-79b0281cfbbe
+  subjects:
+  - entities:
+    - role: player
+      name: Ricky Lopez
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '16'
+  uuid: 10abf725-ea4f-4c37-af2b-e605b3673f81
+  subjects:
+  - entities:
+    - role: player
+      name: Camden Boehm
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '17'
+  uuid: 94e48e99-fc9f-442f-a33b-8f9ec0005114
+  subjects:
+  - entities:
+    - role: player
+      name: Caden Borcherding
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '18'
+  uuid: d4b709ba-b934-4234-b11d-1154c160056e
+  subjects:
+  - entities:
+    - role: player
+      name: Connor Wells
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '19'
+  uuid: 32e195a8-67bc-47b0-b664-b03871c54bcc
+  subjects:
+  - entities:
+    - role: player
+      name: Cooper Gornet
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '20'
+  uuid: 36589850-3c0d-4785-b201-fc494d69dd88
+  subjects:
+  - entities:
+    - role: player
+      name: Leo Nockley
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '21'
+  uuid: a5eb59b2-1918-4651-ab72-98cdb590e706
+  subjects:
+  - entities:
+    - role: player
+      name: Andrew Jimenez
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '22'
+  uuid: e4b9e063-9715-4e51-94f1-1bc9476948b7
+  subjects:
+  - entities:
+    - role: player
+      name: Andres Jimenez
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '23'
+  uuid: 81fefe3c-5aa1-48c8-9c7d-8a73c86268e7
+  subjects:
+  - entities:
+    - role: player
+      name: Graham Houston
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '24'
+  uuid: bec3146c-e01f-4b77-ad13-a305d670e992
+  subjects:
+  - entities:
+    - role: player
+      name: Marcus Cantu
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '25'
+  uuid: 8c7eb5a0-d6fd-4fdc-a303-5894155bf320
+  subjects:
+  - entities:
+    - role: player
+      name: Brady Buenik
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '26'
+  uuid: e80d105b-aa28-41dc-8d59-e6d221eef2e8
+  subjects:
+  - entities:
+    - role: player
+      name: Gavin McMillan
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '27'
+  uuid: 1bb1d01e-7e43-4a68-9790-48467a3af020
+  subjects:
+  - entities:
+    - role: player
+      name: Anderson Kaufmann
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '28'
+  uuid: 22ad84d5-dd22-4ab7-93dc-b875d8f767f6
+  subjects:
+  - entities:
+    - role: player
+      name: Ka'alekahi Kuhaulua
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '29'
+  uuid: 7d791979-5f5c-4a53-9ae1-9312a45f06f4
+  subjects:
+  - entities:
+    - role: player
+      name: Oliver Van Tiem
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '30'
+  uuid: b84ac09d-9c46-4e19-8cdf-45ae578109aa
+  subjects:
+  - entities:
+    - role: player
+      name: Jack Byers
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '31'
+  uuid: f7f4b8ff-e77e-4211-a47d-d03e490fcca0
+  subjects:
+  - entities:
+    - role: player
+      name: Jared Grindlinger
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '32'
+  uuid: 7b0fc506-a272-4df9-8812-c4f7d2493e55
+  subjects:
+  - entities:
+    - role: player
+      name: Orion Gonzalez
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '33'
+  uuid: 16ac9e00-d212-4683-bbc9-228cce404960
+  subjects:
+  - entities:
+    - role: player
+      name: Luke Armijo
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '34'
+  uuid: b92eb247-10a2-465f-a24e-b5c01f52fd27
+  subjects:
+  - entities:
+    - role: player
+      name: Jace Duckett
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '35'
+  uuid: e46439ab-517d-407a-8975-0389489e564c
+  subjects:
+  - entities:
+    - role: player
+      name: Samir Mohammed
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '36'
+  uuid: abd05118-f27a-44c7-8d6d-dcc9798cb918
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Seamon
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '37'
+  uuid: cbcdd097-03c5-4676-9fca-847e9549d446
+  subjects:
+  - entities:
+    - role: player
+      name: Colton Floyd
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '38'
+  uuid: 390f5a4c-b62c-4bfc-9b9d-3a49cd70372e
+  subjects:
+  - entities:
+    - role: player
+      name: Frank Thomas III
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '39'
+  uuid: 814e0cba-abc0-4127-aa86-68601920accb
+  subjects:
+  - entities:
+    - role: player
+      name: Grady Nelson
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '40'
+  uuid: 28b43de0-91a2-4f88-87a3-1313d078fa73
+  subjects:
+  - entities:
+    - role: player
+      name: Hudson Oliver
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '41'
+  uuid: 0f6314b3-adeb-4312-939d-5faa090d7f2b
+  subjects:
+  - entities:
+    - role: player
+      name: Griffin McKain
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '42'
+  uuid: f620094d-6546-42ae-8cd0-f36993b2a598
+  subjects:
+  - entities:
+    - role: player
+      name: Jack Woda
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '43'
+  uuid: 4a04312a-aafc-4dee-a502-f9e2e296b804
+  subjects:
+  - entities:
+    - role: player
+      name: Dexter McCleon Jr.
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '44'
+  uuid: 81e18459-f6dc-4a66-a9a2-b67cd1901546
+  subjects:
+  - entities:
+    - role: player
+      name: Eli Jones
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '45'
+  uuid: 8316f88e-dca0-4d41-86be-21a6a76e9ef9
+  subjects:
+  - entities:
+    - role: player
+      name: Connor Salerno
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '46'
+  uuid: c24b25a7-562c-4d69-b829-aa24161ca7b6
+  subjects:
+  - entities:
+    - role: player
+      name: Brennan New
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '47'
+  uuid: a01c68ea-08ea-445e-b291-632a926b0db0
+  subjects:
+  - entities:
+    - role: player
+      name: Keegan Burke
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '48'
+  uuid: 0f851986-1d84-4a30-b660-d21ec788c43f
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Beatty
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '49'
+  uuid: c152ae8e-a9a5-4879-adb2-ab5bcef721d6
+  subjects:
+  - entities:
+    - role: player
+      name: Cooper Collins
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '50'
+  uuid: 8f46f5fb-ba71-42f7-9114-3f0f3bc35419
+  subjects:
+  - entities:
+    - role: player
+      name: Carter Hadnot
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '51'
+  uuid: 96c13702-34cd-419c-83d4-ccca35ecf5ad
+  subjects:
+  - entities:
+    - role: player
+      name: Levi Leathers
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '52'
+  uuid: deadcc16-07b7-424f-a288-857edb84f642
+  subjects:
+  - entities:
+    - role: player
+      name: Max Hemenway
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '53'
+  uuid: 56cefcb7-719a-4e2d-91ec-796dcfff4e22
+  subjects:
+  - entities:
+    - role: player
+      name: Moises Gudino
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '54'
+  uuid: a836854f-ddc5-41cb-ac38-c4b20a911bb0
+  subjects:
+  - entities:
+    - role: player
+      name: Junior Lopez
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '55'
+  uuid: 3d06c828-898f-474c-8a4e-6661752f5386
+  subjects:
+  - entities:
+    - role: player
+      name: Chase Fuller
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '56'
+  uuid: '07398f29-3403-4436-a69b-4a26dee63bad'
+  subjects:
+  - entities:
+    - role: player
+      name: Cooper Jones
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '57'
+  uuid: 317e15a0-cdc4-4b14-abc3-6ccb8f853043
+  subjects:
+  - entities:
+    - role: player
+      name: Seddrick Henderson III
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '58'
+  uuid: 156568e1-77c0-465c-b64e-3388b945ab3e
+  subjects:
+  - entities:
+    - role: player
+      name: Connor Balazic
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '59'
+  uuid: 5974919f-0b9b-4f00-b368-a3e47795c3f5
+  subjects:
+  - entities:
+    - role: player
+      name: Bobby Villa
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '60'
+  uuid: 545dcca9-8a6b-4ce0-a122-41add84d5d6c
+  subjects:
+  - entities:
+    - role: player
+      name: Landon Green
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '61'
+  uuid: fd98aab3-6fd6-473a-8eb3-2ee1967e9a43
+  subjects:
+  - entities:
+    - role: player
+      name: Jordan Ayala
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '62'
+  uuid: 9e77369a-f97e-4cc7-814a-b2c1dc8e258b
+  subjects:
+  - entities:
+    - role: player
+      name: Jeremiah Hall
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '63'
+  uuid: 3c0461c0-0021-4728-8335-c8d37d12adc6
+  subjects:
+  - entities:
+    - role: player
+      name: Brogan Witcher
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '64'
+  uuid: e4294881-7c98-4b51-965c-49dcb6c8c24a
+  subjects:
+  - entities:
+    - role: player
+      name: Landon McDonald
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '65'
+  uuid: 99152962-293e-4fa0-b67a-580a61830f85
+  subjects:
+  - entities:
+    - role: player
+      name: Matthew Werner
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '66'
+  uuid: 9b1ab159-0952-4cf3-9cd1-433868f7b293
+  subjects:
+  - entities:
+    - role: player
+      name: Grant Sperandio
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '67'
+  uuid: c06686ff-7465-4c6d-895c-4472813b2f10
+  subjects:
+  - entities:
+    - role: player
+      name: Dariel Carrion
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '68'
+  uuid: c935bf6d-a1ae-41cf-9177-0f326058bea1
+  subjects:
+  - entities:
+    - role: player
+      name: Carter Shouse
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '69'
+  uuid: 69ae309b-9643-43b3-8680-0e0cb10a9f44
+  subjects:
+  - entities:
+    - role: player
+      name: Cade Allen
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '70'
+  uuid: 0bc46567-da80-47b2-9bc9-aebdd7c9d30d
+  subjects:
+  - entities:
+    - role: player
+      name: Xander Tiller
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '71'
+  uuid: 4645a6d5-69ac-440f-ac46-58b30be5af50
+  subjects:
+  - entities:
+    - role: player
+      name: William Haggerty
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 

--- a/data/baseball/2026-panini-prizm-stars-stripes/checklists/18u-national-team-signatures.yaml
+++ b/data/baseball/2026-panini-prizm-stars-stripes/checklists/18u-national-team-signatures.yaml
@@ -1,0 +1,280 @@
+- number: '1'
+  uuid: ef08848a-703d-4214-9de0-7bd8101b565f
+  subjects:
+  - entities:
+    - role: player
+      name: Aiden Ruiz
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '2'
+  uuid: f632db66-bdf8-4d4e-a4c4-791de5d4acc0
+  subjects:
+  - entities:
+    - role: player
+      name: Matthew Sharman
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '3'
+  uuid: 57087b21-cc79-47f7-b37c-23db91dbbee4
+  subjects:
+  - entities:
+    - role: player
+      name: Andrew Costello
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '4'
+  uuid: 89744e8c-118c-4a48-b74f-1fd1e4727208
+  subjects:
+  - entities:
+    - role: player
+      name: Coleman Borthwick
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '5'
+  uuid: 47e31490-4198-4e8b-9532-61d5e1e1c671
+  subjects:
+  - entities:
+    - role: player
+      name: Cole Koeninger
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '6'
+  uuid: 2c0f2fb2-4cc0-4e80-9db3-07aaeaad8723
+  subjects:
+  - entities:
+    - role: player
+      name: Kaden Waechter
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '7'
+  uuid: 38e104f9-6ed9-487d-aa2b-33f644551ac2
+  subjects:
+  - entities:
+    - role: player
+      name: Jaden Jackson
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '8'
+  uuid: 51d5d3ea-7ecd-4e94-9b77-7efa00b9756b
+  subjects:
+  - entities:
+    - role: player
+      name: Carson Bolemon
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '9'
+  uuid: 4ef0ff2c-40cc-464c-a36d-729ee1963713
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Lombard
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '10'
+  uuid: 0aa74b9b-8578-48bd-b458-07e82ca0f0ab
+  subjects:
+  - entities:
+    - role: player
+      name: Grady Emerson
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '11'
+  uuid: f11e4c56-c639-4ed3-8ac3-bb5da99eaefb
+  subjects:
+  - entities:
+    - role: player
+      name: Trey Rangel
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '12'
+  uuid: b1f00b2e-4039-4bf1-bf74-d49abb94da3b
+  subjects:
+  - entities:
+    - role: player
+      name: Gio Rojas
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '13'
+  uuid: dcdbeed9-4acf-4dae-b951-16da95c8f752
+  subjects:
+  - entities:
+    - role: player
+      name: Jorvorskie Lane Jr.
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '14'
+  uuid: bacdea31-0f5a-425c-9980-0253e96a32b7
+  subjects:
+  - entities:
+    - role: player
+      name: Anthony Murphy
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '15'
+  uuid: 578149cc-0f8d-4533-aa19-12a6fdabc4b1
+  subjects:
+  - entities:
+    - role: player
+      name: Brody Crane
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '16'
+  uuid: 0e5cf1ef-d442-4869-adf0-01b6a5498916
+  subjects:
+  - entities:
+    - role: player
+      name: Will Brick
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '17'
+  uuid: 547a3d8a-f7ed-4462-8a50-d600f71863f5
+  subjects:
+  - entities:
+    - role: player
+      name: CJ Sampson
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '18'
+  uuid: c2740b3f-ab74-491a-9bca-7fae5c5b3a45
+  subjects:
+  - entities:
+    - role: player
+      name: Jared Grindlinger
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '19'
+  uuid: 33395b9e-35e6-484c-849c-8eea7a60740b
+  subjects:
+  - entities:
+    - role: player
+      name: James Clark
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '20'
+  uuid: da56a1b4-c468-4245-9ba5-f022069827bf
+  subjects:
+  - entities:
+    - role: player
+      name: Brody Schumaker
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '21'
+  uuid: a14f41c3-3c6e-4656-b9ff-6d881624721d
+  subjects:
+  - entities:
+    - role: player
+      name: Grady Emerson
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '22'
+  uuid: 00b02268-1ce8-434b-b751-ba9a0b17ae2d
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Lombard
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '23'
+  uuid: 0e24d5b2-8bd4-489b-bc1b-da78cfa1dfc3
+  subjects:
+  - entities:
+    - role: player
+      name: Jorvorskie Lane Jr.
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '24'
+  uuid: 0a3b97c7-4a10-4388-9ca2-ed6b8c97547a
+  subjects:
+  - entities:
+    - role: player
+      name: Trey Rangel
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '25'
+  uuid: 7a9370dc-bda5-4705-b6d0-317692a5d1e4
+  subjects:
+  - entities:
+    - role: player
+      name: Coleman Borthwick
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '26'
+  uuid: 7ad3fe98-7caf-444a-aea5-f3a02e7336d8
+  subjects:
+  - entities:
+    - role: player
+      name: Gio Rojas
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '27'
+  uuid: c4ecbd38-fe8e-4e70-914b-161f2a11f4ed
+  subjects:
+  - entities:
+    - role: player
+      name: Kaden Waechter
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '28'
+  uuid: 5d8252fd-4777-49e0-9ca7-a81fcb42981e
+  subjects:
+  - entities:
+    - role: player
+      name: Cole Koeninger
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 

--- a/data/baseball/2026-panini-prizm-stars-stripes/checklists/all-american.yaml
+++ b/data/baseball/2026-panini-prizm-stars-stripes/checklists/all-american.yaml
@@ -1,0 +1,250 @@
+- number: '1'
+  uuid: 861fd504-7b3f-438d-ba1a-7100cf076152
+  subjects:
+  - entities:
+    - role: player
+      name: Devin Taylor
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '2'
+  uuid: e339e34f-a4e9-4ea4-9025-6df916a5dc80
+  subjects:
+  - entities:
+    - role: player
+      name: AJ Gracia
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '3'
+  uuid: 87fba4ff-846e-4a64-a567-23041c3bead1
+  subjects:
+  - entities:
+    - role: player
+      name: Alex Gordon
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '4'
+  uuid: edd5426c-0654-4245-b90d-da69255ab963
+  subjects:
+  - entities:
+    - role: player
+      name: Hagen Smith
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '5'
+  uuid: b0c6d2bf-e8f7-44cd-955d-b09a914c95cb
+  subjects:
+  - entities:
+    - role: player
+      name: Frank Thomas
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '6'
+  uuid: 90c23ef4-ddb8-47cd-a89c-e7017f03f1ad
+  subjects:
+  - entities:
+    - role: player
+      name: Eric Becker
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '7'
+  uuid: 43aa13e2-c6a3-45e9-96b8-4e2d88fd7043
+  subjects:
+  - entities:
+    - role: player
+      name: Roch Cholowsky
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '8'
+  uuid: a7163d6f-1518-4a83-9a8a-be7445a9e18a
+  subjects:
+  - entities:
+    - role: player
+      name: Jamie Arnold
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '9'
+  uuid: 8187e0e3-855c-41f2-98c9-d5cf89bd2c85
+  subjects:
+  - entities:
+    - role: player
+      name: Dylan Crews
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '10'
+  uuid: dec69596-7b55-4add-b11b-cfbca84894d3
+  subjects:
+  - entities:
+    - role: player
+      name: Vahn Lackey
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '11'
+  uuid: 7e79a3b0-a9b4-4962-b6c4-21512c43a788
+  subjects:
+  - entities:
+    - role: player
+      name: Ethan Kleinschmit
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '12'
+  uuid: d97d4fa9-65f3-4b34-bd4c-32694c96d5f0
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Dudan
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '13'
+  uuid: d68796fc-6f46-4e8b-b703-fd0447edded1
+  subjects:
+  - entities:
+    - role: player
+      name: Rhett Lowder
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '14'
+  uuid: 68d23829-ef20-48d2-86d4-9d3f7f416565
+  subjects:
+  - entities:
+    - role: player
+      name: Enrique Bradfield Jr.
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '15'
+  uuid: 76e04ad1-ddcb-4988-8fdf-d34f9258fece
+  subjects:
+  - entities:
+    - role: player
+      name: Paul Skenes
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '16'
+  uuid: 6f97f47a-ddd6-41a8-a13f-f54e7014c408
+  subjects:
+  - entities:
+    - role: player
+      name: Ace Reese
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '17'
+  uuid: 3070e782-6295-460d-aa8c-53d327280d85
+  subjects:
+  - entities:
+    - role: player
+      name: Braden Montgomery
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '18'
+  uuid: 4b9e1141-6f2b-4d32-be36-1c2e23651e76
+  subjects:
+  - entities:
+    - role: player
+      name: Charlie Condon
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '19'
+  uuid: b9c2fe3a-a591-42ad-9f14-2c839da53c6b
+  subjects:
+  - entities:
+    - role: player
+      name: Ryan Zimmerman
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '20'
+  uuid: 8be4582b-cc45-4972-8d47-436619c70cab
+  subjects:
+  - entities:
+    - role: player
+      name: Jace LaViolette
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '21'
+  uuid: f294f726-0222-43a2-bac6-6758b3f72377
+  subjects:
+  - entities:
+    - role: player
+      name: Liam Peterson
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '22'
+  uuid: 2424fd7a-25e2-4b87-838e-a4793041c654
+  subjects:
+  - entities:
+    - role: player
+      name: Christian Moore
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '23'
+  uuid: f5572419-3d31-41cb-b739-5a0a6a39364d
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Wilson
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '24'
+  uuid: 669dbe3c-b396-4244-ace6-6152305cf08f
+  subjects:
+  - entities:
+    - role: player
+      name: Chris Rembert
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '25'
+  uuid: e6d4f200-602c-4f47-b83d-8f34e8edbb13
+  subjects:
+  - entities:
+    - role: player
+      name: Drew Burress
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 

--- a/data/baseball/2026-panini-prizm-stars-stripes/checklists/base-prizms-signatures-green.yaml
+++ b/data/baseball/2026-panini-prizm-stars-stripes/checklists/base-prizms-signatures-green.yaml
@@ -1,0 +1,320 @@
+- number: '2'
+  uuid: 1115f7b9-194b-4a60-a4ac-5a397f0ee0b6
+  subjects:
+  - entities:
+    - role: player
+      name: Broedy Poppell
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '8'
+  uuid: 5c61e0b0-0a8c-4f2f-a907-bc3939f2c0ee
+  subjects:
+  - entities:
+    - role: player
+      name: LJ Mercurius
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '20'
+  uuid: 9b8094dd-2734-4cde-9e90-762dae49fb20
+  subjects:
+  - entities:
+    - role: player
+      name: Cameron Bagwell
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '21'
+  uuid: edc2aeb0-94a0-4e24-973f-45da0c179508
+  subjects:
+  - entities:
+    - role: player
+      name: Tomas Valincius
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '24'
+  uuid: f40385c4-97b8-418c-8086-9b9452591121
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Cruz
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '30'
+  uuid: 8ef11d1d-fdff-4af1-a927-bb5af8679902
+  subjects:
+  - entities:
+    - role: player
+      name: Trey Beard
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '45'
+  uuid: 9c0943b0-44cf-4e57-b0b3-a7e48c1113e1
+  subjects:
+  - entities:
+    - role: player
+      name: AJ Ciscar
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '46'
+  uuid: a0d7a4b8-d03d-48d2-af13-531bf1cf3c78
+  subjects:
+  - entities:
+    - role: player
+      name: Daniel Cuvet
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '47'
+  uuid: 997f206a-b559-4c9a-a992-4e62a51b05ae
+  subjects:
+  - entities:
+    - role: player
+      name: Cole Carlon
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '55'
+  uuid: 2e6b8490-a324-4bb9-a818-669df24df54b
+  subjects:
+  - entities:
+    - role: player
+      name: Alex Hernandez
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '58'
+  uuid: 3dca9194-912c-4018-850f-605754f62f46
+  subjects:
+  - entities:
+    - role: player
+      name: James Guyette
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '66'
+  uuid: 2a976892-52be-4e9f-af48-71d58c40bcb5
+  subjects:
+  - entities:
+    - role: player
+      name: Tommy LaPour
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '73'
+  uuid: f1b27053-2fdf-4deb-af91-8de25d2f9a3d
+  subjects:
+  - entities:
+    - role: player
+      name: Evan Dempsey
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '75'
+  uuid: 200b232a-9392-415e-85c6-c4ae7c605b05
+  subjects:
+  - entities:
+    - role: player
+      name: Cam Kozeal
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '76'
+  uuid: e46113d0-c10f-43ae-bc7f-af99e8ba7b3c
+  subjects:
+  - entities:
+    - role: player
+      name: Easton Hawk
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '80'
+  uuid: 2cc9f7fb-2caf-43d3-943b-b512e70e89a9
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Flora
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '82'
+  uuid: a5c5194a-c1b3-4337-8b93-cde105999223
+  subjects:
+  - entities:
+    - role: player
+      name: Smith Bailey
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '87'
+  uuid: 32b4727f-fc5c-4cc5-a7dd-b1fa33fa860c
+  subjects:
+  - entities:
+    - role: player
+      name: Jared Grindlinger
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '88'
+  uuid: 4c568115-8bc9-4a23-beb7-7b15ebcd4dff
+  subjects:
+  - entities:
+    - role: player
+      name: Anderson Nance
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '91'
+  uuid: ea189f24-4680-4ec0-9325-2f1edfd73fed
+  subjects:
+  - entities:
+    - role: player
+      name: Jared Grindlinger
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '100'
+  uuid: e76c5a2f-1a9e-43a0-bdce-6d0609bfd3eb
+  subjects:
+  - entities:
+    - role: player
+      name: Owen Kramkowski
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '112'
+  uuid: 3482a0ee-f114-4b09-a897-462adc802272
+  subjects:
+  - entities:
+    - role: player
+      name: Landon Mack
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '123'
+  uuid: f8238b9e-6313-48fc-a735-e54f1b317210
+  subjects:
+  - entities:
+    - role: player
+      name: Tyler Smith
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '124'
+  uuid: 4cd4b01a-6a7e-42d2-9bae-84e0ec7c3cfd
+  subjects:
+  - entities:
+    - role: player
+      name: Brady Ballinger
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '128'
+  uuid: 14ec4167-755f-43b8-a504-703a72613736
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan Traeger
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '131'
+  uuid: ac5ff6f2-f20a-4db4-9f66-52436c5d7925
+  subjects:
+  - entities:
+    - role: player
+      name: KJ Scobey
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '134'
+  uuid: 6d542d1e-b137-4c4d-bf51-d50457b7e11e
+  subjects:
+  - entities:
+    - role: player
+      name: Noah Franco
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '139'
+  uuid: 991ce669-d0b8-4fe6-bcf6-dc4b9ebe0939
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Johnson
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '160'
+  uuid: 54bfbaf6-27f1-4dc8-bedb-c55d08220c88
+  subjects:
+  - entities:
+    - role: player
+      name: Myles Bailey
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '165'
+  uuid: 5ca3ee4c-8043-4376-adfe-f812191d901a
+  subjects:
+  - entities:
+    - role: player
+      name: Tague Davis
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '169'
+  uuid: 0ff90927-efa5-4cb2-95db-48f89b93f74a
+  subjects:
+  - entities:
+    - role: player
+      name: Max Bayles
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '190'
+  uuid: 9a1e4955-5a78-4449-8508-0ac9ba57ffb2
+  subjects:
+  - entities:
+    - role: player
+      name: Aidan King
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 

--- a/data/baseball/2026-panini-prizm-stars-stripes/checklists/base-prizms-signatures.yaml
+++ b/data/baseball/2026-panini-prizm-stars-stripes/checklists/base-prizms-signatures.yaml
@@ -1,0 +1,2000 @@
+- number: '1'
+  uuid: 6cfd4897-c83c-4cbb-855f-20eee97cb7b9
+  subjects:
+  - entities:
+    - role: player
+      name: AJ Elliott
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '2'
+  uuid: 5bd45420-6cd6-47cb-9657-1b5d411e8b16
+  subjects:
+  - entities:
+    - role: player
+      name: Broedy Poppell
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '3'
+  uuid: e613ea5d-58c7-4b46-9cbc-e0824dc3f58d
+  subjects:
+  - entities:
+    - role: player
+      name: Frank Thomas III
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '4'
+  uuid: 73bceead-8233-46f8-a6b4-4f1d7b02e840
+  subjects:
+  - entities:
+    - role: player
+      name: Cooper Gornet
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '5'
+  uuid: fc2708b2-775c-4879-83ac-b5e7fd07bf77
+  subjects:
+  - entities:
+    - role: player
+      name: Nathan Malone
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '6'
+  uuid: e7a5ece7-473e-47d6-8224-ce50ad085a32
+  subjects:
+  - entities:
+    - role: player
+      name: Barret Schell
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '7'
+  uuid: 2cc8545a-789d-4362-8e30-9993cb13158c
+  subjects:
+  - entities:
+    - role: player
+      name: Anthony Frausto III
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '8'
+  uuid: f1df50ba-ac0f-43a7-a501-7d20094905ce
+  subjects:
+  - entities:
+    - role: player
+      name: LJ Mercurius
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '9'
+  uuid: 31a2e97f-8973-4182-8a13-d4453b65d88e
+  subjects:
+  - entities:
+    - role: player
+      name: Derek Vazquez
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '10'
+  uuid: e7389f5c-ae25-4e82-a140-bc8d61748def
+  subjects:
+  - entities:
+    - role: player
+      name: Colin Anderson
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '11'
+  uuid: 823da226-f1e4-4559-9f99-2fd0a892fc6e
+  subjects:
+  - entities:
+    - role: player
+      name: Carter Hadnot
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '12'
+  uuid: 79518815-c91f-4d77-9522-3b698e103dff
+  subjects:
+  - entities:
+    - role: player
+      name: Ryan McPherson
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '13'
+  uuid: 594864f6-e47a-4e96-ad3e-87202a3fcf12
+  subjects:
+  - entities:
+    - role: player
+      name: James Clark
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '14'
+  uuid: 84835da5-4fc3-4483-9b5e-1391e9d3c0a0
+  subjects:
+  - entities:
+    - role: player
+      name: Brock Bliss
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '15'
+  uuid: b135b71b-e130-4340-93a0-268c4b60d1f6
+  subjects:
+  - entities:
+    - role: player
+      name: Grant Sperandio
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '16'
+  uuid: 7ceaf544-6391-4b46-a103-07c7bb279065
+  subjects:
+  - entities:
+    - role: player
+      name: Landon King
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '17'
+  uuid: 9af0cd4e-003b-4d11-b1d0-cbb9da7fa910
+  subjects:
+  - entities:
+    - role: player
+      name: Christopher Chikodroff
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '18'
+  uuid: e82089be-78ef-4cf3-ae25-6c30e413f049
+  subjects:
+  - entities:
+    - role: player
+      name: Brett Renfrow
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '19'
+  uuid: 2d08e017-bff8-4991-8b63-88687095025c
+  subjects:
+  - entities:
+    - role: player
+      name: Leo Nockley
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '20'
+  uuid: 7ed0a6bc-466b-4935-b33b-1c6370038fb6
+  subjects:
+  - entities:
+    - role: player
+      name: Cameron Bagwell
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '21'
+  uuid: 768acb07-6335-4469-9671-f2a040305384
+  subjects:
+  - entities:
+    - role: player
+      name: Tomas Valincius
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '22'
+  uuid: f1d2280b-d49f-44cc-b3c5-92b53cf58b86
+  subjects:
+  - entities:
+    - role: player
+      name: Cullen Scott
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '23'
+  uuid: 0e723776-8682-46cd-a7dc-78f24d3fc28f
+  subjects:
+  - entities:
+    - role: player
+      name: Connor Salerno
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '24'
+  uuid: 85387780-7152-4729-8589-b3d38c68cefa
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Cruz
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '25'
+  uuid: 5270f7e6-746b-4f94-bbf6-c45c8d12494d
+  subjects:
+  - entities:
+    - role: player
+      name: Noah Jarolimek
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '26'
+  uuid: 04cfbb13-d501-4054-982d-3eea8da81093
+  subjects:
+  - entities:
+    - role: player
+      name: Ricky Ojeda
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '27'
+  uuid: 8e8f8202-6d59-4d6c-bd3f-01ee4f4bc631
+  subjects:
+  - entities:
+    - role: player
+      name: Kekoa Delatori
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '28'
+  uuid: 63c394ee-8b21-4df3-a5c8-fdbbe7696a66
+  subjects:
+  - entities:
+    - role: player
+      name: Vahn Lackey
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '29'
+  uuid: 5d256040-1235-4ca7-931d-f87e6979b359
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Dudan
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '30'
+  uuid: ce461d35-a140-4566-8d71-b0f4cd74d9e9
+  subjects:
+  - entities:
+    - role: player
+      name: Trey Beard
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '31'
+  uuid: 410e10d3-950b-4c76-8734-70cf8a26fc5f
+  subjects:
+  - entities:
+    - role: player
+      name: Anthony Murphy
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '32'
+  uuid: 57444617-de47-4209-97a5-cfd7952555f8
+  subjects:
+  - entities:
+    - role: player
+      name: Andrew Costello
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '33'
+  uuid: 3232dc40-1092-4fbb-99a6-70b8335e03d7
+  subjects:
+  - entities:
+    - role: player
+      name: Nateo Victorio
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '34'
+  uuid: 342e691f-55cf-4bbd-ae12-6889f1899e87
+  subjects:
+  - entities:
+    - role: player
+      name: Gavin Chakar
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '35'
+  uuid: f6cc86e2-25f0-44d8-ba01-cade66ce5ae6
+  subjects:
+  - entities:
+    - role: player
+      name: Davis Romejko
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '36'
+  uuid: 3c9e1ffc-0a8c-4a39-9968-72df938c6498
+  subjects:
+  - entities:
+    - role: player
+      name: Dax Whitney
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '37'
+  uuid: 7cb04204-552b-4a98-b958-f8833135ea2b
+  subjects:
+  - entities:
+    - role: player
+      name: Brody Schumaker
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '38'
+  uuid: e1058461-7b5f-44b3-9992-0804f8b6246f
+  subjects:
+  - entities:
+    - role: player
+      name: Liam Peterson
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '39'
+  uuid: 71c7045e-48a0-42e5-9178-c92409b15ffa
+  subjects:
+  - entities:
+    - role: player
+      name: Drew Burress
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '40'
+  uuid: 16840371-ecc2-4c02-97f3-d01c0d008021
+  subjects:
+  - entities:
+    - role: player
+      name: Connor Wells
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '41'
+  uuid: 95895d63-4438-48b2-a8a1-8f46665172d8
+  subjects:
+  - entities:
+    - role: player
+      name: Jeremiah Hall
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '42'
+  uuid: 0a6ab94a-688c-492b-842e-9f693bb76949
+  subjects:
+  - entities:
+    - role: player
+      name: Camden Boehm
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '43'
+  uuid: 5cefdf84-d528-4950-b35c-81d3a2003f95
+  subjects:
+  - entities:
+    - role: player
+      name: Mateo Mier
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '44'
+  uuid: 28ecffaf-344d-4542-84aa-a8bdb64f2fd5
+  subjects:
+  - entities:
+    - role: player
+      name: Oliver Van Tiem
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '45'
+  uuid: d9bb9ff2-41d0-40d2-b4e2-a703f8344789
+  subjects:
+  - entities:
+    - role: player
+      name: AJ Ciscar
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '46'
+  uuid: 60649c20-8607-4ed7-84f1-7c3068bf9d4c
+  subjects:
+  - entities:
+    - role: player
+      name: Daniel Cuvet
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '47'
+  uuid: 529444e2-f4a8-45b3-a075-841ebc826198
+  subjects:
+  - entities:
+    - role: player
+      name: Cole Carlon
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '48'
+  uuid: d2f42d98-0466-4d2d-8d9a-a066f7edeaab
+  subjects:
+  - entities:
+    - role: player
+      name: Duncan Mount
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '49'
+  uuid: 36b1177a-4d74-414c-8ed6-e8fe6bd132de
+  subjects:
+  - entities:
+    - role: player
+      name: Bobby Villa
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '50'
+  uuid: cdb6f491-5095-4cb6-852e-ed2c2e26b15a
+  subjects:
+  - entities:
+    - role: player
+      name: Xavier Rodriguez
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '51'
+  uuid: b496de05-b038-47d5-bbca-fdac3ffecdb9
+  subjects:
+  - entities:
+    - role: player
+      name: Landon Green
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '52'
+  uuid: 7d120a0f-0de5-47a6-b580-2ec6c1c68870
+  subjects:
+  - entities:
+    - role: player
+      name: Jack Byers
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '53'
+  uuid: 997e688b-c166-4a31-ba0e-0078bb022852
+  subjects:
+  - entities:
+    - role: player
+      name: Ace Reese
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '54'
+  uuid: e33b06ca-d3ba-4f76-ba2c-e94829af06e8
+  subjects:
+  - entities:
+    - role: player
+      name: Hardin Sullivan
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '55'
+  uuid: 2a3ddb1b-b93d-47dc-af29-cd1d723dfe52
+  subjects:
+  - entities:
+    - role: player
+      name: Alex Hernandez
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '56'
+  uuid: fa559493-d3a8-44e2-9495-6a9ce381f302
+  subjects:
+  - entities:
+    - role: player
+      name: Chase Gockenbach
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '57'
+  uuid: 5c3411d5-9f1f-4d55-940d-47f96de8a273
+  subjects:
+  - entities:
+    - role: player
+      name: Nolyn Nickels
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '58'
+  uuid: 61537cd3-c83a-4551-9bf0-47aadfcafb02
+  subjects:
+  - entities:
+    - role: player
+      name: James Guyette
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '59'
+  uuid: 2ea03cae-8299-4f5c-bfb8-de211d8c4c82
+  subjects:
+  - entities:
+    - role: player
+      name: Ryan Lynch
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '60'
+  uuid: b69b6ad5-9a0f-4114-ad21-b2f18b936ae8
+  subjects:
+  - entities:
+    - role: player
+      name: Chase Fuller
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '61'
+  uuid: 3cfb59ad-4223-47de-b8fe-e314482cfc03
+  subjects:
+  - entities:
+    - role: player
+      name: Carson Bolemon
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '62'
+  uuid: 508b61a6-721c-4753-a173-cf8297177397
+  subjects:
+  - entities:
+    - role: player
+      name: Trey Rangel
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '63'
+  uuid: 2901f6b1-4831-47cc-9b59-242443feeb08
+  subjects:
+  - entities:
+    - role: player
+      name: Brady Buenik
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '64'
+  uuid: cbd2c71a-1ebb-459a-84a0-62a4d5543540
+  subjects:
+  - entities:
+    - role: player
+      name: Caden Borcherding
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '65'
+  uuid: 7e138464-9806-458d-ad79-6b89059cb219
+  subjects:
+  - entities:
+    - role: player
+      name: Hunter Sundby
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '66'
+  uuid: feb522cb-d623-4bdf-9fb1-207a9c186166
+  subjects:
+  - entities:
+    - role: player
+      name: Tommy LaPour
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '67'
+  uuid: 076674a4-addb-42c8-9570-874031c91571
+  subjects:
+  - entities:
+    - role: player
+      name: Jose Partida
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '68'
+  uuid: ea71f632-2bfc-41f8-8127-4b38f101f4b5
+  subjects:
+  - entities:
+    - role: player
+      name: Ethan Norby
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '69'
+  uuid: 74e9ca18-27c1-48cb-8cfe-77a60937bffe
+  subjects:
+  - entities:
+    - role: player
+      name: Dexter McCleon Jr.
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '70'
+  uuid: 9fb65b94-90c4-4f8c-b8b0-6ba55d791f59
+  subjects:
+  - entities:
+    - role: player
+      name: Jack Carson
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '71'
+  uuid: 6ee22a92-4979-417d-aca7-ba2bea7bcf7d
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Beatty
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '72'
+  uuid: d4cc46bf-86b5-4035-9c75-6159029c69af
+  subjects:
+  - entities:
+    - role: player
+      name: Grady Nelson
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '73'
+  uuid: 40b0a755-f7ab-4c29-ac71-f57b47bc96cb
+  subjects:
+  - entities:
+    - role: player
+      name: Evan Dempsey
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '74'
+  uuid: 672cfe97-bf73-40f4-8be2-7838514fc33d
+  subjects:
+  - entities:
+    - role: player
+      name: Ethan Gustus
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '75'
+  uuid: fe1ceb9d-cf99-47e2-9a12-403a6308d3ea
+  subjects:
+  - entities:
+    - role: player
+      name: Cam Kozeal
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '76'
+  uuid: 6101907b-63b9-4c8d-846b-2e5cbacd7d34
+  subjects:
+  - entities:
+    - role: player
+      name: Easton Hawk
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '77'
+  uuid: 7842a2ff-1bd3-4acb-9558-f3d2414831b3
+  subjects:
+  - entities:
+    - role: player
+      name: Gabe Gaeckle
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '78'
+  uuid: 4ab579a3-4ae1-4d3f-9e9e-d2c4d593524c
+  subjects:
+  - entities:
+    - role: player
+      name: Landon McDonald
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '79'
+  uuid: a64c8b4e-9bb7-4dd1-90f2-2585292baedb
+  subjects:
+  - entities:
+    - role: player
+      name: Levi Leathers
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '80'
+  uuid: 68a87a21-ecd2-422f-b43c-7af2d0d7fdd2
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Flora
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '81'
+  uuid: cfd5827b-5dcb-4e3e-8b02-ea397fdb9680
+  subjects:
+  - entities:
+    - role: player
+      name: Roch Cholowsky
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '82'
+  uuid: 68e28ee6-c3e5-4103-bade-0e575c18027d
+  subjects:
+  - entities:
+    - role: player
+      name: Smith Bailey
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '83'
+  uuid: 3a51fbc2-b655-4692-884e-1823efd28c7e
+  subjects:
+  - entities:
+    - role: player
+      name: Jorvorskie Lane Jr.
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '84'
+  uuid: 394e606c-8b3a-46b4-b5b5-dd877007f53b
+  subjects:
+  - entities:
+    - role: player
+      name: Brody Crane
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '85'
+  uuid: 68f86624-09ab-469d-bb8a-a69a988e65f9
+  subjects:
+  - entities:
+    - role: player
+      name: Luke Esquivel
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '86'
+  uuid: 6e345cb8-8e12-4f75-a207-a8b5d48078b8
+  subjects:
+  - entities:
+    - role: player
+      name: Chris Rembert
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '87'
+  uuid: 74256754-6bac-4294-a874-39c741bb40a6
+  subjects:
+  - entities:
+    - role: player
+      name: Jared Grindlinger
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '88'
+  uuid: 64bbe2aa-78da-42a2-a391-0c0e2f1e7efd
+  subjects:
+  - entities:
+    - role: player
+      name: Anderson Nance
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '89'
+  uuid: 859d74ff-7303-4e9c-8d6e-e51eb75b53d5
+  subjects:
+  - entities:
+    - role: player
+      name: Greyson Bell
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '90'
+  uuid: 88ef3362-e945-44b4-8c58-0ea220c8ec55
+  subjects:
+  - entities:
+    - role: player
+      name: Yariel Diaz
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '91'
+  uuid: 7068dcd7-101a-4f60-ac81-8d18d90262d3
+  subjects:
+  - entities:
+    - role: player
+      name: Jared Grindlinger
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '92'
+  uuid: 6dfd231e-0916-4125-a616-59d4ac2e9f01
+  subjects:
+  - entities:
+    - role: player
+      name: Jake Romero
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '93'
+  uuid: 3bbb772c-ce55-49bc-8c38-8a97de9ceff0
+  subjects:
+  - entities:
+    - role: player
+      name: Eli Jones
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '94'
+  uuid: a3899b20-90b2-4c42-acb9-abd8fc94e5af
+  subjects:
+  - entities:
+    - role: player
+      name: Coleman Borthwick
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '95'
+  uuid: ff3b4799-c4c3-43a2-a9d9-02d7b2baf883
+  subjects:
+  - entities:
+    - role: player
+      name: Andres Jimenez
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '96'
+  uuid: 99ae8225-f236-4b97-a7dd-aceecb6c6565
+  subjects:
+  - entities:
+    - role: player
+      name: Jameson Wilhite
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '97'
+  uuid: 07d2f936-b117-4550-b08e-79a87aa4dc01
+  subjects:
+  - entities:
+    - role: player
+      name: Ethan Kleinschmit
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '98'
+  uuid: d696f099-c54d-462e-af13-f3a6c014c338
+  subjects:
+  - entities:
+    - role: player
+      name: Cooper Jones
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '99'
+  uuid: 5200cd6b-ea13-4479-b578-a29a91a8dde3
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Lombard
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '100'
+  uuid: da3e069b-ab8d-43c2-bb0d-5b0b6657cfc9
+  subjects:
+  - entities:
+    - role: player
+      name: Owen Kramkowski
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '101'
+  uuid: 9b6c76b8-e336-4b03-b4dd-4feaba189f21
+  subjects:
+  - entities:
+    - role: player
+      name: Jaxon Spray
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '102'
+  uuid: 041a17a4-ceba-4208-93f5-37ff871b896b
+  subjects:
+  - entities:
+    - role: player
+      name: Ricky Lopez
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '103'
+  uuid: e31ff7c5-f9a3-4859-a77e-830cf33b0dcd
+  subjects:
+  - entities:
+    - role: player
+      name: Cole Koeninger
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '104'
+  uuid: df3dae2e-065d-4133-8d8a-c6b32281ad34
+  subjects:
+  - entities:
+    - role: player
+      name: Blake Morningstar
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '105'
+  uuid: 0507ff8f-2eca-4ef4-b5ec-b000ca6fb564
+  subjects:
+  - entities:
+    - role: player
+      name: Jason DeCaro
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '106'
+  uuid: 2c479561-ca6f-4141-b95d-c1f66482b0c3
+  subjects:
+  - entities:
+    - role: player
+      name: Hudson Oliver
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '107'
+  uuid: abcd77df-e4fb-4101-bfc1-b0394ba93995
+  subjects:
+  - entities:
+    - role: player
+      name: Kai Sapp
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '108'
+  uuid: 58f000a9-8024-4df8-85d8-da207b077a71
+  subjects:
+  - entities:
+    - role: player
+      name: Kristian Valadez
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '109'
+  uuid: eae10573-3105-443e-86ae-ca103413e4da
+  subjects:
+  - entities:
+    - role: player
+      name: Jaden Jackson
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '110'
+  uuid: 3a400ac2-a712-482a-8898-c7f6440ec7a5
+  subjects:
+  - entities:
+    - role: player
+      name: William Haggerty
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '111'
+  uuid: 025e4719-4cbc-4f81-b19a-0f6afc2ec213
+  subjects:
+  - entities:
+    - role: player
+      name: Gavin McMillan
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '112'
+  uuid: 5a7596c5-f9af-42ad-b92f-e9d1adf3050c
+  subjects:
+  - entities:
+    - role: player
+      name: Landon Mack
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '113'
+  uuid: 4636fb4c-2393-498e-a256-176af5148e5e
+  subjects:
+  - entities:
+    - role: player
+      name: Zion Rose
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '114'
+  uuid: d91d4a7b-4949-4ebf-b9e1-2b78e9421572
+  subjects:
+  - entities:
+    - role: player
+      name: Mason Bitzenhofer
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '115'
+  uuid: a5d7c0e5-6dca-40f4-bf1c-532b2a3ce5d3
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan Hatch
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '116'
+  uuid: e17928cc-b606-445d-8fff-57d3fe31dfa8
+  subjects:
+  - entities:
+    - role: player
+      name: Jaden Freeze
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '117'
+  uuid: '08fa5a3c-0c8f-4dd7-a031-ea4d2ba06793'
+  subjects:
+  - entities:
+    - role: player
+      name: Colton Floyd
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '118'
+  uuid: a1341b14-444d-46fa-9807-33e95fe5ed5f
+  subjects:
+  - entities:
+    - role: player
+      name: Jace Duckett
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '119'
+  uuid: 3a1acfff-5781-4710-baf3-8166764a9f64
+  subjects:
+  - entities:
+    - role: player
+      name: Gio Rojas
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '120'
+  uuid: 90858467-9052-4d56-830e-a1fa72034ae0
+  subjects:
+  - entities:
+    - role: player
+      name: Matthew Werner
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '121'
+  uuid: e6ec5109-dea5-468a-8462-a39e204db710
+  subjects:
+  - entities:
+    - role: player
+      name: Aiden Ruiz
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '122'
+  uuid: 2cd5412d-8213-4c2d-9b6d-cc534f824a3c
+  subjects:
+  - entities:
+    - role: player
+      name: Radner Roth
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '123'
+  uuid: 7c4b9cec-c36a-4697-b5d7-9a98883e4773
+  subjects:
+  - entities:
+    - role: player
+      name: Tyler Smith
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '124'
+  uuid: 857c8f25-8023-4aa4-b49b-fd8b535d3ed3
+  subjects:
+  - entities:
+    - role: player
+      name: Brady Ballinger
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '125'
+  uuid: c4aa1249-7294-4acb-8e7f-1883149fbae2
+  subjects:
+  - entities:
+    - role: player
+      name: Russell McGee
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '126'
+  uuid: 6b02efed-aa2f-4bf0-b0d8-b3f1f5aefad0
+  subjects:
+  - entities:
+    - role: player
+      name: Mulivai Levu
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '127'
+  uuid: 264cddd2-7eb6-4483-8f99-3fc2018623ce
+  subjects:
+  - entities:
+    - role: player
+      name: AJ Gracia
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '128'
+  uuid: 9e7146ba-18d2-472b-9d0c-6a1785d99a81
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan Traeger
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '129'
+  uuid: 3374cd5a-7e9f-4131-a863-7fe381c3c8a9
+  subjects:
+  - entities:
+    - role: player
+      name: Macgraw VanWormer
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '130'
+  uuid: 7cafb93d-7b8d-4d3f-af9b-bf126c5cd065
+  subjects:
+  - entities:
+    - role: player
+      name: Samir Mohammed
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '131'
+  uuid: 11f90750-1bad-4666-b569-0b3e0d65e1e0
+  subjects:
+  - entities:
+    - role: player
+      name: KJ Scobey
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '132'
+  uuid: fa07fad3-3d23-4c05-806c-bff7f161d3d1
+  subjects:
+  - entities:
+    - role: player
+      name: Charlie Sarsfield
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '133'
+  uuid: 382356ec-7f68-4546-ae2a-30212e5a3d1c
+  subjects:
+  - entities:
+    - role: player
+      name: Seddrick Henderson III
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '134'
+  uuid: 2967be34-7df7-4f9a-9a96-5fdcdaaecbab
+  subjects:
+  - entities:
+    - role: player
+      name: Noah Franco
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '135'
+  uuid: b618cdad-4873-4299-bbe7-a3ae3f077a3b
+  subjects:
+  - entities:
+    - role: player
+      name: Moises Gudino
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '136'
+  uuid: 2970bcbc-1786-47bb-ad2b-8cd951a1fa63
+  subjects:
+  - entities:
+    - role: player
+      name: Will Brick
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '137'
+  uuid: f59f4300-3eca-4d5b-9e48-ea021d31c90b
+  subjects:
+  - entities:
+    - role: player
+      name: Valentin Ceballos
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '138'
+  uuid: ac47325e-6970-4fea-a4d1-9375aa1f7aea
+  subjects:
+  - entities:
+    - role: player
+      name: Brennan McLaughlin
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '139'
+  uuid: ebe3a7f1-a1ce-48ce-9840-c17d5316fffb
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Johnson
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '140'
+  uuid: ad85f873-88f7-4cc6-b0dd-dc667ec58d39
+  subjects:
+  - entities:
+    - role: player
+      name: Roch Cholowsky
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '141'
+  uuid: 881b516b-fd0d-40aa-bf27-a650f23036b4
+  subjects:
+  - entities:
+    - role: player
+      name: Grady Emerson
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '142'
+  uuid: 7677968d-6e0b-447f-9fcb-bd541d65172e
+  subjects:
+  - entities:
+    - role: player
+      name: Eric Becker
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '143'
+  uuid: 0db08aab-f9c0-45a6-a6a9-f080ed6019e3
+  subjects:
+  - entities:
+    - role: player
+      name: Liam Peterson
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '144'
+  uuid: c4ce4775-02f3-4085-b0d0-bf55978663c8
+  subjects:
+  - entities:
+    - role: player
+      name: Matthew Fernandez
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '145'
+  uuid: 1d9b86cd-7f6c-4012-a9b2-bc95e09c6cb5
+  subjects:
+  - entities:
+    - role: player
+      name: Brogan Witcher
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '146'
+  uuid: 7e96f3bd-47ca-4c32-9606-2af2fa67c47f
+  subjects:
+  - entities:
+    - role: player
+      name: Andrew Jimenez
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '147'
+  uuid: e4e8a67e-2c55-454a-b7c9-8e791a14fad6
+  subjects:
+  - entities:
+    - role: player
+      name: AJ Gracia
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '148'
+  uuid: 8061b5ca-cd37-4c06-a19d-c37b77775b05
+  subjects:
+  - entities:
+    - role: player
+      name: Marcus Cantu
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '149'
+  uuid: 321b1e4d-6e0b-40e0-9cdf-044657f73f25
+  subjects:
+  - entities:
+    - role: player
+      name: Colton Petersmith
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '150'
+  uuid: ea1cdb54-52e6-450a-9acd-01c18b414127
+  subjects:
+  - entities:
+    - role: player
+      name: Junior Lopez
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '151'
+  uuid: b1c068b7-eed5-49d6-b61a-264509952ad2
+  subjects:
+  - entities:
+    - role: player
+      name: Xander Tiller
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '152'
+  uuid: 213caed5-bc18-4a4c-b310-aeb408d8d44a
+  subjects:
+  - entities:
+    - role: player
+      name: Max Hemenway
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '153'
+  uuid: 03bb35eb-2d06-4bac-a2e1-a417aa8f336a
+  subjects:
+  - entities:
+    - role: player
+      name: Eric Becker
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '154'
+  uuid: d7bdb8b1-4162-4319-8924-f5087e579b2a
+  subjects:
+  - entities:
+    - role: player
+      name: Bryan Ravelo
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '155'
+  uuid: 7774e483-ccaa-4867-9061-988ebf8a7fea
+  subjects:
+  - entities:
+    - role: player
+      name: Grady Emerson
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '156'
+  uuid: f7951364-e8e6-449c-acd1-5579ee7ae71b
+  subjects:
+  - entities:
+    - role: player
+      name: Ryder Helfrick
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '157'
+  uuid: 6c1de789-2f89-46d8-a88c-3b15e92a2ec7
+  subjects:
+  - entities:
+    - role: player
+      name: Matthew Sharman
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '158'
+  uuid: 89070a7a-df35-42d1-ae6f-ec1337fe5a94
+  subjects:
+  - entities:
+    - role: player
+      name: Tyler Bell
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '159'
+  uuid: 6b20215f-9573-47ed-b428-08dec87ffd26
+  subjects:
+  - entities:
+    - role: player
+      name: CJ Sampson
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '160'
+  uuid: 6a89959f-e1be-46c6-9e96-7622ae61a950
+  subjects:
+  - entities:
+    - role: player
+      name: Myles Bailey
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '161'
+  uuid: 98df2341-b905-4449-b3e5-d707c32b41d9
+  subjects:
+  - entities:
+    - role: player
+      name: Tyler Bell
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '162'
+  uuid: 64b4d1e3-5bfc-4300-85d7-319743caa758
+  subjects:
+  - entities:
+    - role: player
+      name: Luke Armijo
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '163'
+  uuid: ba24cbaf-3559-4f87-a2ed-a3189317dd97
+  subjects:
+  - entities:
+    - role: player
+      name: Banks Addison
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '164'
+  uuid: 9cf381d8-c530-46c0-afb3-e15df8aa58db
+  subjects:
+  - entities:
+    - role: player
+      name: Logan Bristol
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '165'
+  uuid: f01753a4-c8a7-47c9-80e9-5d8f99ecf633
+  subjects:
+  - entities:
+    - role: player
+      name: Tague Davis
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '166'
+  uuid: e67a3864-00fa-41f9-ad42-8b0a64dc960b
+  subjects:
+  - entities:
+    - role: player
+      name: Jason Marll Jr.
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '167'
+  uuid: 2883019d-89ff-429e-a75c-4152a737c2d5
+  subjects:
+  - entities:
+    - role: player
+      name: Ace Reese
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '168'
+  uuid: 0ff64d58-e92d-4aff-a8a1-da8b95667f5b
+  subjects:
+  - entities:
+    - role: player
+      name: Drew Burress
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '169'
+  uuid: 9d530c34-3832-4022-9685-4f67b3b36ee7
+  subjects:
+  - entities:
+    - role: player
+      name: Max Bayles
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '170'
+  uuid: b5af7814-78e4-4431-8d6b-ffe550c51d45
+  subjects:
+  - entities:
+    - role: player
+      name: Coleman Borthwick
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '171'
+  uuid: 3c353414-381a-4ea9-b61c-a3d109f54afc
+  subjects:
+  - entities:
+    - role: player
+      name: Gio Rojas
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '172'
+  uuid: 1feca995-d7be-46d4-b8e0-07b889bd4b00
+  subjects:
+  - entities:
+    - role: player
+      name: Griffin McKain
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '173'
+  uuid: 007a6c33-bd77-41d4-b573-1cf3970d89ed
+  subjects:
+  - entities:
+    - role: player
+      name: Keegan Burke
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '174'
+  uuid: 49cf6e0a-ccaa-4a3d-b83f-be3ecf721df7
+  subjects:
+  - entities:
+    - role: player
+      name: Cade Allen
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '175'
+  uuid: 6627c15d-5446-4129-b284-fcced23129ac
+  subjects:
+  - entities:
+    - role: player
+      name: Louis Lappe
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '176'
+  uuid: bbe6cfcf-83b1-4ff5-a2f4-cca9835c2522
+  subjects:
+  - entities:
+    - role: player
+      name: Dariel Carrion
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '177'
+  uuid: 2e9d7e56-e79b-4028-88fd-a51589a9d5bc
+  subjects:
+  - entities:
+    - role: player
+      name: Ka'alekahi Kuhaulua
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '178'
+  uuid: 97555d07-35b6-4b3a-975b-3135ddd8a82f
+  subjects:
+  - entities:
+    - role: player
+      name: Orion Gonzalez
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '179'
+  uuid: 03a687ee-bd8f-4d3f-9aca-67855ef80f86
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Seamon
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '180'
+  uuid: ff3b11ef-d27e-4f7b-9bd8-180df802e60a
+  subjects:
+  - entities:
+    - role: player
+      name: Carter Shouse
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '181'
+  uuid: fc30c509-1d67-42ff-8e76-7b079121332a
+  subjects:
+  - entities:
+    - role: player
+      name: Jordan Ayala
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '182'
+  uuid: 70680540-d977-4323-8a3d-2915fcf65f4e
+  subjects:
+  - entities:
+    - role: player
+      name: Ryan Marohn
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '183'
+  uuid: 1a70919a-f943-4c90-94af-691a84be8af9
+  subjects:
+  - entities:
+    - role: player
+      name: Anderson Kaufmann
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '184'
+  uuid: 333b9ad2-6fcb-4732-b5f6-50ceb1ec4d58
+  subjects:
+  - entities:
+    - role: player
+      name: Jack Woda
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '185'
+  uuid: 259b1e5b-ae51-4eb0-a2a2-5b2b6ca2f2e6
+  subjects:
+  - entities:
+    - role: player
+      name: Max Hemenway
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '186'
+  uuid: 66124ca3-46b3-40ef-b1d7-7ecb160aa953
+  subjects:
+  - entities:
+    - role: player
+      name: Cooper Collins
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '187'
+  uuid: fb6df5c9-62b5-4f5e-8f26-316b2afbd615
+  subjects:
+  - entities:
+    - role: player
+      name: Graham Houston
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '188'
+  uuid: 21b6a58c-1803-458f-a95c-d599d0549c0a
+  subjects:
+  - entities:
+    - role: player
+      name: Dax Whitney
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '189'
+  uuid: bf750ad4-a0a4-4620-88c2-20985f6e0168
+  subjects:
+  - entities:
+    - role: player
+      name: Brennan New
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '190'
+  uuid: '069a0383-3c17-403c-9819-abfec4c46fa9'
+  subjects:
+  - entities:
+    - role: player
+      name: Aidan King
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '191'
+  uuid: b9e29240-41ba-42e4-9305-6fbc146d7d74
+  subjects:
+  - entities:
+    - role: player
+      name: Connor Balazic
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '192'
+  uuid: 83afe928-1090-496b-8a17-85bf52f2de3e
+  subjects:
+  - entities:
+    - role: player
+      name: Kaden Waechter
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '193'
+  uuid: a257a5af-1eee-4b67-a7f9-cbe910890e1d
+  subjects:
+  - entities:
+    - role: player
+      name: Keelan Zumwalt
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '194'
+  uuid: 607cf092-865d-4728-a98b-eafa2b70f3ad
+  subjects:
+  - entities:
+    - role: player
+      name: Tristin Gaines
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '195'
+  uuid: 9834bbdd-5696-4738-83f3-59b71f660f9a
+  subjects:
+  - entities:
+    - role: player
+      name: Lucas Moore
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '196'
+  uuid: 87e724f4-d7b8-4d6a-8b22-58cf4901849c
+  subjects:
+  - entities:
+    - role: player
+      name: Trent O'Malley
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '197'
+  uuid: 4ab365b8-a874-4ce9-80cd-385b0053ca16
+  subjects:
+  - entities:
+    - role: player
+      name: Cole Gibler
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '198'
+  uuid: fab2f90f-b93b-48d5-b94a-e7538569ed14
+  subjects:
+  - entities:
+    - role: player
+      name: Chase Fuller
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '199'
+  uuid: 43b9c4f6-b7b6-426b-9b41-4961f14d64d9
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Seamon
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '200'
+  uuid: adab6ab9-ce1c-4dab-8560-db80d4b19786
+  subjects:
+  - entities:
+    - role: player
+      name: Dexter McCleon Jr.
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 

--- a/data/baseball/2026-panini-prizm-stars-stripes/checklists/base-set.yaml
+++ b/data/baseball/2026-panini-prizm-stars-stripes/checklists/base-set.yaml
@@ -1,0 +1,2000 @@
+- number: '1'
+  uuid: dddd089e-7bbb-4048-80bc-0991bb233281
+  subjects:
+  - entities:
+    - role: player
+      name: AJ Elliott
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '2'
+  uuid: 18ef8b4a-5e38-4fa8-80ac-4918cbb50d8e
+  subjects:
+  - entities:
+    - role: player
+      name: Broedy Poppell
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '3'
+  uuid: 73cc44c2-acb2-4ad8-8a9d-4902f5f6e11a
+  subjects:
+  - entities:
+    - role: player
+      name: Frank Thomas III
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '4'
+  uuid: 1d56fe3b-1770-46a5-a052-e25ad1429195
+  subjects:
+  - entities:
+    - role: player
+      name: Cooper Gornet
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '5'
+  uuid: 337bfa84-926f-49ce-8f7e-e9048b1c84bd
+  subjects:
+  - entities:
+    - role: player
+      name: Nathan Malone
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '6'
+  uuid: df4d4e91-f808-4d88-a434-ccf8595c63a6
+  subjects:
+  - entities:
+    - role: player
+      name: Barret Schell
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '7'
+  uuid: 341ceb52-3338-443e-86e2-08620b5670c3
+  subjects:
+  - entities:
+    - role: player
+      name: Anthony Frausto III
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '8'
+  uuid: d07416e3-fc69-40ee-9c9d-bab6b37c5d22
+  subjects:
+  - entities:
+    - role: player
+      name: LJ Mercurius
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '9'
+  uuid: 54515d21-b2b5-4ac6-9967-da1ad61f7fd7
+  subjects:
+  - entities:
+    - role: player
+      name: Derek Vazquez
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '10'
+  uuid: 9a36d45a-ac60-418a-9135-f228e3d64aac
+  subjects:
+  - entities:
+    - role: player
+      name: Colin Anderson
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '11'
+  uuid: 607fa75a-4df4-4eea-9b3c-55282cf20c42
+  subjects:
+  - entities:
+    - role: player
+      name: Carter Hadnot
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '12'
+  uuid: 84d8248b-aa9c-488a-b8f7-7b2e8fc2b309
+  subjects:
+  - entities:
+    - role: player
+      name: Ryan McPherson
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '13'
+  uuid: b615e4c1-c19a-4a95-aa2e-0d8c59d3f8b0
+  subjects:
+  - entities:
+    - role: player
+      name: James Clark
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '14'
+  uuid: 62b1929d-a1e2-410b-a281-fc65dbe10ada
+  subjects:
+  - entities:
+    - role: player
+      name: Brock Bliss
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '15'
+  uuid: a4f89ea2-4c6f-41c6-b860-d9b97228c640
+  subjects:
+  - entities:
+    - role: player
+      name: Grant Sperandio
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '16'
+  uuid: 988082c3-26ee-4ff6-8cc5-59d23353cbc0
+  subjects:
+  - entities:
+    - role: player
+      name: Landon King
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '17'
+  uuid: a4e7a4c4-b90d-4b94-864c-ecec0e251f20
+  subjects:
+  - entities:
+    - role: player
+      name: Christopher Chikodroff
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '18'
+  uuid: 6d6530a8-1f06-4e80-ab4c-ffabf366a540
+  subjects:
+  - entities:
+    - role: player
+      name: Brett Renfrow
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '19'
+  uuid: 82f44429-0cb9-4757-9849-7d956d301cf0
+  subjects:
+  - entities:
+    - role: player
+      name: Leo Nockley
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '20'
+  uuid: 52ce2e92-db42-4154-b0f8-c203ce5b6058
+  subjects:
+  - entities:
+    - role: player
+      name: Cameron Bagwell
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '21'
+  uuid: 92f7e8a3-fd83-4d49-9f70-267d86b927e4
+  subjects:
+  - entities:
+    - role: player
+      name: Tomas Valincius
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '22'
+  uuid: 44ca699e-f606-4000-bb27-fe5ded8c4733
+  subjects:
+  - entities:
+    - role: player
+      name: Cullen Scott
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '23'
+  uuid: a0f9fbf8-0279-4c63-ad72-b60ba56fb2e8
+  subjects:
+  - entities:
+    - role: player
+      name: Connor Salerno
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '24'
+  uuid: 0cd6d536-cb4e-48e4-a6c8-c4509d205967
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Cruz
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '25'
+  uuid: f0955584-25e6-4c7e-b918-6521fd923183
+  subjects:
+  - entities:
+    - role: player
+      name: Noah Jarolimek
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '26'
+  uuid: f6000cb3-38eb-46ad-b190-e639780d6547
+  subjects:
+  - entities:
+    - role: player
+      name: Ricky Ojeda
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '27'
+  uuid: 7805d9d0-d122-4fed-bd6f-62805f9a3a7b
+  subjects:
+  - entities:
+    - role: player
+      name: Kekoa Delatori
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '28'
+  uuid: c26ab148-5c16-42a7-aa0a-84d2a61da642
+  subjects:
+  - entities:
+    - role: player
+      name: Vahn Lackey
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '29'
+  uuid: 442b75e1-7d1f-4bcb-a7e0-d2de63144689
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Dudan
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '30'
+  uuid: 969a281d-8795-4fc2-b3e7-c0cd523e9096
+  subjects:
+  - entities:
+    - role: player
+      name: Trey Beard
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '31'
+  uuid: 87134c2a-c952-4880-af73-e5d0158fed3e
+  subjects:
+  - entities:
+    - role: player
+      name: Anthony Murphy
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '32'
+  uuid: 98688093-670d-40b0-a4b2-85bf11047151
+  subjects:
+  - entities:
+    - role: player
+      name: Andrew Costello
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '33'
+  uuid: 1ad7141e-afe7-4b12-8df0-60cf4979b0c1
+  subjects:
+  - entities:
+    - role: player
+      name: Nateo Victorio
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '34'
+  uuid: 7a05cee4-c831-47f2-b441-05d836d5af57
+  subjects:
+  - entities:
+    - role: player
+      name: Gavin Chakar
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '35'
+  uuid: 4d654574-c68c-490f-b894-af8e20af2fe6
+  subjects:
+  - entities:
+    - role: player
+      name: Davis Romejko
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '36'
+  uuid: 9faefe65-9cf8-4d63-836d-79a28bf2eeaf
+  subjects:
+  - entities:
+    - role: player
+      name: Dax Whitney
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '37'
+  uuid: e2128d87-7402-4b17-ac74-2d91b6440b7f
+  subjects:
+  - entities:
+    - role: player
+      name: Brody Schumaker
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '38'
+  uuid: 8acbe706-1baf-4813-9ff0-b61c713a0f20
+  subjects:
+  - entities:
+    - role: player
+      name: Liam Peterson
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '39'
+  uuid: c1d6a7dd-fb3e-4687-85d7-3ce1f2d02125
+  subjects:
+  - entities:
+    - role: player
+      name: Drew Burress
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '40'
+  uuid: aceeab04-623a-400c-876b-4cae4c0deeb1
+  subjects:
+  - entities:
+    - role: player
+      name: Connor Wells
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '41'
+  uuid: e90d4964-9503-47ca-ad7c-cd2637265f19
+  subjects:
+  - entities:
+    - role: player
+      name: Jeremiah Hall
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '42'
+  uuid: e9524011-d6b3-4623-86ee-6d94b3149a57
+  subjects:
+  - entities:
+    - role: player
+      name: Camden Boehm
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '43'
+  uuid: f7f269c5-7f65-45e5-8dff-d4fb4f958b99
+  subjects:
+  - entities:
+    - role: player
+      name: Mateo Mier
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '44'
+  uuid: f86f206f-a53a-4b27-8ddd-0848466ab078
+  subjects:
+  - entities:
+    - role: player
+      name: Oliver Van Tiem
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '45'
+  uuid: d49690bb-45bd-44ac-87dd-fb1ae1e1d978
+  subjects:
+  - entities:
+    - role: player
+      name: AJ Ciscar
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '46'
+  uuid: bd210edb-437b-4878-9f9b-96f0d9864b06
+  subjects:
+  - entities:
+    - role: player
+      name: Daniel Cuvet
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '47'
+  uuid: ccbb2495-7a2f-4143-aad7-1044126c85ed
+  subjects:
+  - entities:
+    - role: player
+      name: Cole Carlon
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '48'
+  uuid: 862bc001-72b8-4c49-83a4-d75425423a66
+  subjects:
+  - entities:
+    - role: player
+      name: Duncan Mount
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '49'
+  uuid: 0ff85da2-3f49-4441-8333-7a2a9837fcf1
+  subjects:
+  - entities:
+    - role: player
+      name: Bobby Villa
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '50'
+  uuid: fd1b82aa-8b4f-42a6-8708-51a8b0292bfd
+  subjects:
+  - entities:
+    - role: player
+      name: Xavier Rodriguez
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '51'
+  uuid: 0c4b6403-d1fc-4367-a61b-666e8d116f57
+  subjects:
+  - entities:
+    - role: player
+      name: Landon Green
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '52'
+  uuid: 18bfe045-fcde-48e0-8cf0-b47712a962d2
+  subjects:
+  - entities:
+    - role: player
+      name: Jack Byers
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '53'
+  uuid: a2578ee0-4053-414a-9156-47426d5b944e
+  subjects:
+  - entities:
+    - role: player
+      name: Ace Reese
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '54'
+  uuid: a2ccd7a2-45d5-4584-ab1f-02a220c0a92f
+  subjects:
+  - entities:
+    - role: player
+      name: Hardin Sullivan
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '55'
+  uuid: 75e45c41-f1bc-4772-935e-dd446249dd19
+  subjects:
+  - entities:
+    - role: player
+      name: Alex Hernandez
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '56'
+  uuid: 9515f9e1-3ef8-4b71-a471-881b0d1ece19
+  subjects:
+  - entities:
+    - role: player
+      name: Chase Gockenbach
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '57'
+  uuid: 8d8b9b52-bd7d-4e10-9e69-71e12ef9a318
+  subjects:
+  - entities:
+    - role: player
+      name: Nolyn Nickels
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '58'
+  uuid: 0a418289-0cc7-4af5-8aad-612126bf759d
+  subjects:
+  - entities:
+    - role: player
+      name: James Guyette
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '59'
+  uuid: d5823fce-9b3f-4848-b57d-da7111a4c067
+  subjects:
+  - entities:
+    - role: player
+      name: Ryan Lynch
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '60'
+  uuid: 2f5312f7-cd97-47b9-b958-2f3b7cf06e3c
+  subjects:
+  - entities:
+    - role: player
+      name: Chase Fuller
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '61'
+  uuid: 1f742c84-863f-4216-8317-e5445b205535
+  subjects:
+  - entities:
+    - role: player
+      name: Carson Bolemon
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '62'
+  uuid: 2a0ba068-68de-4968-8d0d-242ece445680
+  subjects:
+  - entities:
+    - role: player
+      name: Trey Rangel
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '63'
+  uuid: 53b657f5-81a6-49b6-8fc9-e5f05136c649
+  subjects:
+  - entities:
+    - role: player
+      name: Brady Buenik
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '64'
+  uuid: 94929aab-7e55-4996-832b-8b46cd511e83
+  subjects:
+  - entities:
+    - role: player
+      name: Caden Borcherding
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '65'
+  uuid: c5c7458c-c58e-45de-b582-e927815deeca
+  subjects:
+  - entities:
+    - role: player
+      name: Hunter Sundby
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '66'
+  uuid: 8c5930e5-c8a8-45e5-8014-6c7d499477bc
+  subjects:
+  - entities:
+    - role: player
+      name: Tommy LaPour
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '67'
+  uuid: b8388292-e97b-42c6-82aa-4a4ec27b471e
+  subjects:
+  - entities:
+    - role: player
+      name: Jose Partida
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '68'
+  uuid: 55f34dff-83e3-4357-81b4-8e20457aca02
+  subjects:
+  - entities:
+    - role: player
+      name: Ethan Norby
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '69'
+  uuid: 0df0d734-36d4-493c-b3a0-3e6b158a3572
+  subjects:
+  - entities:
+    - role: player
+      name: Dexter McCleon Jr.
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '70'
+  uuid: 52d5308f-a237-4a0f-8f59-fb93a58ab663
+  subjects:
+  - entities:
+    - role: player
+      name: Jack Carson
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '71'
+  uuid: da36ba04-01bd-4063-98ad-89985db29910
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Beatty
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '72'
+  uuid: 8d61905a-e8a1-42d1-ae20-fdc890f8529e
+  subjects:
+  - entities:
+    - role: player
+      name: Grady Nelson
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '73'
+  uuid: a8385ae8-ff91-42e2-ae8f-31ddb33f1d3e
+  subjects:
+  - entities:
+    - role: player
+      name: Evan Dempsey
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '74'
+  uuid: 0c378095-34f1-4aa7-9266-b9593b65fb40
+  subjects:
+  - entities:
+    - role: player
+      name: Ethan Gustus
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '75'
+  uuid: ac65d58b-a448-4b3b-96e0-d4ee72160eba
+  subjects:
+  - entities:
+    - role: player
+      name: Cam Kozeal
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '76'
+  uuid: f07e5b39-f9fc-4fd5-ac3d-8eda17803506
+  subjects:
+  - entities:
+    - role: player
+      name: Easton Hawk
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '77'
+  uuid: f4076e3b-5018-47a9-9d67-aa9eb514901c
+  subjects:
+  - entities:
+    - role: player
+      name: Gabe Gaeckle
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '78'
+  uuid: 994fe724-5aeb-4bd0-bc3c-6310085fe16b
+  subjects:
+  - entities:
+    - role: player
+      name: Landon McDonald
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '79'
+  uuid: 95bb442a-a735-4408-a748-3f8c6f07985a
+  subjects:
+  - entities:
+    - role: player
+      name: Levi Leathers
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '80'
+  uuid: 23fb8be8-7dca-47cd-b37a-42c48dcacaf7
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Flora
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '81'
+  uuid: a8c5d418-ee98-4ea8-bf7c-0a9de46348c0
+  subjects:
+  - entities:
+    - role: player
+      name: Roch Cholowsky
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '82'
+  uuid: b3e881f2-2b6c-4a9c-8331-25ec0a76dd9f
+  subjects:
+  - entities:
+    - role: player
+      name: Smith Bailey
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '83'
+  uuid: 81cea17a-a9c7-413a-8a04-55b74d4a5b1d
+  subjects:
+  - entities:
+    - role: player
+      name: Jorvorskie Lane Jr.
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '84'
+  uuid: b4329ced-c6f5-49f7-865b-8c7e4aa8abf9
+  subjects:
+  - entities:
+    - role: player
+      name: Brody Crane
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '85'
+  uuid: 1656c126-68b1-43f8-bd52-2e432f7afb67
+  subjects:
+  - entities:
+    - role: player
+      name: Luke Esquivel
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '86'
+  uuid: 78f1e859-a232-40d2-bac6-012bae89133c
+  subjects:
+  - entities:
+    - role: player
+      name: Chris Rembert
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '87'
+  uuid: b2cfb358-ee1d-4ea1-8b9b-7cd5aad2481e
+  subjects:
+  - entities:
+    - role: player
+      name: Jared Grindlinger
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '88'
+  uuid: bc8fb333-a2d3-4c98-8a50-a313f0ffcf2b
+  subjects:
+  - entities:
+    - role: player
+      name: Anderson Nance
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '89'
+  uuid: f05c643a-7d38-4b42-997f-67b7370713ef
+  subjects:
+  - entities:
+    - role: player
+      name: Greyson Bell
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '90'
+  uuid: 26980bc1-4998-43a6-83ab-a375fa870a34
+  subjects:
+  - entities:
+    - role: player
+      name: Yariel Diaz
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '91'
+  uuid: b5844991-6f2d-43c3-a8e4-9434631ed874
+  subjects:
+  - entities:
+    - role: player
+      name: Jared Grindlinger
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '92'
+  uuid: e33a53cc-6bc2-4900-9691-cffca57d274a
+  subjects:
+  - entities:
+    - role: player
+      name: Jake Romero
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '93'
+  uuid: 5dce0d4d-6a1d-4ef8-9851-6391a96c334b
+  subjects:
+  - entities:
+    - role: player
+      name: Eli Jones
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '94'
+  uuid: 64dd48ef-0680-4fc0-99dc-7b379ef90bd0
+  subjects:
+  - entities:
+    - role: player
+      name: Coleman Borthwick
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '95'
+  uuid: 3da6d761-d38c-4648-ac1c-c083e961a9c0
+  subjects:
+  - entities:
+    - role: player
+      name: Andres Jimenez
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '96'
+  uuid: a63970bb-c4fc-4fac-8ab2-f5cf61f97361
+  subjects:
+  - entities:
+    - role: player
+      name: Jameson Wilhite
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '97'
+  uuid: 14b8e5b9-ed01-4abf-bb33-1458d3a84f55
+  subjects:
+  - entities:
+    - role: player
+      name: Ethan Kleinschmit
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '98'
+  uuid: 44a1e1b1-ca53-4bf9-8156-0476d4975229
+  subjects:
+  - entities:
+    - role: player
+      name: Cooper Jones
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '99'
+  uuid: 75eda961-7e89-40fe-82cd-dfbdc3d6b0c9
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Lombard
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '100'
+  uuid: 73b14f37-86b8-4901-b5b3-d709cbb7dc1d
+  subjects:
+  - entities:
+    - role: player
+      name: Owen Kramkowski
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '101'
+  uuid: 9151f1ed-ecac-4028-9c58-f93ab8787fb2
+  subjects:
+  - entities:
+    - role: player
+      name: Jaxon Spray
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '102'
+  uuid: 70458491-5764-4d7f-811a-61b8c4079fad
+  subjects:
+  - entities:
+    - role: player
+      name: Ricky Lopez
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '103'
+  uuid: e561ac3e-8e6b-44af-8dc9-ddeac878e37a
+  subjects:
+  - entities:
+    - role: player
+      name: Cole Koeninger
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '104'
+  uuid: 28f37798-d06b-43d4-bf9d-16c888ce2777
+  subjects:
+  - entities:
+    - role: player
+      name: Blake Morningstar
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '105'
+  uuid: 6a5e4e0e-c341-483b-a819-b511b2c57d05
+  subjects:
+  - entities:
+    - role: player
+      name: Jason DeCaro
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '106'
+  uuid: ead5a864-526c-46c6-89e8-2d78405d1c12
+  subjects:
+  - entities:
+    - role: player
+      name: Hudson Oliver
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '107'
+  uuid: 7ce7fcdd-9dce-4b3a-9747-ff3ac84af5a3
+  subjects:
+  - entities:
+    - role: player
+      name: Kai Sapp
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '108'
+  uuid: a414ae12-28cf-4e7e-851e-2f837cb9e2a9
+  subjects:
+  - entities:
+    - role: player
+      name: Kristian Valadez
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '109'
+  uuid: 2c8f3c68-ff80-446e-8be8-d149daa96838
+  subjects:
+  - entities:
+    - role: player
+      name: Jaden Jackson
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '110'
+  uuid: 292590cf-5793-441b-845c-f403b46f97cd
+  subjects:
+  - entities:
+    - role: player
+      name: William Haggerty
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '111'
+  uuid: 57caeea9-a13e-434a-8189-18241616a9a6
+  subjects:
+  - entities:
+    - role: player
+      name: Gavin McMillan
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '112'
+  uuid: c5b1609c-0af9-4708-a950-f119894a1448
+  subjects:
+  - entities:
+    - role: player
+      name: Landon Mack
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '113'
+  uuid: a362b374-f400-4852-81f0-3faf2fa07b56
+  subjects:
+  - entities:
+    - role: player
+      name: Zion Rose
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '114'
+  uuid: 753e590d-9007-48a6-98ae-ac923dac42c7
+  subjects:
+  - entities:
+    - role: player
+      name: Mason Bitzenhofer
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '115'
+  uuid: eb07e472-f75d-4d60-b476-ac485d76449e
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan Hatch
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '116'
+  uuid: b67b0f09-4731-4fdd-a1b6-5fe4ce123650
+  subjects:
+  - entities:
+    - role: player
+      name: Jaden Freeze
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '117'
+  uuid: b17eece6-2f03-409a-b973-03a4f8828fd1
+  subjects:
+  - entities:
+    - role: player
+      name: Colton Floyd
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '118'
+  uuid: fb54ce49-47be-47ec-8dc9-dd564b5a9ce6
+  subjects:
+  - entities:
+    - role: player
+      name: Jace Duckett
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '119'
+  uuid: 8e201406-54da-4516-a2ae-36d83e05a2d8
+  subjects:
+  - entities:
+    - role: player
+      name: Gio Rojas
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '120'
+  uuid: 9031f478-e541-430a-a6eb-8cdd3723aa91
+  subjects:
+  - entities:
+    - role: player
+      name: Matthew Werner
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '121'
+  uuid: 4b482e1a-2df0-41c0-bdeb-6622895ee574
+  subjects:
+  - entities:
+    - role: player
+      name: Aiden Ruiz
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '122'
+  uuid: b49dd715-76eb-4098-8beb-116169cf3eb4
+  subjects:
+  - entities:
+    - role: player
+      name: Radner Roth
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '123'
+  uuid: 52f48c4c-797e-41bb-973c-37cce91bf053
+  subjects:
+  - entities:
+    - role: player
+      name: Tyler Smith
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '124'
+  uuid: beb97690-c312-4532-94a2-c5a0a105ea03
+  subjects:
+  - entities:
+    - role: player
+      name: Brady Ballinger
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '125'
+  uuid: 0fc8acda-0a71-4831-9090-7f82e803f38e
+  subjects:
+  - entities:
+    - role: player
+      name: Russell McGee
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '126'
+  uuid: bf7f6692-b290-441e-b429-0e0f4d11bec8
+  subjects:
+  - entities:
+    - role: player
+      name: Mulivai Levu
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '127'
+  uuid: 17d5d6fd-307d-44c0-a8c0-17b91e470af2
+  subjects:
+  - entities:
+    - role: player
+      name: AJ Gracia
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '128'
+  uuid: 4f4e9468-f4b0-4712-bd89-1f3709bccfec
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan Traeger
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '129'
+  uuid: b79f6611-48bf-4e64-a0bf-c2a8a1cd9a92
+  subjects:
+  - entities:
+    - role: player
+      name: Macgraw VanWormer
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '130'
+  uuid: 37da3203-a148-417a-ab54-8ed1e320b83f
+  subjects:
+  - entities:
+    - role: player
+      name: Samir Mohammed
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '131'
+  uuid: c71a02ac-a412-4771-99af-9075e138dfe6
+  subjects:
+  - entities:
+    - role: player
+      name: KJ Scobey
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '132'
+  uuid: 7a86fc42-b57f-442f-9a37-83fb907d061f
+  subjects:
+  - entities:
+    - role: player
+      name: Charlie Sarsfield
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '133'
+  uuid: c29fca13-adfb-474a-b33b-4556bd0b5e4a
+  subjects:
+  - entities:
+    - role: player
+      name: Seddrick Henderson III
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '134'
+  uuid: b8f7bf60-2fdf-45c8-8859-302143a87f13
+  subjects:
+  - entities:
+    - role: player
+      name: Noah Franco
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '135'
+  uuid: 939161cc-f7eb-43c1-96f9-97827bb0fcf1
+  subjects:
+  - entities:
+    - role: player
+      name: Moises Gudino
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '136'
+  uuid: b3993a2f-cec4-4d28-b593-81c243b8b12e
+  subjects:
+  - entities:
+    - role: player
+      name: Will Brick
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '137'
+  uuid: f204b9b1-eac1-4648-acaf-e0612784de2b
+  subjects:
+  - entities:
+    - role: player
+      name: Valentin Ceballos
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '138'
+  uuid: 1daea82c-d35c-4654-9eac-d955a0ebfa5a
+  subjects:
+  - entities:
+    - role: player
+      name: Brennan McLaughlin
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '139'
+  uuid: fb61c16a-c2fa-4d40-937a-37ca98ceeec2
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Johnson
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '140'
+  uuid: 133f84aa-e513-4c2f-b4f8-6fd144e44f9a
+  subjects:
+  - entities:
+    - role: player
+      name: Roch Cholowsky
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '141'
+  uuid: 398dbeca-a433-4749-a78b-93150c0eb38f
+  subjects:
+  - entities:
+    - role: player
+      name: Grady Emerson
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '142'
+  uuid: 12e50629-9365-4c51-9ae6-1bfd45b61a72
+  subjects:
+  - entities:
+    - role: player
+      name: Eric Becker
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '143'
+  uuid: '038f24cf-3c3a-4aec-8d75-10f01b870fba'
+  subjects:
+  - entities:
+    - role: player
+      name: Liam Peterson
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '144'
+  uuid: 52b1e0e4-7070-4a91-83e5-e88c1fc8a73c
+  subjects:
+  - entities:
+    - role: player
+      name: Matthew Fernandez
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '145'
+  uuid: 5abea51b-b622-4b90-861e-9a7025271d35
+  subjects:
+  - entities:
+    - role: player
+      name: Brogan Witcher
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '146'
+  uuid: de68641f-ead5-4b8b-9d91-db1d0638d538
+  subjects:
+  - entities:
+    - role: player
+      name: Andrew Jimenez
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '147'
+  uuid: 300a4fe4-a1a7-4c0c-a8df-43c0f9dd513e
+  subjects:
+  - entities:
+    - role: player
+      name: AJ Gracia
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '148'
+  uuid: c65414b0-d38a-4821-9d44-544f8de3e644
+  subjects:
+  - entities:
+    - role: player
+      name: Marcus Cantu
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '149'
+  uuid: 542b0576-8ce6-46cb-a64c-95c50394236a
+  subjects:
+  - entities:
+    - role: player
+      name: Colton Petersmith
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '150'
+  uuid: 35fcea3b-ff0f-498b-9c6a-58a5bc0d2f16
+  subjects:
+  - entities:
+    - role: player
+      name: Junior Lopez
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '151'
+  uuid: 0edd82d4-7821-4a4b-8430-bab354c6c2c1
+  subjects:
+  - entities:
+    - role: player
+      name: Xander Tiller
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '152'
+  uuid: f26d88fb-483a-4b50-ba62-58f798874353
+  subjects:
+  - entities:
+    - role: player
+      name: Max Hemenway
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '153'
+  uuid: 2a81453e-4c28-4831-b0cb-a5d7f888870f
+  subjects:
+  - entities:
+    - role: player
+      name: Eric Becker
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '154'
+  uuid: b8a754c1-f00a-4d63-8538-a7d032feb352
+  subjects:
+  - entities:
+    - role: player
+      name: Bryan Ravelo
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '155'
+  uuid: 2b9b4a7f-86f3-4a41-b963-837167dafb7b
+  subjects:
+  - entities:
+    - role: player
+      name: Grady Emerson
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '156'
+  uuid: '09ab7c7a-868e-4fed-8a4b-5247ff95cd36'
+  subjects:
+  - entities:
+    - role: player
+      name: Ryder Helfrick
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '157'
+  uuid: ebc84887-88b9-4a40-aaae-63bd043f7362
+  subjects:
+  - entities:
+    - role: player
+      name: Matthew Sharman
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '158'
+  uuid: 05426db5-d8cb-401b-9c60-54ce71269c8b
+  subjects:
+  - entities:
+    - role: player
+      name: Tyler Bell
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '159'
+  uuid: 8be8138e-68f2-4178-93e0-07e122578812
+  subjects:
+  - entities:
+    - role: player
+      name: CJ Sampson
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '160'
+  uuid: 8a383ce6-0324-41d1-b98b-7cedf1cfe757
+  subjects:
+  - entities:
+    - role: player
+      name: Myles Bailey
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '161'
+  uuid: 3f10ef94-44c9-4f56-940c-de6a4595a55d
+  subjects:
+  - entities:
+    - role: player
+      name: Tyler Bell
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '162'
+  uuid: a6871ecd-482e-4293-9abb-4f1d863d891d
+  subjects:
+  - entities:
+    - role: player
+      name: Luke Armijo
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '163'
+  uuid: d0d3535d-167c-4fad-91f6-95f76182f3ca
+  subjects:
+  - entities:
+    - role: player
+      name: Banks Addison
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '164'
+  uuid: d2a33a31-5c6a-45f5-a57d-3f27efe36305
+  subjects:
+  - entities:
+    - role: player
+      name: Logan Bristol
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '165'
+  uuid: 9a51d615-6af1-487f-8ae5-4d4b46205b1d
+  subjects:
+  - entities:
+    - role: player
+      name: Tague Davis
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '166'
+  uuid: f62a409f-3df7-4d6e-9374-6ef806a103eb
+  subjects:
+  - entities:
+    - role: player
+      name: Jason Marll Jr.
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '167'
+  uuid: ec91bd28-b5db-4aaf-891f-45f8abc6dbeb
+  subjects:
+  - entities:
+    - role: player
+      name: Ace Reese
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '168'
+  uuid: dfd75e81-5762-46db-b55d-41d1008a1e33
+  subjects:
+  - entities:
+    - role: player
+      name: Drew Burress
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '169'
+  uuid: be13879e-3b09-4bfb-b227-ed7b35586341
+  subjects:
+  - entities:
+    - role: player
+      name: Max Bayles
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '170'
+  uuid: 7c005e2c-7e75-438d-be68-8bbe1d39b240
+  subjects:
+  - entities:
+    - role: player
+      name: Coleman Borthwick
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '171'
+  uuid: 0bdaea6b-d113-4d43-a050-d7dd1bc846c0
+  subjects:
+  - entities:
+    - role: player
+      name: Gio Rojas
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '172'
+  uuid: 2bd0750f-f5d4-48dc-a3d6-728e6e994dfb
+  subjects:
+  - entities:
+    - role: player
+      name: Griffin McKain
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '173'
+  uuid: d834cafa-2382-4185-90b7-a4659e2426b4
+  subjects:
+  - entities:
+    - role: player
+      name: Keegan Burke
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '174'
+  uuid: 11b8625f-0bba-4961-895f-959772004c1c
+  subjects:
+  - entities:
+    - role: player
+      name: Cade Allen
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '175'
+  uuid: bc928e30-d69a-439b-8f1f-a8a4b027c424
+  subjects:
+  - entities:
+    - role: player
+      name: Louis Lappe
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '176'
+  uuid: 885eae89-b6b3-4e68-b6c7-19a76e835ca4
+  subjects:
+  - entities:
+    - role: player
+      name: Dariel Carrion
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '177'
+  uuid: 3bc9cc9f-c377-4268-b637-ed9ef8b04496
+  subjects:
+  - entities:
+    - role: player
+      name: Ka'alekahi Kuhaulua
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '178'
+  uuid: 71ae80a0-7add-4ec9-9f1f-449f7d4a3d89
+  subjects:
+  - entities:
+    - role: player
+      name: Orion Gonzalez
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '179'
+  uuid: 7baab307-e094-4ed3-97ff-798b5acec4e3
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Seamon
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '180'
+  uuid: cf781a75-b40f-432f-ad65-a1408e72d36e
+  subjects:
+  - entities:
+    - role: player
+      name: Carter Shouse
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '181'
+  uuid: c36696ff-5740-4d63-a4c4-aea79c253773
+  subjects:
+  - entities:
+    - role: player
+      name: Jordan Ayala
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '182'
+  uuid: e9a800ae-4c79-4129-a2f1-b5b8775d1699
+  subjects:
+  - entities:
+    - role: player
+      name: Ryan Marohn
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '183'
+  uuid: 5567c565-5fc5-4fe1-9109-b590e3e01e2e
+  subjects:
+  - entities:
+    - role: player
+      name: Anderson Kaufmann
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '184'
+  uuid: f2ea1f24-ab5b-4fd3-a1d3-ce600a43a78b
+  subjects:
+  - entities:
+    - role: player
+      name: Jack Woda
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '185'
+  uuid: 47c74de5-1d79-49d2-84be-5d5be79c70e5
+  subjects:
+  - entities:
+    - role: player
+      name: Max Hemenway
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '186'
+  uuid: 1f1b9d82-8b5a-4686-bd1e-1652286e65f9
+  subjects:
+  - entities:
+    - role: player
+      name: Cooper Collins
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '187'
+  uuid: a88f14f1-160f-4933-87ce-61b9e366a9eb
+  subjects:
+  - entities:
+    - role: player
+      name: Graham Houston
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '188'
+  uuid: 59f2187d-d7df-4774-be33-24657ae85427
+  subjects:
+  - entities:
+    - role: player
+      name: Dax Whitney
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '189'
+  uuid: 7257acb4-2f63-45fc-ad88-74fb8e090b21
+  subjects:
+  - entities:
+    - role: player
+      name: Brennan New
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '190'
+  uuid: 190852e4-e8bf-4a53-abd9-562e2d643021
+  subjects:
+  - entities:
+    - role: player
+      name: Aidan King
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '191'
+  uuid: d7552639-e252-4e2a-b168-54b6810a78f5
+  subjects:
+  - entities:
+    - role: player
+      name: Connor Balazic
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '192'
+  uuid: 6bad8209-c3db-4547-84b0-f879398e90ed
+  subjects:
+  - entities:
+    - role: player
+      name: Kaden Waechter
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '193'
+  uuid: c0cdac05-0a22-43b9-8bbc-2f11777a8905
+  subjects:
+  - entities:
+    - role: player
+      name: Keelan Zumwalt
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '194'
+  uuid: 532a9c51-180c-464c-83f0-7dbd3c8dc1a9
+  subjects:
+  - entities:
+    - role: player
+      name: Tristin Gaines
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '195'
+  uuid: 73cbfacf-a6cd-4f5b-ae18-a399de5afcdc
+  subjects:
+  - entities:
+    - role: player
+      name: Lucas Moore
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '196'
+  uuid: 9d45432b-806d-431c-a700-fe5c5ca727ec
+  subjects:
+  - entities:
+    - role: player
+      name: Trent O'Malley
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '197'
+  uuid: c442d396-cb57-4ade-b891-630cd3a3b987
+  subjects:
+  - entities:
+    - role: player
+      name: Cole Gibler
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '198'
+  uuid: 58aced72-03fd-4230-bcef-e657af390c34
+  subjects:
+  - entities:
+    - role: player
+      name: Chase Fuller
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '199'
+  uuid: 1cccce0c-1e01-4bd2-9e88-7ae9700d6b7a
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Seamon
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '200'
+  uuid: da56c01f-9349-4c43-9459-bbba8466208e
+  subjects:
+  - entities:
+    - role: player
+      name: Dexter McCleon Jr.
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 

--- a/data/baseball/2026-panini-prizm-stars-stripes/checklists/jumbo-materials-flag.yaml
+++ b/data/baseball/2026-panini-prizm-stars-stripes/checklists/jumbo-materials-flag.yaml
@@ -1,0 +1,1840 @@
+- number: '1'
+  uuid: 4ba7127b-920a-412e-958f-c8fafb1fa5f0
+  subjects:
+  - entities:
+    - role: player
+      name: Brogan Witcher
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '2'
+  uuid: 946b256b-24c4-4758-ac2f-511b49382ca5
+  subjects:
+  - entities:
+    - role: player
+      name: Junior Lopez
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '3'
+  uuid: 2480c2be-a5f0-40a1-8f75-72ef6117c720
+  subjects:
+  - entities:
+    - role: player
+      name: Logan Bristol
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '5'
+  uuid: 3702fda8-315f-4422-acd3-acbb987d3b16
+  subjects:
+  - entities:
+    - role: player
+      name: Jack Mattingly
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '6'
+  uuid: 66aed5b5-27d9-43fc-b3b2-77fcbd4d16b4
+  subjects:
+  - entities:
+    - role: player
+      name: Drew Burress
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '7'
+  uuid: b08bcf09-2b77-4dbb-b4b2-c1c313963ce2
+  subjects:
+  - entities:
+    - role: player
+      name: Brody Crane
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '8'
+  uuid: 388bc57f-8b76-4854-bf59-0721adc76665
+  subjects:
+  - entities:
+    - role: player
+      name: Carson Bolemon
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '9'
+  uuid: f07aaf10-95c4-4c70-b187-16c468ca4931
+  subjects:
+  - entities:
+    - role: player
+      name: Eric Becker
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '10'
+  uuid: 4a2ac0cc-8e6c-4e8e-9e15-9c21592f7112
+  subjects:
+  - entities:
+    - role: player
+      name: Tyler Bell
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '11'
+  uuid: 66a25978-8da3-4614-9bf4-1f25370bf602
+  subjects:
+  - entities:
+    - role: player
+      name: Cole Koeninger
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '12'
+  uuid: 78623cc5-02ce-49a4-a565-529f0b9b3ef9
+  subjects:
+  - entities:
+    - role: player
+      name: Yohandy Morales
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '13'
+  uuid: 749915db-663e-4799-b596-8a20450b944a
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Beatty
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '14'
+  uuid: 1c8a961b-7583-4efc-8984-52675bf4f6d6
+  subjects:
+  - entities:
+    - role: player
+      name: Blake Morningstar
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '15'
+  uuid: 92032a6f-cf8f-4650-a4a2-0f5e3496621b
+  subjects:
+  - entities:
+    - role: player
+      name: Jordan Ayala
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '16'
+  uuid: ebd0d662-7669-4ce8-8752-39ffb3601313
+  subjects:
+  - entities:
+    - role: player
+      name: Derek Vazquez
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '17'
+  uuid: 69873266-ffdb-4398-8a04-f28630503bd9
+  subjects:
+  - entities:
+    - role: player
+      name: Grant Sperandio
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '18'
+  uuid: 85283a41-db3a-4c40-a919-98755556342a
+  subjects:
+  - entities:
+    - role: player
+      name: Cooper Jones
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '19'
+  uuid: 68cfac29-1780-42e5-991b-c1d2c25def6a
+  subjects:
+  - entities:
+    - role: player
+      name: Tristin Gaines
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '20'
+  uuid: 5af707b9-586f-45d1-80db-bbcfb2c1af05
+  subjects:
+  - entities:
+    - role: player
+      name: Mattias DiMaggio
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '21'
+  uuid: c9d0db3e-6b17-48bc-b5c4-888a928b06e4
+  subjects:
+  - entities:
+    - role: player
+      name: Clayton Ratliff
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '22'
+  uuid: 0f30239a-24c7-41c5-ba6b-95c74e539dc4
+  subjects:
+  - entities:
+    - role: player
+      name: Mateo Mier
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '25'
+  uuid: eae3bfac-44a8-4166-a927-943368e2aaa8
+  subjects:
+  - entities:
+    - role: player
+      name: Noah Jarolimek
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '26'
+  uuid: 93aa08a7-2e32-4a0b-a81e-a87eb9f72d91
+  subjects:
+  - entities:
+    - role: player
+      name: Kekoa Delatori
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '27'
+  uuid: 42b13bff-241e-4f13-a56f-7b818db42be8
+  subjects:
+  - entities:
+    - role: player
+      name: Carter Hadnot
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '28'
+  uuid: d2e68670-e415-4aca-bd62-049d709ca5c2
+  subjects:
+  - entities:
+    - role: player
+      name: Colt Carter
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '29'
+  uuid: a1076831-fb3e-40a3-92dd-84fc4863bc56
+  subjects:
+  - entities:
+    - role: player
+      name: Bryant Ju
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '30'
+  uuid: 6aa2b974-3240-435c-af6f-10bd5510ab82
+  subjects:
+  - entities:
+    - role: player
+      name: CJ Dornfeld
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '31'
+  uuid: 9855d59b-c6b7-468f-a08b-6c1c1262615e
+  subjects:
+  - entities:
+    - role: player
+      name: Brandon Sweeney
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '32'
+  uuid: fb146c61-aebd-44af-8335-88e54ad5bf03
+  subjects:
+  - entities:
+    - role: player
+      name: Moises Gudino
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '33'
+  uuid: 68fc3e9a-3e28-48b7-a219-861a7b00d4d4
+  subjects:
+  - entities:
+    - role: player
+      name: Zion Rose
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '34'
+  uuid: c003e0d6-7161-4d96-abb2-0781e9972cd2
+  subjects:
+  - entities:
+    - role: player
+      name: Alex Pena
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '35'
+  uuid: d3cb3f1c-7210-400f-a13a-8c1c8be04793
+  subjects:
+  - entities:
+    - role: player
+      name: Jared Grindlinger
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '36'
+  uuid: 5ed2fc3e-450d-444c-9425-13723fc4ca85
+  subjects:
+  - entities:
+    - role: player
+      name: Jesse Maddox
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '37'
+  uuid: a50e903a-22f4-434f-83ce-f3f12de7dba9
+  subjects:
+  - entities:
+    - role: player
+      name: Anthony Frausto III
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '38'
+  uuid: d71bdd71-bc95-4c90-bf45-de33bf9cf44e
+  subjects:
+  - entities:
+    - role: player
+      name: Cooper Collins
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '39'
+  uuid: 217b7715-2aef-4990-baaf-2fab2a28050b
+  subjects:
+  - entities:
+    - role: player
+      name: Liam Peterson
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '40'
+  uuid: 6d020cce-7e48-46a0-902b-63ad1cba5b44
+  subjects:
+  - entities:
+    - role: player
+      name: Eli Jones
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '41'
+  uuid: 2b5785d6-41b6-44ee-b048-dbfec7000ce5
+  subjects:
+  - entities:
+    - role: player
+      name: Brett Renfrow
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '42'
+  uuid: 119da636-70bc-4ee0-bd9e-d7c095e288be
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson McAneeley
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '43'
+  uuid: c49fb8e8-ed10-4201-824f-65de4d2f9403
+  subjects:
+  - entities:
+    - role: player
+      name: Matthew Sharman
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '44'
+  uuid: a5d59807-1019-4982-886b-1eb5309b858b
+  subjects:
+  - entities:
+    - role: player
+      name: Orion Gonzalez
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '47'
+  uuid: d00d210f-1e5a-4ddc-b17a-23900559d194
+  subjects:
+  - entities:
+    - role: player
+      name: Landon Green
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '48'
+  uuid: 6bdde3e2-47c2-48db-82c4-fec251f1d816
+  subjects:
+  - entities:
+    - role: player
+      name: Grady Emerson
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '49'
+  uuid: 418df541-8d57-4dbe-a2e4-7f54afb020fa
+  subjects:
+  - entities:
+    - role: player
+      name: Carter Shouse
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '50'
+  uuid: d5d68f2d-d49a-4ad4-a637-f03a0cad3644
+  subjects:
+  - entities:
+    - role: player
+      name: Gio Rojas
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '51'
+  uuid: ef9e16e6-d35d-41ea-b9fa-8d726ccaf4d8
+  subjects:
+  - entities:
+    - role: player
+      name: Caden Borcherding
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '52'
+  uuid: ec60ce22-c7e0-46f8-9e7a-2ee8c051a9a3
+  subjects:
+  - entities:
+    - role: player
+      name: Bobby Villa
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '53'
+  uuid: 1471c451-df9a-48a0-b3a7-0964feac38dd
+  subjects:
+  - entities:
+    - role: player
+      name: AJ Gracia
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '54'
+  uuid: 8f1dd88f-2f58-44bb-ac29-e8ec2d3d651b
+  subjects:
+  - entities:
+    - role: player
+      name: Ryan Marohn
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '55'
+  uuid: e98b6a5a-5f96-4943-a998-1651e50a4c47
+  subjects:
+  - entities:
+    - role: player
+      name: Joshua Pierre
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '56'
+  uuid: eca17fff-2a31-4d2f-9d26-68826e8e0750
+  subjects:
+  - entities:
+    - role: player
+      name: Colton Petersmith
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '57'
+  uuid: e3c1d80f-e04d-4791-a0f5-8686f5138d24
+  subjects:
+  - entities:
+    - role: player
+      name: Miles Lockridge
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '58'
+  uuid: c173be4b-02ad-4dc4-ac8e-9da2066d4206
+  subjects:
+  - entities:
+    - role: player
+      name: Luke Armijo
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '59'
+  uuid: 9bbcf48c-d157-4908-b4ab-f2b7343e4f64
+  subjects:
+  - entities:
+    - role: player
+      name: Will Brick
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '60'
+  uuid: 8493b0f8-ac5d-4f59-a74f-f53028576209
+  subjects:
+  - entities:
+    - role: player
+      name: Cooper Gear
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '61'
+  uuid: a24432e8-84d2-4a6b-ad78-e43dc1bee9da
+  subjects:
+  - entities:
+    - role: player
+      name: Brody Schumaker
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '62'
+  uuid: 06b6b057-ff0e-40a7-934d-80820514dbd7
+  subjects:
+  - entities:
+    - role: player
+      name: Jeremiah Hall
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '63'
+  uuid: ecee1bc4-2ef7-4f62-86ae-96436c6ddeba
+  subjects:
+  - entities:
+    - role: player
+      name: Ethan Norby
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '65'
+  uuid: e0c3ef9b-81b6-4fed-8444-0bf2a9efa088
+  subjects:
+  - entities:
+    - role: player
+      name: William Miller
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '67'
+  uuid: 524a317d-8b1b-43e9-ba8f-9f08d5b9eb19
+  subjects:
+  - entities:
+    - role: player
+      name: Connor Balazic
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '68'
+  uuid: 7eace2b4-0fb1-4c37-b88f-ec568839ebf4
+  subjects:
+  - entities:
+    - role: player
+      name: Michael Ohman
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '69'
+  uuid: bac1e472-1ed3-4a34-a25f-cbbeaeed749e
+  subjects:
+  - entities:
+    - role: player
+      name: Dexter McCleon Jr.
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '70'
+  uuid: 476aacea-bcbf-462a-ad41-f8f44edc74c7
+  subjects:
+  - entities:
+    - role: player
+      name: Kingston George
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '72'
+  uuid: d479e4bc-7d00-44ad-b27e-d98b736e3742
+  subjects:
+  - entities:
+    - role: player
+      name: Dax Whitney
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '73'
+  uuid: 6f237b36-8dd3-45e7-8bc0-e399f4f75e41
+  subjects:
+  - entities:
+    - role: player
+      name: Gavin Chakar
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '75'
+  uuid: cc824ff2-878e-4b84-b974-fee130e27ba6
+  subjects:
+  - entities:
+    - role: player
+      name: Josh Hartle
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '76'
+  uuid: be17d719-cb35-4fc4-8d7a-6e1180cd6c2d
+  subjects:
+  - entities:
+    - role: player
+      name: Marcus Cantu
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '77'
+  uuid: 63b925a0-cd9e-4290-9a20-29c4d589b320
+  subjects:
+  - entities:
+    - role: player
+      name: DJ Lee II
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '78'
+  uuid: 59913782-af13-418e-838e-1ef9d3e63856
+  subjects:
+  - entities:
+    - role: player
+      name: CJ Sampson
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '79'
+  uuid: 2f859a99-9048-4e4b-a6ed-d5ff557fca7e
+  subjects:
+  - entities:
+    - role: player
+      name: Lucca Bacigalupi
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '80'
+  uuid: 1dd86f1a-8746-48a9-aec9-00fa3748478d
+  subjects:
+  - entities:
+    - role: player
+      name: Ryder Helfrick
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '81'
+  uuid: 4d6e77c3-34d0-4351-a11d-c7b71ffc42bb
+  subjects:
+  - entities:
+    - role: player
+      name: William Haggerty
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '82'
+  uuid: 762a2ed6-a41b-4710-b085-4a02139f1e42
+  subjects:
+  - entities:
+    - role: player
+      name: Ethan Kleinschmit
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '83'
+  uuid: c73c5236-bd82-4b6d-b463-11ce7e7c84cc
+  subjects:
+  - entities:
+    - role: player
+      name: Ethan Gustus
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '84'
+  uuid: df0dc763-f947-4ce2-a96c-64984f7a3b07
+  subjects:
+  - entities:
+    - role: player
+      name: Jack Byers
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '85'
+  uuid: 8c2df5fc-882f-41ec-91d3-0a53eef83d97
+  subjects:
+  - entities:
+    - role: player
+      name: Xavier Rodriguez
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '87'
+  uuid: 56cc3b32-df21-454e-9a2b-cc98f87a6876
+  subjects:
+  - entities:
+    - role: player
+      name: Connor Wells
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '88'
+  uuid: c9a56093-c2e3-4480-8c20-5ca1546c1f19
+  subjects:
+  - entities:
+    - role: player
+      name: Carlo Rivero
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '89'
+  uuid: 3aedaaa7-209a-4b69-a4fd-8b5a4d41dcde
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan Bingham
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '90'
+  uuid: 93b1c234-fbba-4b75-95eb-06d22bd83911
+  subjects:
+  - entities:
+    - role: player
+      name: Grady Nelson
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '91'
+  uuid: d89ebfba-563c-4903-8157-8a749495b21c
+  subjects:
+  - entities:
+    - role: player
+      name: Levi Leathers
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '92'
+  uuid: 51ed0871-ab67-4e0a-8b11-523da0cf44b5
+  subjects:
+  - entities:
+    - role: player
+      name: Banks Addison
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '93'
+  uuid: adc3e489-58d4-4745-b348-fd4a64710916
+  subjects:
+  - entities:
+    - role: player
+      name: Anderson Kaufmann
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '95'
+  uuid: 84dba2df-9118-42f2-b17d-23d9dc4acb52
+  subjects:
+  - entities:
+    - role: player
+      name: Jaden Freeze
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '96'
+  uuid: 4ab89ef4-9c2d-45d0-b121-f037472509ff
+  subjects:
+  - entities:
+    - role: player
+      name: Anthony Murphy
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '97'
+  uuid: 53a20c03-e184-40fb-8210-c187a816a440
+  subjects:
+  - entities:
+    - role: player
+      name: Vahn Lackey
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '99'
+  uuid: 20673235-5450-4825-8539-7ff6ad1723a2
+  subjects:
+  - entities:
+    - role: player
+      name: Valentin Ceballos
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '100'
+  uuid: 5dc7c367-1353-4e1f-9ac8-8f9bc7000212
+  subjects:
+  - entities:
+    - role: player
+      name: Oliver Van Tiem
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '101'
+  uuid: 952e3fc3-08a6-4e8a-8166-0ae8031cdeee
+  subjects:
+  - entities:
+    - role: player
+      name: Colton Floyd
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '102'
+  uuid: 175b5cd6-4a8c-425a-9e63-937d39b84e58
+  subjects:
+  - entities:
+    - role: player
+      name: Sean Simon
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '103'
+  uuid: cf837c68-d4de-44ea-b9eb-12b09b1a45cc
+  subjects:
+  - entities:
+    - role: player
+      name: Griffin McKain
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '104'
+  uuid: 1ae837b9-fbd9-4418-a3f1-bd749f28b535
+  subjects:
+  - entities:
+    - role: player
+      name: Brenner Brown
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '105'
+  uuid: b5d7721d-67ab-43c4-915a-09ec3325fd9e
+  subjects:
+  - entities:
+    - role: player
+      name: Seddrick Henderson III
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '106'
+  uuid: 56e0e385-5139-402c-85fb-c8923881e44d
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Dudan
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '107'
+  uuid: 32580fcf-f270-47af-bb94-4c2a68f45e97
+  subjects:
+  - entities:
+    - role: player
+      name: Louis Lappe
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '108'
+  uuid: 4b7d2004-81d8-4880-8f40-1f00088ca5e0
+  subjects:
+  - entities:
+    - role: player
+      name: Levi Wolf
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '109'
+  uuid: 6e38d277-2f9a-445d-bee8-ae35ccd09bbe
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Seamon
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '110'
+  uuid: d8db67de-e8a4-4cb8-8fd3-d9f5c9a23d8b
+  subjects:
+  - entities:
+    - role: player
+      name: Tyler Early
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '111'
+  uuid: 85bb19fd-e33e-414e-90f1-a5b73b061ef8
+  subjects:
+  - entities:
+    - role: player
+      name: Jason Marll Jr.
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '112'
+  uuid: b694d0aa-d6cc-424e-a19d-2087c18fc436
+  subjects:
+  - entities:
+    - role: player
+      name: Matthew Werner
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '113'
+  uuid: 03e0597b-0f44-415a-9778-e3eea07bf34a
+  subjects:
+  - entities:
+    - role: player
+      name: Brennan McLaughlin
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '114'
+  uuid: 4d6fa5f1-9c19-436f-9bcc-a612ae0d4a63
+  subjects:
+  - entities:
+    - role: player
+      name: Graham Houston
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '115'
+  uuid: b7ac4a2c-42d5-49f2-ac28-6a4ddf145899
+  subjects:
+  - entities:
+    - role: player
+      name: James Clark
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '116'
+  uuid: a8f0baee-007a-4bfe-8022-ec6a88d53c64
+  subjects:
+  - entities:
+    - role: player
+      name: Cooper Hutton
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '117'
+  uuid: b8234b2c-5c0e-4f62-806f-7015ebe125a4
+  subjects:
+  - entities:
+    - role: player
+      name: Micah Delos Reyes
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '118'
+  uuid: 2c40e652-e75d-4ebe-af33-d0197012086d
+  subjects:
+  - entities:
+    - role: player
+      name: Charlie Sarsfield
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '119'
+  uuid: 74d4486f-1f04-4a22-ae4e-3f6e63090965
+  subjects:
+  - entities:
+    - role: player
+      name: Nathan Malone
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '120'
+  uuid: 8919d695-05d6-4815-a556-85f57fb9b8f4
+  subjects:
+  - entities:
+    - role: player
+      name: Trent O'Malley
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '121'
+  uuid: 5e6932b8-cb5e-4379-ba6b-e1ef7fc5e3e1
+  subjects:
+  - entities:
+    - role: player
+      name: Jaden Jackson
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '122'
+  uuid: 2861aca1-307d-4416-8454-c637aafd0206
+  subjects:
+  - entities:
+    - role: player
+      name: Ka'alekahi Kuhaulua
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '123'
+  uuid: ab43be82-a99a-4eca-a799-d2aca63b791e
+  subjects:
+  - entities:
+    - role: player
+      name: Cade Allen
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '124'
+  uuid: 18fb8af3-3c1b-49a3-9de4-11f72020ec88
+  subjects:
+  - entities:
+    - role: player
+      name: Mason Devine
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '125'
+  uuid: f17e3523-9ba0-439c-a536-9f2c8cf92b4b
+  subjects:
+  - entities:
+    - role: player
+      name: Jose Partida
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '126'
+  uuid: cd7194bf-989f-47f9-8f49-788e040ec187
+  subjects:
+  - entities:
+    - role: player
+      name: Colin Anderson
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '127'
+  uuid: 40d119c6-1432-4ad7-860b-34b601100d7d
+  subjects:
+  - entities:
+    - role: player
+      name: Enzi-Yaw Otieku
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '128'
+  uuid: 6462aa13-b83d-4646-bde7-9961b5eb747d
+  subjects:
+  - entities:
+    - role: player
+      name: Lucas Diaz
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '129'
+  uuid: e9496471-119a-4e7e-a8da-d599e30ab0b8
+  subjects:
+  - entities:
+    - role: player
+      name: Jorvorskie Lane Jr.
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '130'
+  uuid: 30510e85-767f-441c-8b7d-d8680aa26182
+  subjects:
+  - entities:
+    - role: player
+      name: Jake Mercado
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '131'
+  uuid: 645baffd-25d7-4cc1-a466-bcea5bf62956
+  subjects:
+  - entities:
+    - role: player
+      name: Macgraw VanWormer
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '132'
+  uuid: 2d0b13e3-a422-4ed6-86ea-322c727b8b4d
+  subjects:
+  - entities:
+    - role: player
+      name: Chase Fuller
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '133'
+  uuid: 2c7a132d-c949-49e8-b21e-5dc4e5fabf10
+  subjects:
+  - entities:
+    - role: player
+      name: Cullen Scott
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '134'
+  uuid: da336543-eb04-45d5-83e8-7086ce7465b1
+  subjects:
+  - entities:
+    - role: player
+      name: Connor Salerno
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '135'
+  uuid: f257a536-0958-488f-8ba4-40d5758e9778
+  subjects:
+  - entities:
+    - role: player
+      name: Nathan Handley-White
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '136'
+  uuid: 20309751-5be1-49bb-8a99-a55f84354f67
+  subjects:
+  - entities:
+    - role: player
+      name: Aiden Ruiz
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '137'
+  uuid: ae2128f7-43fe-4135-99bb-beb4575fdb3f
+  subjects:
+  - entities:
+    - role: player
+      name: Andrew Jimenez
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '138'
+  uuid: 31d7a845-b8ed-49e4-8fc7-f1da4a0ad179
+  subjects:
+  - entities:
+    - role: player
+      name: Jared Grindlinger
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '139'
+  uuid: 65efa01c-7347-4b49-a324-2eb6239d195b
+  subjects:
+  - entities:
+    - role: player
+      name: Frank Thomas III
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '140'
+  uuid: a2e72ac0-6006-47ca-a0c3-0a46b6222056
+  subjects:
+  - entities:
+    - role: player
+      name: Brennan New
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '141'
+  uuid: 97420475-064d-4ecd-83a4-ae3a8142c663
+  subjects:
+  - entities:
+    - role: player
+      name: Cole Gibler
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '142'
+  uuid: 6506420b-5c56-40f7-8280-11c50d322e38
+  subjects:
+  - entities:
+    - role: player
+      name: Samir Mohammed
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '143'
+  uuid: 45a38e10-7c28-4759-ace9-e0d5449972ef
+  subjects:
+  - entities:
+    - role: player
+      name: Wyatt Peabody
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '144'
+  uuid: 92145a19-bb19-4268-898f-a674625394f4
+  subjects:
+  - entities:
+    - role: player
+      name: Ryan Lynch
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '145'
+  uuid: dfc3b3e7-831c-49fd-9c30-6fcf98c805ba
+  subjects:
+  - entities:
+    - role: player
+      name: Chris Rembert
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '146'
+  uuid: ddc9c6be-bc0b-4841-9476-648a29c79cfa
+  subjects:
+  - entities:
+    - role: player
+      name: Greyson Bell
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '147'
+  uuid: 865c48dc-2157-486b-b93c-e9bb362be2f0
+  subjects:
+  - entities:
+    - role: player
+      name: Brady Buenik
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '148'
+  uuid: '039cff9f-f588-4457-a0d8-3510f73f280a'
+  subjects:
+  - entities:
+    - role: player
+      name: Carson Schoener
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '149'
+  uuid: 50cb7592-2171-4bd2-a964-047e1664f371
+  subjects:
+  - entities:
+    - role: player
+      name: Ricky Ojeda
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '150'
+  uuid: 4df3998c-6900-486c-88e6-94f93baea7eb
+  subjects:
+  - entities:
+    - role: player
+      name: Christian Choe
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '151'
+  uuid: 64d375b7-bbd2-4615-9664-93b2d95c537e
+  subjects:
+  - entities:
+    - role: player
+      name: Keegan Burke
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '152'
+  uuid: a2f8b876-3ef5-4492-9fcf-c8aba903d8fb
+  subjects:
+  - entities:
+    - role: player
+      name: Jayden Portes
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '153'
+  uuid: 559e08e8-e7b2-46d0-88eb-cf06c4bc5ade
+  subjects:
+  - entities:
+    - role: player
+      name: Jason DeCaro
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '154'
+  uuid: 7252f24a-78a6-4cf0-9a8d-fa9e6bc7e72f
+  subjects:
+  - entities:
+    - role: player
+      name: Hudson Oliver
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '155'
+  uuid: cce29aa6-470b-4baf-97a5-4e7079ce212e
+  subjects:
+  - entities:
+    - role: player
+      name: Bowen Landry
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '156'
+  uuid: 652ec365-6463-486d-ad2d-0687795cb188
+  subjects:
+  - entities:
+    - role: player
+      name: Kaden Waechter
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '157'
+  uuid: f25ea11d-fe81-489b-bf7f-6aee1225b983
+  subjects:
+  - entities:
+    - role: player
+      name: Andres Jimenez
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '158'
+  uuid: 9764a6c7-0d3e-4a2f-83b3-edce3cec4550
+  subjects:
+  - entities:
+    - role: player
+      name: Boston Targac
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '159'
+  uuid: '08019d5c-1cd3-490a-8c1c-48ec782f877a'
+  subjects:
+  - entities:
+    - role: player
+      name: Leo Nockley
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '161'
+  uuid: 07b5b76c-07e7-49c5-872e-5b52501058b8
+  subjects:
+  - entities:
+    - role: player
+      name: Nolyn Nickels
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '162'
+  uuid: 8bf975af-4473-4640-88b4-49a2f5dd982c
+  subjects:
+  - entities:
+    - role: player
+      name: Fielder Grebert
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '163'
+  uuid: fc6786a3-01ed-4f3f-82d5-c600c09248c6
+  subjects:
+  - entities:
+    - role: player
+      name: Jack Woda
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '165'
+  uuid: b57b6738-37d6-4f01-b512-fdffeeaddac3
+  subjects:
+  - entities:
+    - role: player
+      name: Nateo Victorio
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '166'
+  uuid: f75f2082-d2e3-4256-9062-81dbfc74c5dc
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Lombard
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '167'
+  uuid: 569a740a-877a-4b0f-babb-073009e01427
+  subjects:
+  - entities:
+    - role: player
+      name: Kade Valdivia
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '168'
+  uuid: 399a52e4-8a5f-4544-82e3-b26697a53873
+  subjects:
+  - entities:
+    - role: player
+      name: Emmric Alapa
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '169'
+  uuid: b9038f2d-cdd0-4357-bcad-fc3e9198ff90
+  subjects:
+  - entities:
+    - role: player
+      name: Coleman Borthwick
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '170'
+  uuid: 33390c8b-22c5-4d80-a244-08a3cb97ce35
+  subjects:
+  - entities:
+    - role: player
+      name: Mason Miller
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '171'
+  uuid: c10e21e3-bb99-42bb-950d-56b3ffaa0d4e
+  subjects:
+  - entities:
+    - role: player
+      name: Noah Burt
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '172'
+  uuid: 3a8c183d-767b-40e6-8eb9-b2e4f89c0abc
+  subjects:
+  - entities:
+    - role: player
+      name: Andrew Costello
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '173'
+  uuid: f95970fc-0d5a-4f12-884b-78a2399014f3
+  subjects:
+  - entities:
+    - role: player
+      name: Xander Tiller
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '174'
+  uuid: 93f4dcf4-48cd-41be-a45e-20629cf0b86e
+  subjects:
+  - entities:
+    - role: player
+      name: Ty Glaus
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '175'
+  uuid: 3d990495-b617-4be2-b1e1-d054708cda49
+  subjects:
+  - entities:
+    - role: player
+      name: Bryan Ravelo
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '176'
+  uuid: 5ac68918-465c-4ae4-8789-e460a883d47b
+  subjects:
+  - entities:
+    - role: player
+      name: Chase Gockenbach
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '177'
+  uuid: e661ef1a-7d1a-449a-8488-b6936ba01f14
+  subjects:
+  - entities:
+    - role: player
+      name: Roch Cholowsky
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '178'
+  uuid: 217e8748-9d22-4e33-93d2-6fddcc25103c
+  subjects:
+  - entities:
+    - role: player
+      name: Amani Tuiasosopo
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '179'
+  uuid: 87f8b91b-4679-4328-b1d9-b7334bb8555e
+  subjects:
+  - entities:
+    - role: player
+      name: Yariel Diaz
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '180'
+  uuid: 5cab60d4-cf43-4918-9311-3c46d9b0798b
+  subjects:
+  - entities:
+    - role: player
+      name: Ricky Lopez
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '181'
+  uuid: 6c596a49-97ae-4d1e-a88e-2e5f5e9a15fd
+  subjects:
+  - entities:
+    - role: player
+      name: Keelan Zumwalt
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '182'
+  uuid: 578b0159-e260-423d-9539-a403fc03f4d5
+  subjects:
+  - entities:
+    - role: player
+      name: Camden Boehm
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '183'
+  uuid: aa97dffc-b7bc-4a33-ba5a-7ec762bbb0e5
+  subjects:
+  - entities:
+    - role: player
+      name: Matthew Fernandez
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '184'
+  uuid: 4fc0c4f9-6d6b-4d26-8c9a-a5ddd3a99e21
+  subjects:
+  - entities:
+    - role: player
+      name: Luke Esquivel
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '185'
+  uuid: b357fb76-6fcb-4caf-abf1-7d8762abd06f
+  subjects:
+  - entities:
+    - role: player
+      name: Gavin McMillan
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '187'
+  uuid: 42dd7387-81f8-4415-ae74-6701deba8c79
+  subjects:
+  - entities:
+    - role: player
+      name: Zaylon Johnson
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '188'
+  uuid: 8b516468-a7f1-4bc1-87e5-c3c37aeccd5a
+  subjects:
+  - entities:
+    - role: player
+      name: Lucas Moore
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '189'
+  uuid: da37f164-9caa-4e77-bb99-f1b556f83b88
+  subjects:
+  - entities:
+    - role: player
+      name: Cooper Gornet
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '190'
+  uuid: 88ced3d2-9360-4725-a0e7-a323d4b82e53
+  subjects:
+  - entities:
+    - role: player
+      name: Landon King
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '191'
+  uuid: f7088949-ae36-4b14-9542-27756d1e0c8f
+  subjects:
+  - entities:
+    - role: player
+      name: Ace Reese
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '192'
+  uuid: e6114504-70cb-4c30-aeea-72bf3461de22
+  subjects:
+  - entities:
+    - role: player
+      name: Paris Head
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '193'
+  uuid: b4192821-6bee-44f4-a548-da87e9fd25c7
+  subjects:
+  - entities:
+    - role: player
+      name: Noah Vrzal
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '194'
+  uuid: 7fc78614-e271-424d-ba2e-f4d1d600531a
+  subjects:
+  - entities:
+    - role: player
+      name: Jace Duckett
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '196'
+  uuid: 5d49fd13-67e6-4623-8839-dcb2e889ba47
+  subjects:
+  - entities:
+    - role: player
+      name: Calvin Madenspacher
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '197'
+  uuid: fd6e2fdb-296b-4c50-aef1-f991008fe437
+  subjects:
+  - entities:
+    - role: player
+      name: Devin Urena
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '198'
+  uuid: aeaba374-dcca-4666-9bc0-39f73a25662b
+  subjects:
+  - entities:
+    - role: player
+      name: Trey Rangel
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '199'
+  uuid: 8fcfeeba-7ec5-4467-85cb-d4bffffa195f
+  subjects:
+  - entities:
+    - role: player
+      name: Ethan Palacios
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '200'
+  uuid: 29fdaf04-d14d-4eaa-a81b-0c929839802d
+  subjects:
+  - entities:
+    - role: player
+      name: Landon McDonald
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 

--- a/data/baseball/2026-panini-prizm-stars-stripes/checklists/jumbo-materials-jersey-number.yaml
+++ b/data/baseball/2026-panini-prizm-stars-stripes/checklists/jumbo-materials-jersey-number.yaml
@@ -1,0 +1,1860 @@
+- number: '1'
+  uuid: bd3aaf78-56a1-41fc-8dd5-11a1b41bbd45
+  subjects:
+  - entities:
+    - role: player
+      name: Brogan Witcher
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '2'
+  uuid: fbfaa61d-570f-43d3-b9f4-f0667ffbdf89
+  subjects:
+  - entities:
+    - role: player
+      name: Junior Lopez
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '3'
+  uuid: '028156e0-9941-4a0a-8c24-b7f22c1eff31'
+  subjects:
+  - entities:
+    - role: player
+      name: Logan Bristol
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '5'
+  uuid: fa089a0b-be33-4026-a5ce-55b1987e7947
+  subjects:
+  - entities:
+    - role: player
+      name: Jack Mattingly
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '6'
+  uuid: ac9068fb-cd27-4ed2-8ffb-7923c06cc85b
+  subjects:
+  - entities:
+    - role: player
+      name: Drew Burress
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '7'
+  uuid: e623ea99-f82c-4ea4-99e5-73ddb906f7f9
+  subjects:
+  - entities:
+    - role: player
+      name: Brody Crane
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '8'
+  uuid: 024dadd7-0676-4466-becb-57fe68ccb34a
+  subjects:
+  - entities:
+    - role: player
+      name: Carson Bolemon
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '9'
+  uuid: 4e1c8138-560c-42f7-9123-b29b5fc181d1
+  subjects:
+  - entities:
+    - role: player
+      name: Eric Becker
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '10'
+  uuid: f296e698-4be3-4e88-9c2d-52c81e4211a4
+  subjects:
+  - entities:
+    - role: player
+      name: Tyler Bell
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '11'
+  uuid: 9d346602-1d8b-46c7-bea5-d22f9efde30e
+  subjects:
+  - entities:
+    - role: player
+      name: Cole Koeninger
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '12'
+  uuid: bab02acc-358f-4c1e-ae6b-36e27048be74
+  subjects:
+  - entities:
+    - role: player
+      name: Yohandy Morales
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '13'
+  uuid: d309fc7f-ce8c-4305-acef-e80268b0da28
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Beatty
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '14'
+  uuid: 880ec213-ed79-4048-9457-9c0db3dc0706
+  subjects:
+  - entities:
+    - role: player
+      name: Blake Morningstar
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '15'
+  uuid: 45231d19-f6a4-4a01-8299-fdc5f934f3b5
+  subjects:
+  - entities:
+    - role: player
+      name: Jordan Ayala
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '16'
+  uuid: 81ac5dbe-7f8d-4a2e-b701-ead90f4e476c
+  subjects:
+  - entities:
+    - role: player
+      name: Derek Vazquez
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '17'
+  uuid: 33d82d3a-9ed9-4c89-b3c8-ab3031bacec2
+  subjects:
+  - entities:
+    - role: player
+      name: Grant Sperandio
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '18'
+  uuid: 0c92d38a-f722-494b-9646-28418f3f9cb1
+  subjects:
+  - entities:
+    - role: player
+      name: Cooper Jones
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '19'
+  uuid: b76cd3d5-1def-49b9-a781-bda39f5ae019
+  subjects:
+  - entities:
+    - role: player
+      name: Tristin Gaines
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '20'
+  uuid: 424c902f-f256-4cbf-815a-e58b8facda62
+  subjects:
+  - entities:
+    - role: player
+      name: Mattias DiMaggio
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '21'
+  uuid: 68d07a56-e528-41a6-9d44-c238938ad388
+  subjects:
+  - entities:
+    - role: player
+      name: Clayton Ratliff
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '22'
+  uuid: c6762609-cda2-43cf-b66f-50eb54be937f
+  subjects:
+  - entities:
+    - role: player
+      name: Mateo Mier
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '23'
+  uuid: 48600324-c4c1-4220-867d-63c3f5dd2c32
+  subjects:
+  - entities:
+    - role: player
+      name: Gabe Gaeckle
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '24'
+  uuid: 76b2c08a-822e-418d-a84e-226e13300b53
+  subjects:
+  - entities:
+    - role: player
+      name: Ryan McPherson
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '25'
+  uuid: 8cba716e-ec21-428e-8b72-8e416f3915a1
+  subjects:
+  - entities:
+    - role: player
+      name: Noah Jarolimek
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '26'
+  uuid: 7fe6d307-fcb1-4b68-9003-fbe7d5597281
+  subjects:
+  - entities:
+    - role: player
+      name: Kekoa Delatori
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '27'
+  uuid: 4b2f43b3-1022-4be0-a5f8-ccbc956599d4
+  subjects:
+  - entities:
+    - role: player
+      name: Carter Hadnot
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '28'
+  uuid: 4c7fc841-2faa-4cef-a704-a27f346ab23a
+  subjects:
+  - entities:
+    - role: player
+      name: Colt Carter
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '29'
+  uuid: 7b1fef90-7d9c-4285-a61f-90e0844e0156
+  subjects:
+  - entities:
+    - role: player
+      name: Bryant Ju
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '30'
+  uuid: eb750155-51a6-4de6-8f96-6919624ae475
+  subjects:
+  - entities:
+    - role: player
+      name: CJ Dornfeld
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '31'
+  uuid: 30fbb583-8bfd-48cd-808e-75b81e9bc19f
+  subjects:
+  - entities:
+    - role: player
+      name: Brandon Sweeney
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '32'
+  uuid: ed1db896-b51c-4b97-b4bf-f3a390daa783
+  subjects:
+  - entities:
+    - role: player
+      name: Moises Gudino
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '33'
+  uuid: e093616c-fd78-40d2-9f4f-bda546cf4853
+  subjects:
+  - entities:
+    - role: player
+      name: Zion Rose
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '34'
+  uuid: bfbcb3e3-f0f9-4b87-9dca-d6c3aa774221
+  subjects:
+  - entities:
+    - role: player
+      name: Alex Pena
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '35'
+  uuid: df80aa10-bfb2-4e0a-b946-f8cb8be05fe9
+  subjects:
+  - entities:
+    - role: player
+      name: Jared Grindlinger
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '36'
+  uuid: 13f8b4b5-5c1d-4de2-b8f1-9e799364e03c
+  subjects:
+  - entities:
+    - role: player
+      name: Jesse Maddox
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '37'
+  uuid: f3f33ebd-3edc-49c0-acbd-6bc8237c39e9
+  subjects:
+  - entities:
+    - role: player
+      name: Anthony Frausto III
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '38'
+  uuid: 381c443f-327f-4d97-b3cc-6e0adb12503f
+  subjects:
+  - entities:
+    - role: player
+      name: Cooper Collins
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '39'
+  uuid: cc1fd9f3-2915-49a2-b5e1-cceb188ac764
+  subjects:
+  - entities:
+    - role: player
+      name: Liam Peterson
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '40'
+  uuid: b4a86233-a5aa-4e32-a9f9-df8a8dc4efd0
+  subjects:
+  - entities:
+    - role: player
+      name: Eli Jones
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '41'
+  uuid: '08825a76-1188-415f-b56a-8f31fd7094cf'
+  subjects:
+  - entities:
+    - role: player
+      name: Brett Renfrow
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '42'
+  uuid: e0a69bb4-f665-4739-b571-32bc8bf3c226
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson McAneeley
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '43'
+  uuid: a4896a00-b798-474d-b92e-fd1b7d925048
+  subjects:
+  - entities:
+    - role: player
+      name: Matthew Sharman
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '44'
+  uuid: 1a3945cc-b6e9-43ff-8b7b-df3d4ac56cc6
+  subjects:
+  - entities:
+    - role: player
+      name: Orion Gonzalez
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '47'
+  uuid: bac61f94-d44a-4f01-900c-3b2cf2e21cc0
+  subjects:
+  - entities:
+    - role: player
+      name: Landon Green
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '48'
+  uuid: a0d5565d-0f3b-4554-967a-f95f8872a0f7
+  subjects:
+  - entities:
+    - role: player
+      name: Grady Emerson
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '49'
+  uuid: 53dae247-eea8-46d1-8eab-0773c6c58120
+  subjects:
+  - entities:
+    - role: player
+      name: Carter Shouse
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '50'
+  uuid: 610247d3-9c19-427c-8aa0-1da6ae711080
+  subjects:
+  - entities:
+    - role: player
+      name: Gio Rojas
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '51'
+  uuid: 7c6c28cf-85a7-4470-b480-c543b4f0e80d
+  subjects:
+  - entities:
+    - role: player
+      name: Caden Borcherding
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '52'
+  uuid: 10e13664-6fca-4bbc-b125-0414a4105be0
+  subjects:
+  - entities:
+    - role: player
+      name: Bobby Villa
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '53'
+  uuid: 309ca735-8eef-4c1c-8594-1f0ebd9dec8d
+  subjects:
+  - entities:
+    - role: player
+      name: AJ Gracia
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '54'
+  uuid: f106fc1f-1629-4bf6-a2d2-7b87aed11833
+  subjects:
+  - entities:
+    - role: player
+      name: Ryan Marohn
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '55'
+  uuid: 87134c33-d7fb-4154-a72b-4496cdc272ba
+  subjects:
+  - entities:
+    - role: player
+      name: Joshua Pierre
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '56'
+  uuid: 46f8b07b-682e-4e83-ada1-8e96b1d3ea43
+  subjects:
+  - entities:
+    - role: player
+      name: Colton Petersmith
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '57'
+  uuid: a3ce9361-7a04-4491-a187-86172b99fff6
+  subjects:
+  - entities:
+    - role: player
+      name: Miles Lockridge
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '58'
+  uuid: 40fcbd11-fd5f-4b6b-90e2-46a8b29019c6
+  subjects:
+  - entities:
+    - role: player
+      name: Luke Armijo
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '59'
+  uuid: c306128b-6d5c-4784-b241-8e7945638fde
+  subjects:
+  - entities:
+    - role: player
+      name: Will Brick
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '60'
+  uuid: ef510e03-dcd8-49fb-a137-ffc314b1889e
+  subjects:
+  - entities:
+    - role: player
+      name: Cooper Gear
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '61'
+  uuid: 8f54302f-d58b-41ee-80fb-fd63ac193a68
+  subjects:
+  - entities:
+    - role: player
+      name: Brody Schumaker
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '62'
+  uuid: 21fda702-5ce9-4956-adb0-2cda8a9e0d1c
+  subjects:
+  - entities:
+    - role: player
+      name: Jeremiah Hall
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '63'
+  uuid: 6df7d65d-a678-4011-a991-690f771faac9
+  subjects:
+  - entities:
+    - role: player
+      name: Ethan Norby
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '65'
+  uuid: 20f5f633-3e1b-4894-8311-84fb8bf8ebe9
+  subjects:
+  - entities:
+    - role: player
+      name: William Miller
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '67'
+  uuid: 7187cd59-aba7-437b-baa5-2d703c677503
+  subjects:
+  - entities:
+    - role: player
+      name: Connor Balazic
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '68'
+  uuid: 87df6c7e-dda1-44ef-a210-f41d3f740d06
+  subjects:
+  - entities:
+    - role: player
+      name: Michael Ohman
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '69'
+  uuid: affebd63-b91c-4254-a2c8-c8b47cee4d81
+  subjects:
+  - entities:
+    - role: player
+      name: Dexter McCleon Jr.
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '70'
+  uuid: b7f7d9c0-13f0-4020-ba6e-384a41c2449d
+  subjects:
+  - entities:
+    - role: player
+      name: Kingston George
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '72'
+  uuid: a978af06-c85b-412c-ada9-8d24faf93248
+  subjects:
+  - entities:
+    - role: player
+      name: Dax Whitney
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '73'
+  uuid: ec453bd2-8763-4de5-a19a-8f5b5b1af427
+  subjects:
+  - entities:
+    - role: player
+      name: Gavin Chakar
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '76'
+  uuid: 13e4eba4-2f67-46f4-9c53-fb28cba548e7
+  subjects:
+  - entities:
+    - role: player
+      name: Marcus Cantu
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '77'
+  uuid: c9cdc7e0-0009-446b-91c9-239ecbc7e98d
+  subjects:
+  - entities:
+    - role: player
+      name: DJ Lee II
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '78'
+  uuid: d2514446-0546-4ae9-8d97-df7d815fd6de
+  subjects:
+  - entities:
+    - role: player
+      name: CJ Sampson
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '79'
+  uuid: 8ed0b869-e2f2-4c5d-921f-a8e66fc728eb
+  subjects:
+  - entities:
+    - role: player
+      name: Lucca Bacigalupi
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '80'
+  uuid: 763dc622-a998-4b67-b398-e62888ae7227
+  subjects:
+  - entities:
+    - role: player
+      name: Ryder Helfrick
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '81'
+  uuid: 76c76c46-c887-4497-b254-898e47b09a8b
+  subjects:
+  - entities:
+    - role: player
+      name: William Haggerty
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '82'
+  uuid: ccad87b4-6ef0-4328-b7bb-7b31c57a243d
+  subjects:
+  - entities:
+    - role: player
+      name: Ethan Kleinschmit
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '83'
+  uuid: 8f22df88-f868-47d5-b063-49e4b2877824
+  subjects:
+  - entities:
+    - role: player
+      name: Ethan Gustus
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '84'
+  uuid: 59cc68d3-e539-4af2-8a31-923eb6f6822c
+  subjects:
+  - entities:
+    - role: player
+      name: Jack Byers
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '85'
+  uuid: e68d70dc-4cd4-4e38-9c44-9f3aac1c5bd6
+  subjects:
+  - entities:
+    - role: player
+      name: Xavier Rodriguez
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '87'
+  uuid: 8c69b8b1-aa1f-4d09-b092-c462c4ba9b30
+  subjects:
+  - entities:
+    - role: player
+      name: Connor Wells
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '88'
+  uuid: 734c41bd-2a05-4d79-84fa-38d4ce73f4af
+  subjects:
+  - entities:
+    - role: player
+      name: Carlo Rivero
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '89'
+  uuid: 6e15e2a9-1550-45c7-9b57-00fe4efec8a0
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan Bingham
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '90'
+  uuid: 0eef6f98-25a5-4245-b0cb-10150d95ae69
+  subjects:
+  - entities:
+    - role: player
+      name: Grady Nelson
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '91'
+  uuid: c82ecb80-3155-46e1-af17-b1dc8a6565c7
+  subjects:
+  - entities:
+    - role: player
+      name: Levi Leathers
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '92'
+  uuid: 8a6c72d8-3e78-41f2-be40-8caa788eab70
+  subjects:
+  - entities:
+    - role: player
+      name: Banks Addison
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '93'
+  uuid: 904cfc5a-1ab2-4abc-81d4-faa2e64929a7
+  subjects:
+  - entities:
+    - role: player
+      name: Anderson Kaufmann
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '95'
+  uuid: b22b3e76-e51a-4ee0-93e4-ded4ddff1066
+  subjects:
+  - entities:
+    - role: player
+      name: Jaden Freeze
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '96'
+  uuid: fc6716ce-4406-4bd9-81b8-800954497529
+  subjects:
+  - entities:
+    - role: player
+      name: Anthony Murphy
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '97'
+  uuid: 41054031-9c6d-49f3-afbe-69bb92bbe123
+  subjects:
+  - entities:
+    - role: player
+      name: Vahn Lackey
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '99'
+  uuid: 32124552-3f7c-48a4-b995-fb4c12351bab
+  subjects:
+  - entities:
+    - role: player
+      name: Valentin Ceballos
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '100'
+  uuid: 8a8f27b4-38ce-46ad-8202-23e794c7ac4a
+  subjects:
+  - entities:
+    - role: player
+      name: Oliver Van Tiem
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '101'
+  uuid: eb7f130f-c280-48d5-abbf-21f682c97bc9
+  subjects:
+  - entities:
+    - role: player
+      name: Colton Floyd
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '102'
+  uuid: 1289048e-ec86-49d1-a6c8-4284c5e07970
+  subjects:
+  - entities:
+    - role: player
+      name: Sean Simon
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '103'
+  uuid: '039ec654-6b2f-453d-a56d-dd66b9b8481a'
+  subjects:
+  - entities:
+    - role: player
+      name: Griffin McKain
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '104'
+  uuid: ecf85b1d-fcf3-48fa-b3e3-540f83a237a1
+  subjects:
+  - entities:
+    - role: player
+      name: Brenner Brown
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '105'
+  uuid: 2428539f-4ea7-4cd4-842c-f5e99ea25776
+  subjects:
+  - entities:
+    - role: player
+      name: Seddrick Henderson III
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '106'
+  uuid: bda2b6e4-8735-4ea5-9ab9-a98798bf687a
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Dudan
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '107'
+  uuid: 23d69500-cfa6-4d0d-bcb1-2424c3f5ebcb
+  subjects:
+  - entities:
+    - role: player
+      name: Louis Lappe
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '108'
+  uuid: 3a6f22b6-7188-4062-8b5e-4df1c0eec2a8
+  subjects:
+  - entities:
+    - role: player
+      name: Levi Wolf
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '109'
+  uuid: 59213f02-da13-4d55-82f7-9e3ea47e20ef
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Seamon
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '110'
+  uuid: 47c462ad-4986-4086-988a-539206ce3f6c
+  subjects:
+  - entities:
+    - role: player
+      name: Tyler Early
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '111'
+  uuid: 0a2ba713-b56e-4812-92fc-02686e7ddd9b
+  subjects:
+  - entities:
+    - role: player
+      name: Jason Marll Jr.
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '112'
+  uuid: d090a8d7-d979-45ac-952e-d6a74a4750a2
+  subjects:
+  - entities:
+    - role: player
+      name: Matthew Werner
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '113'
+  uuid: 36aa1b8b-6c3c-45e8-98e8-e8e4dbcfbdbf
+  subjects:
+  - entities:
+    - role: player
+      name: Brennan McLaughlin
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '114'
+  uuid: 477d6331-8205-42f3-9d0a-15dbfe6ca0ec
+  subjects:
+  - entities:
+    - role: player
+      name: Graham Houston
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '115'
+  uuid: 8a9b0765-da38-43cc-9ce5-703f5aaf6049
+  subjects:
+  - entities:
+    - role: player
+      name: James Clark
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '116'
+  uuid: f4e23c6c-fd23-4985-b33a-0502f8c23db9
+  subjects:
+  - entities:
+    - role: player
+      name: Cooper Hutton
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '117'
+  uuid: fd716264-5816-4cbf-8890-513e1b6f29a9
+  subjects:
+  - entities:
+    - role: player
+      name: Micah Delos Reyes
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '118'
+  uuid: d8011a8b-8d2d-40b6-8d64-fa1e7b52ef0f
+  subjects:
+  - entities:
+    - role: player
+      name: Charlie Sarsfield
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '119'
+  uuid: 05fac855-9a54-414c-910e-cb5e7763232a
+  subjects:
+  - entities:
+    - role: player
+      name: Nathan Malone
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '120'
+  uuid: d638792f-c99e-4042-879b-82ba59672632
+  subjects:
+  - entities:
+    - role: player
+      name: Trent O'Malley
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '121'
+  uuid: c82641d0-e7a9-46b1-9c4b-5990d8118755
+  subjects:
+  - entities:
+    - role: player
+      name: Jaden Jackson
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '122'
+  uuid: b7b116a5-f54b-4fe0-8291-7f752b29449b
+  subjects:
+  - entities:
+    - role: player
+      name: Ka'alekahi Kuhaulua
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '123'
+  uuid: 82172767-9c31-42c2-9885-b08cc010ef1f
+  subjects:
+  - entities:
+    - role: player
+      name: Cade Allen
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '124'
+  uuid: '08f0c5db-7c43-44f9-8162-384e5e23b8da'
+  subjects:
+  - entities:
+    - role: player
+      name: Mason Devine
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '125'
+  uuid: c12c7848-5b28-4dd5-84bd-f1e153438269
+  subjects:
+  - entities:
+    - role: player
+      name: Jose Partida
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '126'
+  uuid: 06bc64ec-638e-4d7e-8495-1a8910099469
+  subjects:
+  - entities:
+    - role: player
+      name: Colin Anderson
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '127'
+  uuid: b4adcfdf-a742-435e-a459-20a97c26e54b
+  subjects:
+  - entities:
+    - role: player
+      name: Enzi-Yaw Otieku
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '128'
+  uuid: 25e05eae-817b-448a-93fa-4f0e6488b01e
+  subjects:
+  - entities:
+    - role: player
+      name: Lucas Diaz
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '129'
+  uuid: ba202640-a231-4d6e-85f3-5dab517a9a6a
+  subjects:
+  - entities:
+    - role: player
+      name: Jorvorskie Lane Jr.
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '130'
+  uuid: 88eb35fe-f308-4bf8-baee-338a45865bb1
+  subjects:
+  - entities:
+    - role: player
+      name: Jake Mercado
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '131'
+  uuid: 5b361f2a-2ef2-4e94-ac15-ef0cb334e50f
+  subjects:
+  - entities:
+    - role: player
+      name: Macgraw VanWormer
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '132'
+  uuid: 9e4d4ae2-673d-43ef-96a6-b06f0d9878b8
+  subjects:
+  - entities:
+    - role: player
+      name: Chase Fuller
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '133'
+  uuid: 4908eeb2-b547-40ed-bbc1-63d444c261df
+  subjects:
+  - entities:
+    - role: player
+      name: Cullen Scott
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '134'
+  uuid: 7cdff081-26eb-4163-8d14-1bb8e4cb1c25
+  subjects:
+  - entities:
+    - role: player
+      name: Connor Salerno
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '135'
+  uuid: 9113367a-eb12-49f2-a267-1c69b0a58e10
+  subjects:
+  - entities:
+    - role: player
+      name: Nathan Handley-White
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '136'
+  uuid: a8f53c38-679d-4e5f-af2b-c5fdafb88f93
+  subjects:
+  - entities:
+    - role: player
+      name: Aiden Ruiz
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '137'
+  uuid: 73cee2b7-b80b-4d54-8130-ee63f6efc322
+  subjects:
+  - entities:
+    - role: player
+      name: Andrew Jimenez
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '138'
+  uuid: d14f5724-a5d6-41b9-afdc-16299d05775e
+  subjects:
+  - entities:
+    - role: player
+      name: Jared Grindlinger
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '139'
+  uuid: dcbc39f5-ae3b-43f4-b51d-04b8413f756b
+  subjects:
+  - entities:
+    - role: player
+      name: Frank Thomas III
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '140'
+  uuid: f8f3271c-28ae-4a8e-a681-0b95602e204d
+  subjects:
+  - entities:
+    - role: player
+      name: Brennan New
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '141'
+  uuid: 855d3182-490b-4792-9baf-dfa97f7bb952
+  subjects:
+  - entities:
+    - role: player
+      name: Cole Gibler
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '142'
+  uuid: ed45a65f-1093-46a0-9ecf-d7d985a43984
+  subjects:
+  - entities:
+    - role: player
+      name: Samir Mohammed
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '143'
+  uuid: 8b3c6510-d81f-430a-83a2-82f7bd3389f4
+  subjects:
+  - entities:
+    - role: player
+      name: Wyatt Peabody
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '144'
+  uuid: 1fae1e4b-1639-43f7-b0eb-ed6536f6db5b
+  subjects:
+  - entities:
+    - role: player
+      name: Ryan Lynch
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '145'
+  uuid: eba266f6-d1ef-4b12-93c6-a26ac4ce8bfc
+  subjects:
+  - entities:
+    - role: player
+      name: Chris Rembert
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '146'
+  uuid: 6b7eb465-ca55-4ca3-b6a5-57c3162c1286
+  subjects:
+  - entities:
+    - role: player
+      name: Greyson Bell
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '147'
+  uuid: 8de6dd07-89cd-4c04-bb0d-cc5d211e8540
+  subjects:
+  - entities:
+    - role: player
+      name: Brady Buenik
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '148'
+  uuid: 82c823cf-774d-4867-bfe1-809d2f71160c
+  subjects:
+  - entities:
+    - role: player
+      name: Carson Schoener
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '149'
+  uuid: d4addb93-b25e-473c-8abc-81c974142202
+  subjects:
+  - entities:
+    - role: player
+      name: Ricky Ojeda
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '150'
+  uuid: be6c47af-2736-4447-aa36-c5aeabb73bf1
+  subjects:
+  - entities:
+    - role: player
+      name: Christian Choe
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '151'
+  uuid: 51f1cebf-2e9d-4494-8969-61bef087d5d0
+  subjects:
+  - entities:
+    - role: player
+      name: Keegan Burke
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '152'
+  uuid: 32ba7302-ec02-46bd-b3da-b62949c02654
+  subjects:
+  - entities:
+    - role: player
+      name: Jayden Portes
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '153'
+  uuid: ec24e04a-ac81-4f79-af7b-2ec2a8a68bae
+  subjects:
+  - entities:
+    - role: player
+      name: Jason DeCaro
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '154'
+  uuid: 598ef220-0b13-4c1f-864a-fd807704aaa7
+  subjects:
+  - entities:
+    - role: player
+      name: Hudson Oliver
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '155'
+  uuid: 8c9cd981-cab6-4ff2-ba6c-6af12f59e00b
+  subjects:
+  - entities:
+    - role: player
+      name: Bowen Landry
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '156'
+  uuid: 72be9a18-60e3-433a-8b3a-c697bec3cd2b
+  subjects:
+  - entities:
+    - role: player
+      name: Kaden Waechter
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '157'
+  uuid: 5b142774-36af-49ec-b88f-a092448c5298
+  subjects:
+  - entities:
+    - role: player
+      name: Andres Jimenez
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '158'
+  uuid: 8e84a719-b3d1-4530-ae80-b2a878286a24
+  subjects:
+  - entities:
+    - role: player
+      name: Boston Targac
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '159'
+  uuid: 2f0f0869-3a83-43ce-beec-af8a63d55e5b
+  subjects:
+  - entities:
+    - role: player
+      name: Leo Nockley
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '161'
+  uuid: 86f8df86-d693-48c5-a476-a19a34e71dfc
+  subjects:
+  - entities:
+    - role: player
+      name: Nolyn Nickels
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '162'
+  uuid: 0c222312-e346-42a5-8b25-3585fc461a8a
+  subjects:
+  - entities:
+    - role: player
+      name: Fielder Grebert
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '163'
+  uuid: 3bc53463-d782-4b78-8eab-c06117821ca9
+  subjects:
+  - entities:
+    - role: player
+      name: Jack Woda
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '164'
+  uuid: e2c7be5b-317b-4001-ae32-89bab89aac95
+  subjects:
+  - entities:
+    - role: player
+      name: Trey Yesavage
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '165'
+  uuid: 11b9ea9c-48a0-4227-8504-257e47d8e438
+  subjects:
+  - entities:
+    - role: player
+      name: Nateo Victorio
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '166'
+  uuid: 76fb2b94-7e2f-42f9-b609-fad9038ac9df
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Lombard
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '167'
+  uuid: a78c68a3-2226-450f-aa15-e95b54ebc166
+  subjects:
+  - entities:
+    - role: player
+      name: Kade Valdivia
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '168'
+  uuid: 292742f7-886c-4df4-a62d-8ef4ce45cf26
+  subjects:
+  - entities:
+    - role: player
+      name: Emmric Alapa
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '169'
+  uuid: 9c0b5679-b790-4583-b7fb-6f3f4daae0ce
+  subjects:
+  - entities:
+    - role: player
+      name: Coleman Borthwick
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '170'
+  uuid: 86f8948e-6de9-47c4-9ca4-d1a7c3dc3ef6
+  subjects:
+  - entities:
+    - role: player
+      name: Mason Miller
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '171'
+  uuid: 1fadf599-a34b-4d8a-99ce-e86bf588e553
+  subjects:
+  - entities:
+    - role: player
+      name: Noah Burt
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '172'
+  uuid: e24770bb-6cf8-4a0a-8360-42c821862cd6
+  subjects:
+  - entities:
+    - role: player
+      name: Andrew Costello
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '173'
+  uuid: 2bc4c9fe-e1dc-471f-aa1a-eeae197b1fa8
+  subjects:
+  - entities:
+    - role: player
+      name: Xander Tiller
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '174'
+  uuid: 91d57207-3f07-4e15-ba95-c8d7f61da1f2
+  subjects:
+  - entities:
+    - role: player
+      name: Ty Glaus
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '175'
+  uuid: 23185ecb-1d72-4d51-8f16-52a0725f8b7d
+  subjects:
+  - entities:
+    - role: player
+      name: Bryan Ravelo
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '176'
+  uuid: 26fe7da9-1aeb-4cab-879b-cedc456da2d5
+  subjects:
+  - entities:
+    - role: player
+      name: Chase Gockenbach
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '177'
+  uuid: 62b41bd7-eb63-495f-baab-dfa102fd56de
+  subjects:
+  - entities:
+    - role: player
+      name: Roch Cholowsky
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '178'
+  uuid: be97aca4-a40e-400e-b1c8-2bef5816cc30
+  subjects:
+  - entities:
+    - role: player
+      name: Amani Tuiasosopo
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '179'
+  uuid: 0137b100-e4ce-4c57-bd6f-9eb2c1df4597
+  subjects:
+  - entities:
+    - role: player
+      name: Yariel Diaz
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '180'
+  uuid: c2aeb06c-bcae-49f3-afb8-8070e73d5830
+  subjects:
+  - entities:
+    - role: player
+      name: Ricky Lopez
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '181'
+  uuid: 8976ad3d-ffdf-4b10-b182-f6cd1333f2d9
+  subjects:
+  - entities:
+    - role: player
+      name: Keelan Zumwalt
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '182'
+  uuid: f015a1d7-5472-42db-bb97-78d501983567
+  subjects:
+  - entities:
+    - role: player
+      name: Camden Boehm
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '183'
+  uuid: 0ea571da-3662-4bba-8f18-324bc78ad11b
+  subjects:
+  - entities:
+    - role: player
+      name: Matthew Fernandez
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '184'
+  uuid: 744111a2-c560-4cea-a249-e9db30a15d03
+  subjects:
+  - entities:
+    - role: player
+      name: Luke Esquivel
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '185'
+  uuid: 0eaba2dd-2e04-40be-80f5-85ee7bef219e
+  subjects:
+  - entities:
+    - role: player
+      name: Gavin McMillan
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '187'
+  uuid: e0958eab-44cb-4d63-882e-bf076dc1ae86
+  subjects:
+  - entities:
+    - role: player
+      name: Zaylon Johnson
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '188'
+  uuid: ad3dc9f9-57eb-4876-bb6f-9bdea93c511b
+  subjects:
+  - entities:
+    - role: player
+      name: Lucas Moore
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '189'
+  uuid: '00679f10-0b57-429a-a1fc-a669befd80f6'
+  subjects:
+  - entities:
+    - role: player
+      name: Cooper Gornet
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '190'
+  uuid: 9d586643-855d-434b-b6a8-caeae7ddd2fd
+  subjects:
+  - entities:
+    - role: player
+      name: Landon King
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '191'
+  uuid: 0bde34a6-abde-4e8e-a606-bef0bfc3cc93
+  subjects:
+  - entities:
+    - role: player
+      name: Ace Reese
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '192'
+  uuid: e1c11ac3-e1a4-4cff-94d2-62e452bdf108
+  subjects:
+  - entities:
+    - role: player
+      name: Paris Head
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '193'
+  uuid: fd4ab60b-fd31-4c4b-90cd-7752306729a1
+  subjects:
+  - entities:
+    - role: player
+      name: Noah Vrzal
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '194'
+  uuid: ab6aac77-36f7-4b3b-8a54-637d1e24f389
+  subjects:
+  - entities:
+    - role: player
+      name: Jace Duckett
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '196'
+  uuid: 02a014d2-0c77-4871-ad1f-93185191151a
+  subjects:
+  - entities:
+    - role: player
+      name: Calvin Madenspacher
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '197'
+  uuid: 5779578b-8f37-4db9-89a3-5a04448188b9
+  subjects:
+  - entities:
+    - role: player
+      name: Devin Urena
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '198'
+  uuid: b0744fcc-255f-4bf5-a6e2-18a600ac1b1e
+  subjects:
+  - entities:
+    - role: player
+      name: Trey Rangel
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '199'
+  uuid: 9d71634c-3beb-464e-b6e1-40a19f78c103
+  subjects:
+  - entities:
+    - role: player
+      name: Ethan Palacios
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '200'
+  uuid: ed6d4c33-237a-4493-a039-b304a67fd2ba
+  subjects:
+  - entities:
+    - role: player
+      name: Landon McDonald
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 

--- a/data/baseball/2026-panini-prizm-stars-stripes/checklists/jumbo-materials-patch.yaml
+++ b/data/baseball/2026-panini-prizm-stars-stripes/checklists/jumbo-materials-patch.yaml
@@ -1,0 +1,1890 @@
+- number: '1'
+  uuid: 7c4484ab-0527-4e22-a905-15b1a1ddb64a
+  subjects:
+  - entities:
+    - role: player
+      name: Brogan Witcher
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '2'
+  uuid: ca9c6b61-2757-4c17-9c63-26c54b385a12
+  subjects:
+  - entities:
+    - role: player
+      name: Junior Lopez
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '3'
+  uuid: a5d67366-fb55-4ffc-b40c-a665069ad75f
+  subjects:
+  - entities:
+    - role: player
+      name: Logan Bristol
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '5'
+  uuid: c3cbb411-290a-4d43-b6da-46777ce843c6
+  subjects:
+  - entities:
+    - role: player
+      name: Jack Mattingly
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '6'
+  uuid: 7ffe8a04-8131-46b2-b0e3-653b550ebb8e
+  subjects:
+  - entities:
+    - role: player
+      name: Drew Burress
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '7'
+  uuid: dba42993-3fb4-45e1-9471-403c6045ba0a
+  subjects:
+  - entities:
+    - role: player
+      name: Brody Crane
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '8'
+  uuid: f7499940-1428-4ebb-ab6a-450665c6ca5d
+  subjects:
+  - entities:
+    - role: player
+      name: Carson Bolemon
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '9'
+  uuid: f9ec1432-eb51-4d0a-973b-a40d361a05ac
+  subjects:
+  - entities:
+    - role: player
+      name: Eric Becker
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '10'
+  uuid: 35bc327d-e224-4aa9-8128-33263d2b5b3d
+  subjects:
+  - entities:
+    - role: player
+      name: Tyler Bell
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '11'
+  uuid: de08598a-a2c1-41bf-8af7-d68bc2906923
+  subjects:
+  - entities:
+    - role: player
+      name: Cole Koeninger
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '12'
+  uuid: e01793e0-af10-4611-a912-81244e8224ab
+  subjects:
+  - entities:
+    - role: player
+      name: Yohandy Morales
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '13'
+  uuid: 9c5428c1-9290-4498-9c6a-c98814d96883
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Beatty
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '14'
+  uuid: 786009b7-a06e-4a3d-892a-70f39fc67765
+  subjects:
+  - entities:
+    - role: player
+      name: Blake Morningstar
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '15'
+  uuid: dcd443af-36f5-4503-a3ae-e6904dba1afd
+  subjects:
+  - entities:
+    - role: player
+      name: Jordan Ayala
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '16'
+  uuid: e3e9c7a9-3738-4fd1-a290-e9e9d783e2d1
+  subjects:
+  - entities:
+    - role: player
+      name: Derek Vazquez
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '17'
+  uuid: 04b543d9-2a84-41ac-9ab0-7fbfe0f39eea
+  subjects:
+  - entities:
+    - role: player
+      name: Grant Sperandio
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '18'
+  uuid: 3fd6f277-13df-4035-b16c-c30618cdfe01
+  subjects:
+  - entities:
+    - role: player
+      name: Cooper Jones
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '20'
+  uuid: 5689df60-7fdd-44c3-8965-726fccdefe55
+  subjects:
+  - entities:
+    - role: player
+      name: Mattias DiMaggio
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '21'
+  uuid: a7c90d98-7e4a-47a9-8728-f0c4e1296a3e
+  subjects:
+  - entities:
+    - role: player
+      name: Clayton Ratliff
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '22'
+  uuid: a40124ce-6d81-4b51-adfd-0670414df30f
+  subjects:
+  - entities:
+    - role: player
+      name: Mateo Mier
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '23'
+  uuid: 2b5c843c-9492-49cc-93a0-a6ccbcc457f6
+  subjects:
+  - entities:
+    - role: player
+      name: Gabe Gaeckle
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '24'
+  uuid: e0bc57e1-f591-4fa2-91ef-df6115fba4fb
+  subjects:
+  - entities:
+    - role: player
+      name: Ryan McPherson
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '25'
+  uuid: dd2f778b-6fe2-4b5f-a8a9-f1912e9f9bf2
+  subjects:
+  - entities:
+    - role: player
+      name: Noah Jarolimek
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '26'
+  uuid: 874f878b-a3fe-4e59-9f7a-097d0c3baecd
+  subjects:
+  - entities:
+    - role: player
+      name: Kekoa Delatori
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '27'
+  uuid: 1ce35b96-fb30-446b-bc28-170992ad62ec
+  subjects:
+  - entities:
+    - role: player
+      name: Carter Hadnot
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '28'
+  uuid: c2530520-f3d8-4c41-96c2-0a40421f8324
+  subjects:
+  - entities:
+    - role: player
+      name: Colt Carter
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '29'
+  uuid: 121871ac-1197-45a7-8ecd-de0247523cb0
+  subjects:
+  - entities:
+    - role: player
+      name: Bryant Ju
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '30'
+  uuid: 404f3705-c7e3-4697-a527-9c33d4f94d4b
+  subjects:
+  - entities:
+    - role: player
+      name: CJ Dornfeld
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '31'
+  uuid: a2ba0f95-7b7c-4470-8298-ae53538747b5
+  subjects:
+  - entities:
+    - role: player
+      name: Brandon Sweeney
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '32'
+  uuid: 4d3b5973-99ac-4465-ac90-411419f7338c
+  subjects:
+  - entities:
+    - role: player
+      name: Moises Gudino
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '33'
+  uuid: 54a8d16c-eadf-41e3-8535-4b46a6350174
+  subjects:
+  - entities:
+    - role: player
+      name: Zion Rose
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '34'
+  uuid: 6690da64-5ce9-41c4-abc1-457dc1a24137
+  subjects:
+  - entities:
+    - role: player
+      name: Alex Pena
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '35'
+  uuid: db427762-f2e6-439a-ac5b-f5c43bef5bc1
+  subjects:
+  - entities:
+    - role: player
+      name: Jared Grindlinger
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '36'
+  uuid: 3d842809-e44e-4cea-b189-bdb829a19b2c
+  subjects:
+  - entities:
+    - role: player
+      name: Jesse Maddox
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '37'
+  uuid: dc182260-0334-439e-a06b-3226320ac2a5
+  subjects:
+  - entities:
+    - role: player
+      name: Anthony Frausto III
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '38'
+  uuid: 7026eab5-a649-46ff-b48f-8adc5a13e499
+  subjects:
+  - entities:
+    - role: player
+      name: Cooper Collins
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '39'
+  uuid: 1c8ec648-99c3-4a1d-b92b-9dbc0d232474
+  subjects:
+  - entities:
+    - role: player
+      name: Liam Peterson
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '40'
+  uuid: 33862874-16b2-4687-b19a-30c367c6ad7e
+  subjects:
+  - entities:
+    - role: player
+      name: Eli Jones
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '41'
+  uuid: 5fcf5e59-310a-4aa1-a351-eb8a13786d0c
+  subjects:
+  - entities:
+    - role: player
+      name: Brett Renfrow
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '42'
+  uuid: d581b733-b914-43ee-85ae-4ba35febbe90
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson McAneeley
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '43'
+  uuid: f4e90c2f-ae38-45b8-8921-c0071226facb
+  subjects:
+  - entities:
+    - role: player
+      name: Matthew Sharman
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '44'
+  uuid: 9524a381-b482-4c3a-b1c3-d2f35a4c6eae
+  subjects:
+  - entities:
+    - role: player
+      name: Orion Gonzalez
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '45'
+  uuid: c26b845c-85a1-456f-96b3-de8ddc97b48d
+  subjects:
+  - entities:
+    - role: player
+      name: Max Hemenway
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '47'
+  uuid: af6414ee-f87d-42ec-a151-1cdc5392a5b1
+  subjects:
+  - entities:
+    - role: player
+      name: Landon Green
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '48'
+  uuid: c1d2e586-a934-4c82-ad36-3929bd30a040
+  subjects:
+  - entities:
+    - role: player
+      name: Grady Emerson
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '49'
+  uuid: da03c457-692f-471f-a14a-6d5400b48680
+  subjects:
+  - entities:
+    - role: player
+      name: Carter Shouse
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '50'
+  uuid: 4a0d6603-0a8a-4859-9675-cb44f33d04f0
+  subjects:
+  - entities:
+    - role: player
+      name: Gio Rojas
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '51'
+  uuid: ea6e4226-1cde-45af-86df-e6f03ceeed5f
+  subjects:
+  - entities:
+    - role: player
+      name: Caden Borcherding
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '52'
+  uuid: '0825f58e-a392-4281-9cee-6b789bdb1d39'
+  subjects:
+  - entities:
+    - role: player
+      name: Bobby Villa
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '53'
+  uuid: b6ffad9e-ed61-4e0c-b5f0-2a993a165814
+  subjects:
+  - entities:
+    - role: player
+      name: AJ Gracia
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '54'
+  uuid: 1686cd49-bae8-419a-a650-0d84ac8dd6a8
+  subjects:
+  - entities:
+    - role: player
+      name: Ryan Marohn
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '55'
+  uuid: f5d37a87-4149-4241-aa0f-2c33bcef39e2
+  subjects:
+  - entities:
+    - role: player
+      name: Joshua Pierre
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '56'
+  uuid: 7985b8d0-cdda-41b8-b9d5-73af9be0b605
+  subjects:
+  - entities:
+    - role: player
+      name: Colton Petersmith
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '57'
+  uuid: 03c37157-0fbf-4ce9-9de2-553bfa15b337
+  subjects:
+  - entities:
+    - role: player
+      name: Miles Lockridge
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '58'
+  uuid: 29d94966-3fa3-453c-b121-e7e4d3ebd2d2
+  subjects:
+  - entities:
+    - role: player
+      name: Luke Armijo
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '59'
+  uuid: 54cedc37-ca7f-46c5-ae59-28e1d369532b
+  subjects:
+  - entities:
+    - role: player
+      name: Will Brick
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '60'
+  uuid: 3ea7f825-4a24-4f9b-9239-c623ebcdc4e0
+  subjects:
+  - entities:
+    - role: player
+      name: Cooper Gear
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '61'
+  uuid: d194da66-d1bd-4c03-8a2b-ecfbae166f7a
+  subjects:
+  - entities:
+    - role: player
+      name: Brody Schumaker
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '62'
+  uuid: fce612e3-bc33-4711-bff6-81b6306712d5
+  subjects:
+  - entities:
+    - role: player
+      name: Jeremiah Hall
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '63'
+  uuid: 77533e1e-03e8-4535-a4a5-1e7712fbf5d1
+  subjects:
+  - entities:
+    - role: player
+      name: Ethan Norby
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '65'
+  uuid: cc341702-e974-4299-b0ae-d5d40345fbae
+  subjects:
+  - entities:
+    - role: player
+      name: William Miller
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '67'
+  uuid: 5049c92d-fc42-466b-ade2-bedb1045064f
+  subjects:
+  - entities:
+    - role: player
+      name: Connor Balazic
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '68'
+  uuid: 2155ea97-2ed6-41b2-911f-fc5edf805f6e
+  subjects:
+  - entities:
+    - role: player
+      name: Michael Ohman
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '69'
+  uuid: e136e4cf-d05b-47fa-9fc0-1793fb43587d
+  subjects:
+  - entities:
+    - role: player
+      name: Dexter McCleon Jr.
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '70'
+  uuid: 6042fece-0edb-4108-8c37-700fbba4cee7
+  subjects:
+  - entities:
+    - role: player
+      name: Kingston George
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '72'
+  uuid: 0b5845c4-58fb-4193-904b-0065d204abca
+  subjects:
+  - entities:
+    - role: player
+      name: Dax Whitney
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '73'
+  uuid: a14bbd3a-759d-4d8c-901c-2e9af07fb8b9
+  subjects:
+  - entities:
+    - role: player
+      name: Gavin Chakar
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '75'
+  uuid: 44079392-82c4-4be6-ba65-43ed430f5c9f
+  subjects:
+  - entities:
+    - role: player
+      name: Josh Hartle
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '76'
+  uuid: '019be3e6-e825-4e97-8bac-234ed2426393'
+  subjects:
+  - entities:
+    - role: player
+      name: Marcus Cantu
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '77'
+  uuid: 64d0c7b9-da15-4096-8d23-252310ccab89
+  subjects:
+  - entities:
+    - role: player
+      name: DJ Lee II
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '78'
+  uuid: dc8eba05-3d21-4157-8e07-3f27d75b5561
+  subjects:
+  - entities:
+    - role: player
+      name: CJ Sampson
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '79'
+  uuid: 71fb8ffb-308c-4c03-b438-954be1b73795
+  subjects:
+  - entities:
+    - role: player
+      name: Lucca Bacigalupi
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '80'
+  uuid: f08378e8-3c62-4d03-b2a9-e687cd6ffdb1
+  subjects:
+  - entities:
+    - role: player
+      name: Ryder Helfrick
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '81'
+  uuid: 53798d1c-1fd7-4d0f-954f-5c7e56347717
+  subjects:
+  - entities:
+    - role: player
+      name: William Haggerty
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '82'
+  uuid: db8330b3-b4c9-4d87-962d-d7c32bb31ecb
+  subjects:
+  - entities:
+    - role: player
+      name: Ethan Kleinschmit
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '83'
+  uuid: bbc1bfb1-ddfe-4401-9d8f-2e1d15d54fa7
+  subjects:
+  - entities:
+    - role: player
+      name: Ethan Gustus
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '84'
+  uuid: f7139e77-029c-45cc-8ccd-a664101cffac
+  subjects:
+  - entities:
+    - role: player
+      name: Jack Byers
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '85'
+  uuid: 630130a5-e4c5-42ff-95bc-60db7db674ac
+  subjects:
+  - entities:
+    - role: player
+      name: Xavier Rodriguez
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '86'
+  uuid: c3fb1ef5-a01e-4826-a51f-cab94979921c
+  subjects:
+  - entities:
+    - role: player
+      name: Ryan Johnson
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '87'
+  uuid: 6b4527b9-09c9-4715-a74e-e3f2436e5ffb
+  subjects:
+  - entities:
+    - role: player
+      name: Connor Wells
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '88'
+  uuid: 1c91c799-13c0-4fb2-ae1d-88113d408175
+  subjects:
+  - entities:
+    - role: player
+      name: Carlo Rivero
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '89'
+  uuid: 6e10fc3f-daaf-49d3-b208-d313f1923af8
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan Bingham
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '90'
+  uuid: 7bb8ef9d-82fb-407d-9082-baf6a4e5b76b
+  subjects:
+  - entities:
+    - role: player
+      name: Grady Nelson
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '91'
+  uuid: abffa9a4-ba25-4b16-ac0d-026111531e89
+  subjects:
+  - entities:
+    - role: player
+      name: Levi Leathers
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '92'
+  uuid: b65caa06-b849-49d2-b6ab-c7a050fc43da
+  subjects:
+  - entities:
+    - role: player
+      name: Banks Addison
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '93'
+  uuid: bcd27420-c516-4abd-af96-7df2794ffd05
+  subjects:
+  - entities:
+    - role: player
+      name: Anderson Kaufmann
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '95'
+  uuid: ab48fd23-079d-4098-9364-27f32816a4ad
+  subjects:
+  - entities:
+    - role: player
+      name: Jaden Freeze
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '96'
+  uuid: cd21af53-a89d-48a3-bc42-8704bf44d500
+  subjects:
+  - entities:
+    - role: player
+      name: Anthony Murphy
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '97'
+  uuid: f0ee42d9-b90d-4fcd-b138-48b0f22a91f4
+  subjects:
+  - entities:
+    - role: player
+      name: Vahn Lackey
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '98'
+  uuid: 860aea70-1062-47ab-8406-a162bdbf48af
+  subjects:
+  - entities:
+    - role: player
+      name: Dariel Carrion
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '99'
+  uuid: 134ed90d-d33b-4923-ac66-18c1db63edcc
+  subjects:
+  - entities:
+    - role: player
+      name: Valentin Ceballos
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '100'
+  uuid: 320de329-a136-4d39-8666-aa3a5702ddd4
+  subjects:
+  - entities:
+    - role: player
+      name: Oliver Van Tiem
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '101'
+  uuid: 47e07cf7-292b-408f-8b91-71163a50eb3e
+  subjects:
+  - entities:
+    - role: player
+      name: Colton Floyd
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '102'
+  uuid: eb4da8fd-4dfc-4368-b56d-4ea707656347
+  subjects:
+  - entities:
+    - role: player
+      name: Sean Simon
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '103'
+  uuid: e2da773e-45c9-43f6-81d5-c75accdc6d6b
+  subjects:
+  - entities:
+    - role: player
+      name: Griffin McKain
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '104'
+  uuid: dc46ff9f-78d3-48a5-ac8e-9026d6689627
+  subjects:
+  - entities:
+    - role: player
+      name: Brenner Brown
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '105'
+  uuid: ee3a97ff-0918-49da-b314-53a591c42d61
+  subjects:
+  - entities:
+    - role: player
+      name: Seddrick Henderson III
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '106'
+  uuid: 165314ff-e91a-452f-ae7c-8016df0dba37
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Dudan
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '107'
+  uuid: 90ec76cb-2b29-4294-bd15-09c815309942
+  subjects:
+  - entities:
+    - role: player
+      name: Louis Lappe
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '108'
+  uuid: a3f9e0d6-4e4a-4286-940a-67816196de18
+  subjects:
+  - entities:
+    - role: player
+      name: Levi Wolf
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '109'
+  uuid: 604eb8ce-ce96-481e-b79e-ba206281b2ce
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Seamon
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '110'
+  uuid: 3e1e3550-2111-481c-8a24-8eb51534877a
+  subjects:
+  - entities:
+    - role: player
+      name: Tyler Early
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '111'
+  uuid: 05f6494f-3d4c-42dd-acab-00ef7461cadb
+  subjects:
+  - entities:
+    - role: player
+      name: Jason Marll Jr.
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '112'
+  uuid: 61198cb2-fc48-4d04-85d2-96d445d1845e
+  subjects:
+  - entities:
+    - role: player
+      name: Matthew Werner
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '113'
+  uuid: 5f67f50e-5788-4b6a-a590-9ae3c6f344db
+  subjects:
+  - entities:
+    - role: player
+      name: Brennan McLaughlin
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '114'
+  uuid: bd62176d-ea0e-445d-9cb7-36ed9ee5f4c1
+  subjects:
+  - entities:
+    - role: player
+      name: Graham Houston
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '115'
+  uuid: 2b903d2a-1133-4b29-9c60-5a2a0c1f6d52
+  subjects:
+  - entities:
+    - role: player
+      name: James Clark
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '116'
+  uuid: 26ad60ac-f16f-44ad-b9bb-2bee93ee21cc
+  subjects:
+  - entities:
+    - role: player
+      name: Cooper Hutton
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '117'
+  uuid: 7a6a045d-eb43-4a20-87d5-a304154bf909
+  subjects:
+  - entities:
+    - role: player
+      name: Micah Delos Reyes
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '118'
+  uuid: 2ab7ef9d-f656-426e-bac4-310146ea73ef
+  subjects:
+  - entities:
+    - role: player
+      name: Charlie Sarsfield
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '119'
+  uuid: d02fef65-4985-4588-8bad-2d48f74aff3f
+  subjects:
+  - entities:
+    - role: player
+      name: Nathan Malone
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '120'
+  uuid: 79f469c4-baae-47b2-83de-3836aca55b92
+  subjects:
+  - entities:
+    - role: player
+      name: Trent O'Malley
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '121'
+  uuid: 7da30cef-9cef-4fcd-a4ca-e30df185b035
+  subjects:
+  - entities:
+    - role: player
+      name: Jaden Jackson
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '122'
+  uuid: 91312551-3ad0-4b0c-bd4d-acf773f99d20
+  subjects:
+  - entities:
+    - role: player
+      name: Ka'alekahi Kuhaulua
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '123'
+  uuid: 1a14ec24-6c57-4a53-b6d6-b28bbc8c7641
+  subjects:
+  - entities:
+    - role: player
+      name: Cade Allen
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '124'
+  uuid: ebd8dcfb-492e-4a3a-80f3-23c6ae98ce2b
+  subjects:
+  - entities:
+    - role: player
+      name: Mason Devine
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '125'
+  uuid: dea9c3fa-dbd8-4bda-87e6-3c7c0ee8afc7
+  subjects:
+  - entities:
+    - role: player
+      name: Jose Partida
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '126'
+  uuid: 9dbbf32e-444f-48e5-affb-5e31f6755a81
+  subjects:
+  - entities:
+    - role: player
+      name: Colin Anderson
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '127'
+  uuid: 6cb6d408-861d-4e49-a4a3-24663de9e35a
+  subjects:
+  - entities:
+    - role: player
+      name: Enzi-Yaw Otieku
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '128'
+  uuid: 78c96f6f-f168-4933-9d08-15bd39b12307
+  subjects:
+  - entities:
+    - role: player
+      name: Lucas Diaz
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '129'
+  uuid: b32637e9-0d80-4345-a316-6d98b08df0ea
+  subjects:
+  - entities:
+    - role: player
+      name: Jorvorskie Lane Jr.
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '130'
+  uuid: 12a5eae8-9c14-4d7f-bd22-9b471a893f2c
+  subjects:
+  - entities:
+    - role: player
+      name: Jake Mercado
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '131'
+  uuid: fde9f55e-57d2-40c2-9fd9-d55c7bf6066e
+  subjects:
+  - entities:
+    - role: player
+      name: Macgraw VanWormer
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '132'
+  uuid: 5194d702-6565-4e76-8589-93db1b27c810
+  subjects:
+  - entities:
+    - role: player
+      name: Chase Fuller
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '133'
+  uuid: fb980738-0be0-4197-b493-f8baba1bc92a
+  subjects:
+  - entities:
+    - role: player
+      name: Cullen Scott
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '134'
+  uuid: 0d8c3908-37b2-479c-a89f-1cbb3164bea1
+  subjects:
+  - entities:
+    - role: player
+      name: Connor Salerno
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '135'
+  uuid: c9423a8b-da7f-410a-984a-7dc4bb62b4ab
+  subjects:
+  - entities:
+    - role: player
+      name: Nathan Handley-White
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '136'
+  uuid: 7078f64f-43d9-4112-934f-00943a375886
+  subjects:
+  - entities:
+    - role: player
+      name: Aiden Ruiz
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '137'
+  uuid: ef240ee3-0e7c-470a-874f-34e4cd445189
+  subjects:
+  - entities:
+    - role: player
+      name: Andrew Jimenez
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '138'
+  uuid: a16cafb9-8a1e-453c-88eb-ce6716c044fc
+  subjects:
+  - entities:
+    - role: player
+      name: Jared Grindlinger
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '139'
+  uuid: d951f131-1cee-4b66-9f7d-fd86a1c77bc3
+  subjects:
+  - entities:
+    - role: player
+      name: Frank Thomas III
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '140'
+  uuid: 5fd967b4-63e4-4b8b-99b1-d40663b3a51c
+  subjects:
+  - entities:
+    - role: player
+      name: Brennan New
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '141'
+  uuid: 1cdc7055-4216-4d90-bb30-6b2c51ba4a7c
+  subjects:
+  - entities:
+    - role: player
+      name: Cole Gibler
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '142'
+  uuid: 976429d9-d852-4e7b-b3b5-6a09f3a24173
+  subjects:
+  - entities:
+    - role: player
+      name: Samir Mohammed
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '143'
+  uuid: 3ae61cb4-ae85-42db-8a28-9aa384d30ec1
+  subjects:
+  - entities:
+    - role: player
+      name: Wyatt Peabody
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '144'
+  uuid: 63fe10fd-8883-4257-bf25-236e9e3a79ea
+  subjects:
+  - entities:
+    - role: player
+      name: Ryan Lynch
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '145'
+  uuid: 6832c780-d371-4336-a53e-2e2577f29fc9
+  subjects:
+  - entities:
+    - role: player
+      name: Chris Rembert
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '146'
+  uuid: 274fa251-263a-464c-80ba-f6f5121c90c6
+  subjects:
+  - entities:
+    - role: player
+      name: Greyson Bell
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '147'
+  uuid: 8847675b-be62-4975-abb7-1322d50d4bc4
+  subjects:
+  - entities:
+    - role: player
+      name: Brady Buenik
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '148'
+  uuid: f26d26fc-7bb4-40fb-b0ae-3c3d2b57bbb8
+  subjects:
+  - entities:
+    - role: player
+      name: Carson Schoener
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '149'
+  uuid: 2b835b41-dc74-4236-9baa-0fbf002dc783
+  subjects:
+  - entities:
+    - role: player
+      name: Ricky Ojeda
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '150'
+  uuid: 7d9498ab-09e9-48ad-91a9-aa3f4941f575
+  subjects:
+  - entities:
+    - role: player
+      name: Christian Choe
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '151'
+  uuid: 65753a53-042a-4412-91de-8f40964857d8
+  subjects:
+  - entities:
+    - role: player
+      name: Keegan Burke
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '152'
+  uuid: 006d750e-9d6d-4815-88bb-c575075d079c
+  subjects:
+  - entities:
+    - role: player
+      name: Jayden Portes
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '153'
+  uuid: 4fc8d5c6-5e7a-43fc-80de-ab468fa34091
+  subjects:
+  - entities:
+    - role: player
+      name: Jason DeCaro
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '154'
+  uuid: f31b01de-1d16-43c3-aed0-bb18123a2bdf
+  subjects:
+  - entities:
+    - role: player
+      name: Hudson Oliver
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '155'
+  uuid: 1e0ea677-d43b-4d36-b32e-f57269855907
+  subjects:
+  - entities:
+    - role: player
+      name: Bowen Landry
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '156'
+  uuid: 647635d3-ae03-4cd9-8650-fe097afd9cff
+  subjects:
+  - entities:
+    - role: player
+      name: Kaden Waechter
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '157'
+  uuid: b48e10e8-94eb-4f94-b2c0-69e063570a06
+  subjects:
+  - entities:
+    - role: player
+      name: Andres Jimenez
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '158'
+  uuid: f61320e5-b76a-4be7-b20e-c53d21b41675
+  subjects:
+  - entities:
+    - role: player
+      name: Boston Targac
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '159'
+  uuid: de11c2ef-2474-41f0-b33b-c8d78acea058
+  subjects:
+  - entities:
+    - role: player
+      name: Leo Nockley
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '161'
+  uuid: cc2b4878-5a1c-4d19-a731-8e30baef274d
+  subjects:
+  - entities:
+    - role: player
+      name: Nolyn Nickels
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '162'
+  uuid: e2f52d11-5f45-404a-915a-14fbc5856f67
+  subjects:
+  - entities:
+    - role: player
+      name: Fielder Grebert
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '163'
+  uuid: 27a32ca0-8f4a-4861-85b6-1f57b33d522c
+  subjects:
+  - entities:
+    - role: player
+      name: Jack Woda
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '164'
+  uuid: 5d3fc1b0-e1a4-4711-aa8e-093182fd1a3b
+  subjects:
+  - entities:
+    - role: player
+      name: Trey Yesavage
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '165'
+  uuid: 3ed93d1a-9d98-498c-a09d-7c9fafaca852
+  subjects:
+  - entities:
+    - role: player
+      name: Nateo Victorio
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '166'
+  uuid: acdb4954-0cc8-4927-a34f-8200b2b8a82c
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Lombard
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '167'
+  uuid: 2570bea0-ef7e-43ab-8a74-06807562b3e6
+  subjects:
+  - entities:
+    - role: player
+      name: Kade Valdivia
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '168'
+  uuid: d13f596c-7f4a-46a8-bb66-e07cc3257cf9
+  subjects:
+  - entities:
+    - role: player
+      name: Emmric Alapa
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '169'
+  uuid: 9342be1b-836e-4a10-a7c3-937aa20a582f
+  subjects:
+  - entities:
+    - role: player
+      name: Coleman Borthwick
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '170'
+  uuid: c2460208-78f6-416f-a328-f57e655ce40b
+  subjects:
+  - entities:
+    - role: player
+      name: Mason Miller
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '171'
+  uuid: 6a4ae5e2-06e6-4554-9503-e5d1caea9699
+  subjects:
+  - entities:
+    - role: player
+      name: Noah Burt
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '172'
+  uuid: 24f95666-fe77-47ea-9aa8-174eb2269865
+  subjects:
+  - entities:
+    - role: player
+      name: Andrew Costello
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '173'
+  uuid: 88cea003-7d7c-4fde-a3fa-9e619954a2ca
+  subjects:
+  - entities:
+    - role: player
+      name: Xander Tiller
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '174'
+  uuid: 133c0f43-6b3c-4896-9498-82c7c5e87e61
+  subjects:
+  - entities:
+    - role: player
+      name: Ty Glaus
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '175'
+  uuid: 4d0668f3-8a01-4f9d-8f86-4edf5af3bd7b
+  subjects:
+  - entities:
+    - role: player
+      name: Bryan Ravelo
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '176'
+  uuid: 28fcb001-48ec-40e4-9d12-ff3709b44c94
+  subjects:
+  - entities:
+    - role: player
+      name: Chase Gockenbach
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '177'
+  uuid: 968c830d-36fe-4f01-a045-f5a478be0faf
+  subjects:
+  - entities:
+    - role: player
+      name: Roch Cholowsky
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '178'
+  uuid: 5124e8bf-9e94-4262-a6fa-e1d386e59e0e
+  subjects:
+  - entities:
+    - role: player
+      name: Amani Tuiasosopo
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '179'
+  uuid: a9e04cc1-0287-44ae-8515-3ab5790b044d
+  subjects:
+  - entities:
+    - role: player
+      name: Yariel Diaz
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '180'
+  uuid: 937eb868-97ff-4a9d-83e1-9f513cf0db35
+  subjects:
+  - entities:
+    - role: player
+      name: Ricky Lopez
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '181'
+  uuid: 949a0f76-89ec-4d5b-bb92-f07e75ab379f
+  subjects:
+  - entities:
+    - role: player
+      name: Keelan Zumwalt
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '182'
+  uuid: c9345bfe-9ceb-4549-ad25-cf83a276b8bf
+  subjects:
+  - entities:
+    - role: player
+      name: Camden Boehm
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '183'
+  uuid: a82eb91d-64bb-4899-8bf8-013fd23b59a6
+  subjects:
+  - entities:
+    - role: player
+      name: Matthew Fernandez
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '184'
+  uuid: b050413e-302a-453c-8c12-d5f131c240d3
+  subjects:
+  - entities:
+    - role: player
+      name: Luke Esquivel
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '185'
+  uuid: 253b356a-8db1-47b5-a2c1-acf3a9442e5f
+  subjects:
+  - entities:
+    - role: player
+      name: Gavin McMillan
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '187'
+  uuid: d0e640dc-f8b2-44fd-822a-7098c7e14604
+  subjects:
+  - entities:
+    - role: player
+      name: Zaylon Johnson
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '188'
+  uuid: 8779f8f8-32a1-41fc-8a95-9dfe6d41b8ed
+  subjects:
+  - entities:
+    - role: player
+      name: Lucas Moore
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '189'
+  uuid: 1af3d464-ef1b-437a-a3a5-7ce97d372736
+  subjects:
+  - entities:
+    - role: player
+      name: Cooper Gornet
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '190'
+  uuid: 9c7cc2c7-2fa6-4968-83af-59944c8ae610
+  subjects:
+  - entities:
+    - role: player
+      name: Landon King
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '191'
+  uuid: 03f3dca0-72dd-4e37-aa7a-1d68deaf5542
+  subjects:
+  - entities:
+    - role: player
+      name: Ace Reese
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '192'
+  uuid: '04281db2-4adb-4afa-b0fb-e920e837c029'
+  subjects:
+  - entities:
+    - role: player
+      name: Paris Head
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '193'
+  uuid: 2852d317-fd82-467e-882a-8ac83a7a2c73
+  subjects:
+  - entities:
+    - role: player
+      name: Noah Vrzal
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '194'
+  uuid: f79f1630-8abc-4570-81f9-3748d873194e
+  subjects:
+  - entities:
+    - role: player
+      name: Jace Duckett
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '196'
+  uuid: 1a826004-9cfa-4e12-b966-b0e498cb8147
+  subjects:
+  - entities:
+    - role: player
+      name: Calvin Madenspacher
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '197'
+  uuid: 8e50024a-9ca1-4820-aa54-14c84133bac9
+  subjects:
+  - entities:
+    - role: player
+      name: Devin Urena
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '198'
+  uuid: 9d4e7e1d-f801-4dd6-9cf0-7ede7c049d0b
+  subjects:
+  - entities:
+    - role: player
+      name: Trey Rangel
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '199'
+  uuid: 12b5dd6b-d93d-4a74-9cd7-78fa1e91beae
+  subjects:
+  - entities:
+    - role: player
+      name: Ethan Palacios
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 
+- number: '200'
+  uuid: a62ed207-aeda-4447-94e6-087e88f246a2
+  subjects:
+  - entities:
+    - role: player
+      name: Landon McDonald
+      ref: 
+    - role: team
+      name: USA Baseball
+      ref: 

--- a/data/baseball/2026-panini-prizm-stars-stripes/manifest.yaml
+++ b/data/baseball/2026-panini-prizm-stars-stripes/manifest.yaml
@@ -1,0 +1,341 @@
+set_id: 2026-panini-prizm-stars-stripes
+base_sets:
+- id: base-set
+  name: Base Set
+  uuid: a6f63d6c-1658-593d-a909-9d7a8b64c034
+  declared_card_count: 200
+  parallels:
+  - name: Prizms Black Finite
+    print_run: 1
+    serial_numbered: true
+  - name: Prizms Black Gold
+    print_run: 5
+    serial_numbered: true
+  - name: Prizms Black Velocity
+    print_run: 39
+    serial_numbered: true
+  - name: Prizms Blue
+    print_run: 299
+    serial_numbered: true
+  - name: Prizms Blue Ice
+    print_run: 99
+    serial_numbered: true
+  - name: Prizms Blue Pulsar
+    print_run: 75
+    serial_numbered: true
+  - name: Prizms Box Set
+  - name: Prizms Box Set Black Pandora
+    print_run: 1
+    serial_numbered: true
+  - name: Prizms Box Set Red Pandora
+    print_run: 39
+    serial_numbered: true
+  - name: Prizms Box Set Signatures
+    print_run: 225
+    serial_numbered: true
+  - name: Prizms Cherry Blossom
+    print_run: 20
+    serial_numbered: true
+  - name: Prizms Cracked Ice
+    print_run: 25
+    serial_numbered: true
+  - name: Prizms Disco
+  - name: Prizms Disco America
+    print_run: 13
+    serial_numbered: true
+  - name: Prizms Disco Black
+    print_run: 1
+    serial_numbered: true
+  - name: Prizms Disco Blue
+    print_run: 149
+    serial_numbered: true
+  - name: Prizms Disco Gold
+    print_run: 10
+    serial_numbered: true
+  - name: Prizms Disco Orange
+    print_run: 75
+    serial_numbered: true
+  - name: Prizms Disco Purple
+    print_run: 99
+    serial_numbered: true
+  - name: Prizms Disco Red
+    print_run: 199
+    serial_numbered: true
+  - name: Prizms Disco Teal
+    print_run: 49
+    serial_numbered: true
+  - name: Prizms Glitter
+  - name: Prizms Gold
+    print_run: 10
+    serial_numbered: true
+  - name: Prizms Gold Vinyl
+    print_run: 1
+    serial_numbered: true
+  - name: Prizms Green
+  - name: Prizms Green Ice
+    print_run: 25
+    serial_numbered: true
+  - name: Prizms Green Pulsar
+    print_run: 25
+    serial_numbered: true
+  - name: Prizms Green Scope
+    print_run: 99
+    serial_numbered: true
+  - name: Prizms Mojo
+    print_run: 25
+    serial_numbered: true
+  - name: Prizms Orange Ice
+    print_run: 199
+    serial_numbered: true
+  - name: Prizms Orange Pulsar
+    print_run: 249
+    serial_numbered: true
+  - name: Prizms Orange Wave
+    print_run: 75
+    serial_numbered: true
+  - name: Prizms Purple
+    print_run: 199
+    serial_numbered: true
+  - name: Prizms Red
+    print_run: 399
+    serial_numbered: true
+  - name: Prizms Red Power
+    print_run: 149
+    serial_numbered: true
+  - name: Prizms Ruby Wave
+  - name: Prizms Silver
+  - name: Prizms Snakeskin
+  subsets:
+  - id: base-prizms-signatures
+    name: Base Prizms Signatures
+    uuid: 82947756-9222-5511-8792-a6eec840b7b2
+    type:
+    - autograph
+    declared_card_count: 200
+    parallels:
+    - name: Gold
+      print_run: 10
+      serial_numbered: true
+    - name: Gold Vinyl
+      print_run: 1
+      serial_numbered: true
+  - id: base-prizms-signatures-green
+    name: Base Prizms Signatures Green
+    uuid: 2d41e756-15e9-52ba-982e-ce239b0adb15
+    type:
+    - autograph
+    declared_card_count: 32
+subsets:
+- id: 13u-14u-national-team-signatures
+  name: 13U/14U National Team Signatures
+  uuid: 33549df3-1aef-5230-8d03-4c1fe8768b66
+  type:
+  - autograph
+  declared_card_count: 50
+  parallels:
+  - name: PE
+  - name: Prizms Black Finite
+    print_run: 1
+    serial_numbered: true
+  - name: Prizms Blue
+    print_run: 49
+    serial_numbered: true
+  - name: Prizms Box Set
+    print_run: 100
+    serial_numbered: true
+  - name: Prizms Disco
+  - name: Prizms Disco Black
+    print_run: 1
+    serial_numbered: true
+  - name: Prizms Disco Gold
+    print_run: 10
+    serial_numbered: true
+  - name: Prizms Disco Red
+    print_run: 25
+    serial_numbered: true
+  - name: Prizms Gold
+    print_run: 10
+    serial_numbered: true
+  - name: Prizms Gold Ice
+    print_run: 10
+    serial_numbered: true
+  - name: Prizms Gold Pulsar
+    print_run: 10
+    serial_numbered: true
+  - name: Prizms Gold Vinyl
+    print_run: 1
+    serial_numbered: true
+  - name: Prizms Green
+  - name: Prizms Green Ice
+    print_run: 99
+    serial_numbered: true
+  - name: Prizms Green Pulsar
+    print_run: 99
+    serial_numbered: true
+  - name: Prizms Mojo
+    print_run: 25
+    serial_numbered: true
+  - name: Prizms Red
+    print_run: 99
+    serial_numbered: true
+- id: 15u-national-team-signatures
+  name: 15U National Team Signatures
+  uuid: 7ac59da6-3adf-56cd-ae14-f175ca0995b0
+  type:
+  - autograph
+  declared_card_count: 20
+  parallels:
+  - name: PE
+  - name: Prizms Black Finite
+    print_run: 1
+    serial_numbered: true
+  - name: Prizms Blue
+    print_run: 49
+    serial_numbered: true
+  - name: Prizms Box Set
+    print_run: 200
+    serial_numbered: true
+  - name: Prizms Disco
+  - name: Prizms Disco Black
+    print_run: 1
+    serial_numbered: true
+  - name: Prizms Disco Gold
+    print_run: 10
+    serial_numbered: true
+  - name: Prizms Disco Red
+    print_run: 25
+    serial_numbered: true
+  - name: Prizms Gold
+    print_run: 10
+    serial_numbered: true
+  - name: Prizms Gold Ice
+    print_run: 10
+    serial_numbered: true
+  - name: Prizms Gold Pulsar
+    print_run: 10
+    serial_numbered: true
+  - name: Prizms Gold Vinyl
+    print_run: 1
+    serial_numbered: true
+  - name: Prizms Green
+  - name: Prizms Green Ice
+    print_run: 99
+    serial_numbered: true
+  - name: Prizms Green Pulsar
+    print_run: 99
+    serial_numbered: true
+  - name: Prizms Mojo
+    print_run: 25
+    serial_numbered: true
+  - name: Prizms Red
+    print_run: 99
+    serial_numbered: true
+- id: 16u-17u-national-team-signatures
+  name: 16U/17U National Team Signatures
+  uuid: 5443e4de-eace-51ab-81df-d1e9b6f7eb63
+  type:
+  - autograph
+  declared_card_count: 71
+- id: 18u-national-team-signatures
+  name: 18U National Team Signatures
+  uuid: 2f983d1b-acae-5a2c-be85-32273381082f
+  type:
+  - autograph
+  declared_card_count: 28
+  parallels:
+  - name: PE
+  - name: Prizms Black Finite
+    print_run: 1
+    serial_numbered: true
+  - name: Prizms Blue
+    print_run: 49
+    serial_numbered: true
+  - name: Prizms Box Set
+    print_run: 200
+    serial_numbered: true
+  - name: Prizms Disco
+  - name: Prizms Disco Black
+    print_run: 1
+    serial_numbered: true
+  - name: Prizms Disco Gold
+    print_run: 10
+    serial_numbered: true
+  - name: Prizms Disco Red
+    print_run: 25
+    serial_numbered: true
+  - name: Prizms Gold
+    print_run: 10
+    serial_numbered: true
+  - name: Prizms Gold Ice
+    print_run: 10
+    serial_numbered: true
+  - name: Prizms Gold Pulsar
+    print_run: 10
+    serial_numbered: true
+  - name: Prizms Gold Vinyl
+    print_run: 1
+    serial_numbered: true
+  - name: Prizms Green
+  - name: Prizms Green Ice
+    print_run: 99
+    serial_numbered: true
+  - name: Prizms Green Pulsar
+    print_run: 99
+    serial_numbered: true
+  - name: Prizms Mojo
+    print_run: 25
+    serial_numbered: true
+  - name: Prizms Red
+    print_run: 99
+    serial_numbered: true
+- id: all-american
+  name: All-American
+  uuid: 034e6d55-446b-558b-a9dc-5f8afd68b3c8
+  type:
+  - insert
+  declared_card_count: 25
+  parallels:
+  - name: Prizms Black Finite
+    print_run: 1
+    serial_numbered: true
+  - name: Prizms Blue
+    print_run: 99
+    serial_numbered: true
+  - name: Prizms Disco
+  - name: Prizms Disco Black
+    print_run: 1
+    serial_numbered: true
+  - name: Prizms Disco Gold
+    print_run: 10
+    serial_numbered: true
+  - name: Prizms Gold
+    print_run: 10
+    serial_numbered: true
+  - name: Prizms Gold Vinyl
+    print_run: 1
+    serial_numbered: true
+  - name: Prizms Green
+  - name: Prizms Mojo
+    print_run: 25
+    serial_numbered: true
+  - name: Prizms Red
+    print_run: 199
+    serial_numbered: true
+- id: jumbo-materials-flag
+  name: Jumbo Materials Flag
+  uuid: bca93f87-fc83-5060-9381-a1fb7bdd6da3
+  type:
+  - relic
+  declared_card_count: 184
+- id: jumbo-materials-jersey-number
+  name: Jumbo Materials Jersey Number
+  uuid: bea87e55-8249-5c87-bece-4eb1053a9130
+  type:
+  - relic
+  declared_card_count: 186
+- id: jumbo-materials-patch
+  name: Jumbo Materials Patch
+  uuid: 41d4d9f3-4d9c-5c85-bacb-921d90691482
+  type:
+  - relic
+  declared_card_count: 189

--- a/data/baseball/2026-panini-prizm-stars-stripes/set.yaml
+++ b/data/baseball/2026-panini-prizm-stars-stripes/set.yaml
@@ -1,0 +1,22 @@
+uuid: 031502ae-b19f-4243-bbed-8fb73939e8f5
+set_id: 2026-panini-prizm-stars-stripes
+name: 2026 Panini Stars & Stripes Prizm
+genre: Sports
+category:
+- USA Baseball
+sports:
+- Baseball
+season: '2026'
+years:
+- 2026
+manufacturer: Panini
+release_date: '2026-04-03'
+description: 2026 Panini Stars & Stripes Prizm was released April 3rd and features
+  current and former members of the USA Baseball team. For the first time, the Stars
+  & Stripes product is printed on Optichrome card stock. Each Hobby pack will contain
+  an insert, a Prizm parallel and either an autograph or game-used card or another
+  Prizm parallel..
+source:
+  name: BaseballCardpedia
+  url: https://baseballcardpedia.com/index.php/2026_Panini_Stars_%26_Stripes_Prizm#Checklist
+  file: import/2026-Panini-Prizm-Stars-Stripes-Baseball-Checklist.xlsx

--- a/data/baseball/2026-panini-prizm-stars-stripes/set.yaml
+++ b/data/baseball/2026-panini-prizm-stars-stripes/set.yaml
@@ -15,7 +15,7 @@ description: 2026 Panini Stars & Stripes Prizm was released April 3rd and featur
   current and former members of the USA Baseball team. For the first time, the Stars
   & Stripes product is printed on Optichrome card stock. Each Hobby pack will contain
   an insert, a Prizm parallel and either an autograph or game-used card or another
-  Prizm parallel..
+  Prizm parallel.
 source:
   name: BaseballCardpedia
   url: https://baseballcardpedia.com/index.php/2026_Panini_Stars_%26_Stripes_Prizm#Checklist


### PR DESCRIPTION
Converts jmurphyrum's **2026 Panini Stars & Stripes Prizm** (#21, exploded) to the **v0.3 manifest form**. Same data, compact and reviewable. Passes the v0.3 validator. Supersedes #21.

1 base set (200); Base Prizms Signatures nested under base; National Team Signatures (by age group) + Jumbo Materials relics at product level.

⚠️ Draft — leaving open so @jmurphyrum can review the structure before merge.