### PR TITLE
feat(data): 2026 Topps Chrome Black in v0.3 manifest form (converted from #22)

### DIFF
--- a/data/baseball/2026-topps-chrome-black/checklists/base-rookie-design-variations.yaml
+++ b/data/baseball/2026-topps-chrome-black/checklists/base-rookie-design-variations.yaml
@@ -1,0 +1,300 @@
+- number: '13'
+  uuid: 49517fce-0fac-4086-8cc4-82f5e945aea5
+  subjects:
+  - entities:
+    - role: player
+      name: Jac Caglianone
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: '17'
+  uuid: 7fbe5b82-d345-46dc-ba9c-f0bfdc4805e6
+  subjects:
+  - entities:
+    - role: player
+      name: Bubba Chandler
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '21'
+  uuid: 655e29a6-55c7-4a82-a258-2a71e6447c2a
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Misiorowski
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: '23'
+  uuid: 346aa525-6213-44c2-8dd9-4171ce90a7b0
+  subjects:
+  - entities:
+    - role: player
+      name: Jhostynxon Garcia
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '26'
+  uuid: '067943a6-1524-4d52-bbcf-39d6a53b788d'
+  subjects:
+  - entities:
+    - role: player
+      name: Payton Tolle
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '27'
+  uuid: 861b5f34-5ac0-4f3e-8675-057bea7e03ac
+  subjects:
+  - entities:
+    - role: player
+      name: Jakob Marsee
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: '28'
+  uuid: b0e88d03-0623-4c26-9da6-5d2c4b23fd69
+  subjects:
+  - entities:
+    - role: player
+      name: Alex Freeland
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '30'
+  uuid: b1dbc034-499a-42b5-9402-b61c26574ec4
+  subjects:
+  - entities:
+    - role: player
+      name: Sal Stewart
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '38'
+  uuid: bb54f86f-0b34-4106-94a6-4cdc233da698
+  subjects:
+  - entities:
+    - role: player
+      name: Chase Burns
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '41'
+  uuid: 0547e81a-317f-46eb-8be4-ae8892f3e117
+  subjects:
+  - entities:
+    - role: player
+      name: Samuel Basallo
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '43'
+  uuid: 0af6d58b-5e43-4bab-a28a-95744a3d5ea1
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Melton
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '44'
+  uuid: 2a82febb-3861-4436-a9ea-87114d77e99e
+  subjects:
+  - entities:
+    - role: player
+      name: C.J. Kayfus
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '48'
+  uuid: d0fc95e4-c121-4a8d-8c48-f0e4c2fee2cc
+  subjects:
+  - entities:
+    - role: player
+      name: Jonah Tong
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '51'
+  uuid: e7c622a1-d841-414a-8a9e-98cd4d04ac16
+  subjects:
+  - entities:
+    - role: player
+      name: Owen Caissie
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '52'
+  uuid: b803ea38-ff0b-48d4-ab41-f33d21c1e449
+  subjects:
+  - entities:
+    - role: player
+      name: Parker Messick
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '56'
+  uuid: 28c255ea-9592-4391-a53b-0283db41fbb6
+  subjects:
+  - entities:
+    - role: player
+      name: Roman Anthony
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '58'
+  uuid: ae1ccbde-a0fe-4837-8c53-52259a1e788e
+  subjects:
+  - entities:
+    - role: player
+      name: Carter Jensen
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: '60'
+  uuid: f315a3dc-62e9-4520-b896-2c067b150aed
+  subjects:
+  - entities:
+    - role: player
+      name: Colson Montgomery
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: '65'
+  uuid: 91042a44-473a-4345-811f-0d46eb3022f9
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan McLean
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '68'
+  uuid: cade3551-be1e-4d06-9a02-0f7fca984161
+  subjects:
+  - entities:
+    - role: player
+      name: Cole Young
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: '70'
+  uuid: 16007f28-d450-44a0-a38d-a0e6c66ad37f
+  subjects:
+  - entities:
+    - role: player
+      name: Dylan Beavers
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '74'
+  uuid: 2717c41a-4998-4246-8674-ac88c91accc5
+  subjects:
+  - entities:
+    - role: player
+      name: Brandon Sproat
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '75'
+  uuid: 2ddc993c-2803-4268-bf8b-598f9d95454d
+  subjects:
+  - entities:
+    - role: player
+      name: Brice Matthews
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '77'
+  uuid: 80e60a25-a939-4a3c-9794-7106285981f4
+  subjects:
+  - entities:
+    - role: player
+      name: Christian Moore
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: '79'
+  uuid: 143158b1-de97-424b-86dd-886888f59b31
+  subjects:
+  - entities:
+    - role: player
+      name: Harry Ford
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: '85'
+  uuid: 0d2973d9-707e-4ede-bc36-1f6c2e475a66
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Teel
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: '98'
+  uuid: de9d6252-f087-4284-bdc7-0c1a1fca70a2
+  subjects:
+  - entities:
+    - role: player
+      name: Cam Schlittler
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '99'
+  uuid: 335250e1-b1c5-4eed-ae7a-56be6c6557cc
+  subjects:
+  - entities:
+    - role: player
+      name: Jimmy Crooks
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: '101'
+  uuid: b5cb22f2-fbed-4975-b984-e17141d05449
+  subjects:
+  - entities:
+    - role: player
+      name: Carson Williams
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: '160'
+  uuid: 341e7023-f438-480e-8023-47da3f519719
+  subjects:
+  - entities:
+    - role: player
+      name: Brady House
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 

--- a/data/baseball/2026-topps-chrome-black/checklists/base-set.yaml
+++ b/data/baseball/2026-topps-chrome-black/checklists/base-set.yaml
@@ -1,0 +1,2053 @@
+- number: '1'
+  uuid: 12d11b89-a374-4900-a6f4-6dce835bb161
+  subjects:
+  - entities:
+    - role: player
+      name: Shohei Ohtani
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '2'
+  uuid: 97bc64ff-5916-4359-acdc-48f71a51489c
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Trout
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: '3'
+  uuid: 1892658a-b5af-46b0-8c96-f0d2d0b1931b
+  subjects:
+  - entities:
+    - role: player
+      name: Ronald Acuña Jr.
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: '4'
+  uuid: 7809ddda-b448-42f5-93e6-208bd83013f0
+  subjects:
+  - entities:
+    - role: player
+      name: Mookie Betts
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '5'
+  uuid: 578da64c-09e6-434a-bff5-42c44389910e
+  subjects:
+  - entities:
+    - role: player
+      name: Freddie Freeman
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '6'
+  uuid: f2d3f119-2acc-43fe-af46-927ced907e10
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '7'
+  uuid: e9e9eb43-4127-4217-895b-633f57e91113
+  subjects:
+  - entities:
+    - role: player
+      name: Julio Rodríguez
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: '8'
+  uuid: 2c0e5f05-9077-4004-a95e-995f89cdc2e9
+  subjects:
+  - entities:
+    - role: player
+      name: Aaron Judge
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '9'
+  uuid: 1cc3beb5-cb93-4183-a28d-31c19a8cb6a7
+  subjects:
+  - entities:
+    - role: player
+      name: José Ramírez
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '10'
+  uuid: 0b4ea6ab-a3bd-4624-8780-1a14fd030b27
+  subjects:
+  - entities:
+    - role: player
+      name: Yordan Alvarez
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '11'
+  uuid: ededd292-cd07-4d1a-9964-6c14c428d8e1
+  subjects:
+  - entities:
+    - role: player
+      name: Gunnar Henderson
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '12'
+  uuid: 33a571fe-2529-46c2-af49-15fe6bf16bb0
+  subjects:
+  - entities:
+    - role: player
+      name: Alex Bregman
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '13'
+  uuid: f768f3f3-0880-469a-8b9c-ae67db2ad68b
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Jac Caglianone
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: '14'
+  uuid: 6818fb89-07d9-4f7a-832d-0f2df29b2c43
+  subjects:
+  - entities:
+    - role: player
+      name: Brendan Donovan
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: '15'
+  uuid: 4fbae3ec-19fd-4a83-a261-97f0f5edd191
+  subjects:
+  - entities:
+    - role: player
+      name: Matt Olson
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: '16'
+  uuid: d6ec1476-eab8-4314-bffa-a8a59af702fc
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Tucker
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '17'
+  uuid: b4933b7a-e5a0-4a3c-ab4f-21282ec50aea
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Bubba Chandler
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '18'
+  uuid: a49dfce5-4391-4bff-a381-b017c8881b33
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Alonso
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '19'
+  uuid: 65f4da5c-0945-4afb-ae1c-7ebbcdbd1657
+  subjects:
+  - entities:
+    - role: player
+      name: Francisco Lindor
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '20'
+  uuid: 07aca600-98c1-43e3-8168-911e2e80722b
+  subjects:
+  - entities:
+    - role: player
+      name: Teoscar Hernández
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '21'
+  uuid: 0f7f2c6a-a42f-4d96-a88d-98a2aefc1f94
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Misiorowski
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: '22'
+  uuid: a55f4c24-eb01-4232-ad48-a55180c31dfa
+  subjects:
+  - entities:
+    - role: player
+      name: Shota Imanaga
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '23'
+  uuid: 79f5087d-0b9f-4025-a362-3f11e300b365
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Jhostynxon Garcia
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '24'
+  uuid: 557e94da-8c80-4e90-978d-6769e36be9f1
+  subjects:
+  - entities:
+    - role: player
+      name: Jose Altuve
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '25'
+  uuid: '05976ed8-4837-4408-8bc7-e0862795cda6'
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan Arenado
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: '26'
+  uuid: 8e6e2a0d-bcaa-479f-bef3-04b7143a2cc6
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Payton Tolle
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '27'
+  uuid: f1a2422d-ae92-46e8-8af9-ed440ba6813d
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Jakob Marsee
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: '28'
+  uuid: 2b73d403-cf0d-49ba-b587-3a2c4051ff7a
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Alex Freeland
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '29'
+  uuid: afac1eae-c1a8-4736-81d7-8e6b00a3bc63
+  subjects:
+  - entities:
+    - role: player
+      name: Marcelo Mayer
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '30'
+  uuid: 65ef54d9-93d5-4167-bb09-ecaec0aa8601
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Sal Stewart
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '31'
+  uuid: 8d308365-c5e6-4b72-bf8f-6aa9555210a0
+  subjects:
+  - entities:
+    - role: player
+      name: Cade Horton
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '32'
+  uuid: ca620211-561f-4202-9b01-3d6d8dc29397
+  subjects:
+  - entities:
+    - role: player
+      name: Chris Sale
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: '33'
+  uuid: 8e8d2850-b862-4da5-900c-9acd5bf63761
+  subjects:
+  - entities:
+    - role: player
+      name: Jung Hoo Lee
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '34'
+  uuid: 60b6451e-13ed-4dcc-9c21-1f95f62b6c4c
+  subjects:
+  - entities:
+    - role: player
+      name: Jordan Beck
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: '35'
+  uuid: cd9b537a-c0ce-4acb-99c0-73fe60e5a335
+  subjects:
+  - entities:
+    - role: player
+      name: Paul Skenes
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '36'
+  uuid: c50de7e2-81f3-47d5-942e-ce467cebfd2f
+  subjects:
+  - entities:
+    - role: player
+      name: Jeremy Peña
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '37'
+  uuid: 956e58df-6020-469c-bbe0-9e22bb166d16
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Stowers
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: '38'
+  uuid: 5039421e-4d04-4a42-ac81-00a5cd4f5eb4
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Chase Burns
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '39'
+  uuid: d3f29235-f034-4dfe-93ee-0773964b8f85
+  subjects:
+  - entities:
+    - role: player
+      name: Jazz Chisholm Jr.
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '40'
+  uuid: e2d2054e-0fed-45b0-b91a-7a7856cda94f
+  subjects:
+  - entities:
+    - role: player
+      name: Zach Neto
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: '41'
+  uuid: 4187ab6f-8ff4-46da-9e26-1f8508758705
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Samuel Basallo
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '42'
+  uuid: 5114e037-6b5a-4035-a22c-611a581122a1
+  subjects:
+  - entities:
+    - role: player
+      name: Christian Yelich
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: '43'
+  uuid: 1d2ba73b-fbac-49e8-871d-751239f243e5
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Melton
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '44'
+  uuid: 4ef8ecd7-6d2f-4447-a80b-f63960d4ef0d
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: C.J. Kayfus
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '45'
+  uuid: f2a38af6-d0ae-439e-b758-f915c5ea9b13
+  subjects:
+  - entities:
+    - role: player
+      name: Tarik Skubal
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '46'
+  uuid: a32b801e-2be1-4c9b-8089-b971e8c42ac2
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Nathan Church
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: '47'
+  uuid: 621eea03-82d2-4d74-84d3-8b3f86fbbca5
+  subjects:
+  - entities:
+    - role: player
+      name: Cal Raleigh
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: '48'
+  uuid: ce27d945-41db-41ab-9db0-dd976537ef28
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Jonah Tong
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '49'
+  uuid: 10022e89-d489-4d31-b1ae-8bfa08baef36
+  subjects:
+  - entities:
+    - role: player
+      name: Yoshinobu Yamamoto
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '50'
+  uuid: 2cf8a507-4cf1-4a16-b3b3-2affdb05764c
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Eldridge
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '51'
+  uuid: 615d2244-6a6b-4082-a1d3-4ebb9f1e5ef7
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Owen Caissie
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '52'
+  uuid: 9b743d75-3085-48a6-8a49-23826b329119
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Parker Messick
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '53'
+  uuid: 3e273dc4-1a45-4a06-a0d4-96a7d79900c1
+  subjects:
+  - entities:
+    - role: player
+      name: Willson Contreras
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: '54'
+  uuid: 482708da-63cf-4c0a-87cd-6ffc169b2f4b
+  subjects:
+  - entities:
+    - role: player
+      name: Matt Chapman
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '55'
+  uuid: 88ed651f-854d-424d-b3e8-ded3aafd4478
+  subjects:
+  - entities:
+    - role: player
+      name: Roki Sasaki
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '56'
+  uuid: 261f7b04-6c91-4474-bc56-e62f281bbea3
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Roman Anthony
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '57'
+  uuid: fa82cf5e-d884-4c35-baba-66cc0403d4b0
+  subjects:
+  - entities:
+    - role: player
+      name: Agustín Ramírez
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: '58'
+  uuid: 26e27c42-b4fd-4f04-9d06-dacb4c01b25c
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Carter Jensen
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: '59'
+  uuid: 6587012e-de1a-488d-8b92-31360aaf57b1
+  subjects:
+  - entities:
+    - role: player
+      name: Randy Arozarena
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: '60'
+  uuid: 7a193e77-fd18-42dd-933f-de2eb55da862
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Colson Montgomery
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: '61'
+  uuid: 1133077f-3fc1-495d-a2cc-e4dbebd858b8
+  subjects:
+  - entities:
+    - role: player
+      name: Masyn Winn
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: '62'
+  uuid: cfd45a0c-f034-4205-a6fa-b2c534080ac9
+  subjects:
+  - entities:
+    - role: player
+      name: Andrew Abbott
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '63'
+  uuid: e5a91be4-c1e8-4abd-ba9b-7e9e5312a35e
+  subjects:
+  - entities:
+    - role: player
+      name: Andrew McCutchen
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '64'
+  uuid: 530ab7b7-6fea-4551-87c3-fb0c55128767
+  subjects:
+  - entities:
+    - role: player
+      name: Xavier Edwards
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: '65'
+  uuid: 22c81fe3-6381-4c05-b85b-9c74e977aa5a
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan McLean
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '66'
+  uuid: 4ef23a58-61e8-4840-be28-9e26aab43dfb
+  subjects:
+  - entities:
+    - role: player
+      name: Dillon Dingler
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '67'
+  uuid: e88c4e3e-7f96-44c2-9410-a6f14eda4f01
+  subjects:
+  - entities:
+    - role: player
+      name: Steven Kwan
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: '68'
+  uuid: d22696bc-94fd-4ab7-8a27-b1da25e174d7
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Cole Young
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: '69'
+  uuid: ec4ae95f-f653-4984-abbe-c78d0c8a09e7
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Denzer Guzman
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: '70'
+  uuid: a9793b00-a9f4-435a-9bc1-d1f1e65f0f3c
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Dylan Beavers
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '71'
+  uuid: 7f86cc10-4a9e-4e5e-92b0-be10c4c40492
+  subjects:
+  - entities:
+    - role: player
+      name: Salvador Perez
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: '72'
+  uuid: 23230d7e-190d-4aa2-a10f-38bdb2ab0d20
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Warming Bernabel
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: '73'
+  uuid: 3aef9e61-98d5-45ec-80fb-39e0dff2fa52
+  subjects:
+  - entities:
+    - role: player
+      name: Bobby Witt Jr.
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: '74'
+  uuid: 4458a061-dc11-4d08-80cc-36e1173c9563
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Brandon Sproat
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '75'
+  uuid: ef6f7c3f-7440-4732-97c3-ba2b343423aa
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Brice Matthews
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '76'
+  uuid: f63a80fa-b0f7-4df8-86b3-e6c249ec7e3c
+  subjects:
+  - entities:
+    - role: player
+      name: Chase Dollander
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: '77'
+  uuid: bf605a27-7ad2-47b0-b695-2bd80d4bd1a5
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Christian Moore
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: '78'
+  uuid: 0e5b0cc0-b3b8-4506-b91e-6b458510a7fb
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Ryan Ritter
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: '79'
+  uuid: 917f1be4-d38e-4f44-92d4-db9c670988c5
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Harry Ford
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: '80'
+  uuid: 3cc5fe7f-3641-479c-a578-c1efbeac9697
+  subjects:
+  - entities:
+    - role: player
+      name: J.P. Crawford
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: '81'
+  uuid: 91f7f60d-772d-4a39-802e-2d3beb6f67d2
+  subjects:
+  - entities:
+    - role: player
+      name: Drake Baldwin
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: '82'
+  uuid: 6acc9df5-b848-499d-bf32-a3896ab7a230
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Robert Jr.
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: '83'
+  uuid: 1439efea-1fad-4bdc-b37b-ac35b69cff79
+  subjects:
+  - entities:
+    - role: player
+      name: Javier Báez
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '84'
+  uuid: d5fdfcf0-7d14-4396-ba29-990517ee12d9
+  subjects:
+  - entities:
+    - role: player
+      name: Cody Bellinger
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '85'
+  uuid: a215e6e3-64e7-4ddc-83d4-db916902d7ee
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Teel
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: '86'
+  uuid: d9d64fdd-dc2d-42d0-ad7c-7d5478d6e103
+  subjects:
+  - entities:
+    - role: player
+      name: Matt Shaw
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '87'
+  uuid: d9ae4c75-57cc-4df6-ae91-afa50bc7ad28
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Crow-Armstrong
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '88'
+  uuid: 617e259b-0301-4af6-99c8-18203e224c9b
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Holliday
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '89'
+  uuid: 79c30985-b032-4307-8ead-e83f73041fca
+  subjects:
+  - entities:
+    - role: player
+      name: Spencer Torkelson
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '90'
+  uuid: 51d527bf-dc29-4737-b623-51286646bc9f
+  subjects:
+  - entities:
+    - role: player
+      name: Riley Greene
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '91'
+  uuid: a58d29a3-7995-4c08-af1d-20242a92d35f
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Chourio
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: '92'
+  uuid: 48200359-da61-4648-9c73-c485c40b1ff0
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Troy Melton
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '93'
+  uuid: 3323ae17-10d7-4a3b-9f35-97c0f9025f44
+  subjects:
+  - entities:
+    - role: player
+      name: Elly De La Cruz
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '94'
+  uuid: 20e6859c-0e29-4ed0-b526-6a3651df30fa
+  subjects:
+  - entities:
+    - role: player
+      name: Kris Bryant
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: '95'
+  uuid: 80f74eb8-659f-44b5-8abb-56139a8a1b5a
+  subjects:
+  - entities:
+    - role: player
+      name: Edgar Quero
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: '96'
+  uuid: a326100d-bab8-41bc-b1b7-a62ed6b2a0f2
+  subjects:
+  - entities:
+    - role: player
+      name: Alec Burleson
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: '97'
+  uuid: 4a838d47-9814-48a9-a31d-b2649372dfa8
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Connelly Early
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '98'
+  uuid: 5444317d-5430-4066-add2-c6404bc07aa6
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Cam Schlittler
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '99'
+  uuid: 5066ae9e-102c-4958-a7b8-48ca340d24dd
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Jimmy Crooks
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: '100'
+  uuid: 2309ec5d-ab5d-4d66-a19a-128be4c24645
+  subjects:
+  - entities:
+    - role: player
+      name: Fernando Tatis Jr.
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: '101'
+  uuid: 173cddb5-9096-47e4-8b50-692c835a8522
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Carson Williams
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: '102'
+  uuid: 925a9063-798a-48f6-9ce5-9dd55a0358f7
+  subjects:
+  - entities:
+    - role: player
+      name: Gabriel Moreno
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: '103'
+  uuid: 1f1576a2-372f-48fc-a802-9f5e7f70414d
+  subjects:
+  - entities:
+    - role: player
+      name: Anthony Volpe
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '104'
+  uuid: 2b0b360a-481f-4779-929a-1f7f46aecf1a
+  subjects:
+  - entities:
+    - role: player
+      name: Zack Wheeler
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: '105'
+  uuid: 91004522-df73-42db-8c1b-723bf1ad9aa1
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Harper
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: '106'
+  uuid: 1a7971f3-213f-4f18-97eb-240db2c45433
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Will Banfield
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: '107'
+  uuid: 24c59015-9d28-4b02-aa81-02e54fbb8739
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob deGrom
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: '108'
+  uuid: ef2ddfe0-cda0-4e0f-9dfe-bf6ba490d262
+  subjects:
+  - entities:
+    - role: player
+      name: Wyatt Langford
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: '109'
+  uuid: 1604b052-44f3-4f50-bd39-ea210a9e913f
+  subjects:
+  - entities:
+    - role: player
+      name: Byron Buxton
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: '110'
+  uuid: 9c64bfaf-f505-4d31-975c-ce89a425d888
+  subjects:
+  - entities:
+    - role: player
+      name: Jasson Domínguez
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '111'
+  uuid: 899f7565-b30d-4686-b8de-5b5702357188
+  subjects:
+  - entities:
+    - role: player
+      name: Vladimir Guerrero Jr.
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '112'
+  uuid: 87fcbb57-b5df-4a7e-8b2f-db449fe248bc
+  subjects:
+  - entities:
+    - role: player
+      name: Carlos Correa
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '113'
+  uuid: b6e9899c-4234-4efa-9497-b4ad9d776838
+  subjects:
+  - entities:
+    - role: player
+      name: Isaac Collins
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: '114'
+  uuid: d6587dac-162d-44b0-8ced-ed7b71f3fdbf
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Arraez
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: '115'
+  uuid: bbd81b59-fb0e-45d1-b5c1-4787d0dfd700
+  subjects:
+  - entities:
+    - role: player
+      name: Bryson Stott
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: '116'
+  uuid: a7e728a5-bd59-41b2-b8c4-007bb62cd74e
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Kurtz
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: '117'
+  uuid: 7e2a873a-7d3c-46c2-b495-1a411bc9a086
+  subjects:
+  - entities:
+    - role: player
+      name: Seiya Suzuki
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '118'
+  uuid: 07e9c1b5-9f68-4e3b-972e-1cb3cba63670
+  subjects:
+  - entities:
+    - role: player
+      name: Ketel Marte
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: '119'
+  uuid: 0d26f436-0938-4828-bb7e-1376933b9e1b
+  subjects:
+  - entities:
+    - role: player
+      name: Kodai Senga
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '120'
+  uuid: a21cb7f1-5b8e-4a5b-a2eb-50d71f933bed
+  subjects:
+  - entities:
+    - role: player
+      name: Xander Bogaerts
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: '121'
+  uuid: a5360dea-bc37-44a5-a75b-ba7ac85209b7
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Heriberto Hernández
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: '122'
+  uuid: 64676f4c-b82d-4b94-a50a-a86a655b7918
+  subjects:
+  - entities:
+    - role: player
+      name: Max Fried
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '123'
+  uuid: 3020235a-453f-4587-bfc1-55788e84afa0
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Carson Whisenhunt
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '124'
+  uuid: 717cc5e7-c91d-4a24-8bd2-7f64d2bace42
+  subjects:
+  - entities:
+    - role: player
+      name: Mason Miller
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: '125'
+  uuid: 67c9bdc4-43d6-4d35-a3b4-b72e2a6ae407
+  subjects:
+  - entities:
+    - role: player
+      name: George Springer
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '126'
+  uuid: 3788d380-38be-4b16-b8c3-5c3ecece2a8f
+  subjects:
+  - entities:
+    - role: player
+      name: Corey Seager
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: '127'
+  uuid: 72044b93-b7d0-48e2-bcfd-726b5a2aea6d
+  subjects:
+  - entities:
+    - role: player
+      name: Corbin Carroll
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: '128'
+  uuid: 563aa0bb-2eba-4bbe-ac3e-79917bdaec25
+  subjects:
+  - entities:
+    - role: player
+      name: Spencer Schwellenbach
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: '129'
+  uuid: b94d0466-aa1e-4748-8b54-23fc1abb33cf
+  subjects:
+  - entities:
+    - role: player
+      name: Brooks Lee
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: '130'
+  uuid: 22cf6da8-aff1-4eb5-83e0-f89387c7a196
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Cody Freeman
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: '131'
+  uuid: 0a2ef82f-7ec7-4401-9d6d-6d44d18e5350
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Trey Yesavage
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '132'
+  uuid: 6effc47b-d53b-4f59-934b-8c52e6fbac8d
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Karros
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: '133'
+  uuid: a249e953-562e-403b-a12f-e16e29098175
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Colby Thomas
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: '134'
+  uuid: 6fe92afe-d4d9-4888-8b97-72447ebb7b73
+  subjects:
+  - entities:
+    - role: player
+      name: Garrett Crochet
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '135'
+  uuid: 0f9e4f9c-06c5-43af-8ee2-77cbeceb43cf
+  subjects:
+  - entities:
+    - role: player
+      name: Coby Mayo
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '136'
+  uuid: 464b6c7a-ce65-4c4d-a650-b0fa361a5086
+  subjects:
+  - entities:
+    - role: player
+      name: Giancarlo Stanton
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '137'
+  uuid: 012b6780-d0e0-44f8-b816-ad6c970425ce
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Zach Cole
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '138'
+  uuid: a018314a-c950-4a98-a5d1-71414afde5df
+  subjects:
+  - entities:
+    - role: player
+      name: Hyeseong Kim
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '139'
+  uuid: 3dd5fece-81bb-4576-8ae3-3017bd91fa00
+  subjects:
+  - entities:
+    - role: player
+      name: Trea Turner
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: '140'
+  uuid: 5e974bb7-6996-4c5c-9320-a2bffd2b186d
+  subjects:
+  - entities:
+    - role: player
+      name: Manny Machado
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: '141'
+  uuid: 1b296e80-2d99-4653-86b3-b9e7cec61205
+  subjects:
+  - entities:
+    - role: player
+      name: Will Smith
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '142'
+  uuid: a71f4cd8-db99-4c2d-a57c-5ec49b9c2913
+  subjects:
+  - entities:
+    - role: player
+      name: Ozzie Albies
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: '143'
+  uuid: 60b2b335-9290-4166-8b69-1512886fc81e
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Shinnosuke Ogasawara
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: '144'
+  uuid: afce1646-3c49-4f9a-a177-7d87c74c4c2c
+  subjects:
+  - entities:
+    - role: player
+      name: Adley Rutschman
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: '145'
+  uuid: c646a389-f1c0-4fff-b831-6ecea501b48f
+  subjects:
+  - entities:
+    - role: player
+      name: Junior Caminero
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: '146'
+  uuid: 21cc3b16-8ae8-4595-ac74-9ad0d89e8166
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Otto Kemp
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: '147'
+  uuid: 4d9ace7f-ccd7-4fe2-83f0-333a4d6193eb
+  subjects:
+  - entities:
+    - role: player
+      name: Andrés Giménez
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '148'
+  uuid: db0f8984-ca53-42c1-a33c-93a849ce043b
+  subjects:
+  - entities:
+    - role: player
+      name: Mick Abel
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: '149'
+  uuid: 476b7a71-0c1b-48a7-b208-df990b06ee26
+  subjects:
+  - entities:
+    - role: player
+      name: Bo Bichette
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '150'
+  uuid: 5082bbd8-642e-40a0-94c0-887b5b5e126d
+  subjects:
+  - entities:
+    - role: player
+      name: Dalton Rushing
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: '151'
+  uuid: 178b91e1-7812-474a-a202-2c4f48c9f8ea
+  subjects:
+  - entities:
+    - role: player
+      name: Geraldo Perdomo
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: '152'
+  uuid: 0a4898c5-3e4b-40ec-a326-cb01a641301a
+  subjects:
+  - entities:
+    - role: player
+      name: Brent Rooker
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: '153'
+  uuid: 2befe8d3-0a5a-494c-a321-0ef05a683c2f
+  subjects:
+  - entities:
+    - role: player
+      name: Justin Verlander
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '154'
+  uuid: 3e62df31-6bda-495a-879b-0a90787f392c
+  subjects:
+  - entities:
+    - role: player
+      name: Freddy Peralta
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: '155'
+  uuid: 0f0250a0-d929-471b-a350-9c28a3eac136
+  subjects:
+  - entities:
+    - role: player
+      name: Dylan Crews
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: '156'
+  uuid: 4c01a614-9460-4595-9632-dffa75887794
+  subjects:
+  - entities:
+    - role: player
+      name: James Wood
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: '157'
+  uuid: 4e047caf-0d0f-4e4f-b4d4-818444e2594c
+  subjects:
+  - entities:
+    - role: player
+      name: Tyler Soderstrom
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: '158'
+  uuid: 3f46fe2f-e312-4212-9c11-38a1fa0f5b21
+  subjects:
+  - entities:
+    - role: player
+      name: Willy Adames
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '159'
+  uuid: d1a4748c-98f9-4ff4-8b71-0c6c01d655f6
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Jobe
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: '160'
+  uuid: 0b84b60e-d3d7-4082-b546-cb12c7357b55
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Brady House
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: '161'
+  uuid: a1757c60-31fc-4de6-9d04-482e58f44275
+  subjects:
+  - entities:
+    - role: player
+      name: Ezequiel Tovar
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: '162'
+  uuid: f7510d6c-556e-4d38-978d-763dd89ddfbd
+  subjects:
+  - entities:
+    - role: player
+      name: CJ Abrams
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: '163'
+  uuid: 9c8fd1a8-35c2-44d9-bf58-51545cf135ac
+  subjects:
+  - entities:
+    - role: player
+      name: Adolis García
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: '164'
+  uuid: 9b64c1e1-4bcc-413c-a615-66ceb010c5cb
+  subjects:
+  - entities:
+    - role: player
+      name: Zac Gallen
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: '165'
+  uuid: cc1af2ea-6992-4dd6-88be-cb6e42b328fa
+  subjects:
+  - entities:
+    - role: player
+      name: Carlos Rodón
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '166'
+  uuid: 6512688e-a7d4-4847-9d77-8c073cc338ab
+  subjects:
+  - entities:
+    - role: player
+      name: Logan Webb
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '167'
+  uuid: 239bc74e-e34a-4911-841a-d7fdbad36d80
+  subjects:
+  - entities:
+    - role: player
+      name: Kristian Campbell
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '168'
+  uuid: 287d10e5-b89a-4e6e-b347-62278f8317c0
+  subjects:
+  - entities:
+    - role: player
+      name: Brice Turang
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: '169'
+  uuid: e403918f-7f7a-423c-a23e-74f5225783be
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Mason Barnett
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: '170'
+  uuid: cb60d467-98bf-452b-9673-96225ad4c6d6
+  subjects:
+  - entities:
+    - role: player
+      name: Brandon Lowe
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: '171'
+  uuid: 41577ea5-2dfe-4285-8d84-a1058f0e0e3e
+  subjects:
+  - entities:
+    - role: player
+      name: MacKenzie Gore
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: '172'
+  uuid: 615817dc-b9e6-454b-8b6c-4f45003198cd
+  subjects:
+  - entities:
+    - role: player
+      name: Gerrit Cole
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '173'
+  uuid: 1b0b2654-b8ae-4746-8cf8-d5a4620450fe
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Wilson
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: '174'
+  uuid: f72fc02d-dd8e-4da4-90d7-d9b83073bb8b
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Drew Gilbert
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '175'
+  uuid: b7116031-7555-4b67-ad2e-8db5e5245fe9
+  subjects:
+  - entities:
+    - role: player
+      name: Nico Hoerner
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: '176'
+  uuid: c9500e01-1ecf-4540-9ef9-4d25ee3d7353
+  subjects:
+  - entities:
+    - role: player
+      name: Chris Bassitt
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '177'
+  uuid: df6cb2ac-b587-411c-a7cd-ef4bc185ae0b
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Merrill
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: '178'
+  uuid: 522722c7-9b19-48ff-b8a5-3a363780ab8e
+  subjects:
+  - entities:
+    - role: player
+      name: Paul Goldschmidt
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: '179'
+  uuid: a0c6a22c-8c86-426d-9e85-5b08cacab9cd
+  subjects:
+  - entities:
+    - role: player
+      name: Rafael Devers
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: '180'
+  uuid: 247616f3-05a7-43c4-ac4c-6b1507bb3f9f
+  subjects:
+  - entities:
+    - role: player
+      name: Alec Bohm
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: '181'
+  uuid: c798e026-ed79-4d5f-a408-d3dc52fa4877
+  subjects:
+  - entities:
+    - role: player
+      name: William Contreras
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: '182'
+  uuid: 3d227f8f-9f7b-4477-b1c1-fbe7c0ab8db5
+  subjects:
+  - entities:
+    - role: player
+      name: Mickey Moniak
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: '183'
+  uuid: bbb18af7-3c5a-467e-a647-97ef0127eb30
+  subjects:
+  - entities:
+    - role: player
+      name: Royce Lewis
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: '184'
+  uuid: 569012bc-0c1d-4f66-8b64-3a8afeb6b8d5
+  subjects:
+  - entities:
+    - role: player
+      name: Michael Harris II
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: '185'
+  uuid: fbf4f771-e2e8-4393-ad5a-ad51bd18e401
+  subjects:
+  - entities:
+    - role: player
+      name: Jonathan Aranda
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: '186'
+  uuid: 43a60863-a2c4-4f5c-bfae-f30e89980a6f
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Yanquiel Fernández
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: '187'
+  uuid: 73e061dd-54c8-4888-9f36-1c6a9dcf1c6d
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Maximo Acosta
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: '188'
+  uuid: 02ee4ed2-3bf2-430f-9aa8-51cc0947b3e8
+  subjects:
+  - entities:
+    - role: player
+      name: Carlos Narváez
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '189'
+  uuid: 8114af49-5137-44ec-9663-f68049afa938
+  subjects:
+  - entities:
+    - role: player
+      name: Max Scherzer
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: '190'
+  uuid: eff40768-386a-415a-b8e1-3cf5f2ae68f9
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Grant Taylor
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: '191'
+  uuid: 046c84e9-b282-4458-ab16-267871d605f7
+  subjects:
+  - entities:
+    - role: player
+      name: Sal Frelick
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: '192'
+  uuid: 28e30d13-62fb-42ad-9c91-ee2cc356fa34
+  subjects:
+  - entities:
+    - role: player
+      name: Marcus Semien
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: '193'
+  uuid: 8d5ced82-b6e7-4551-8459-42065f3fc075
+  subjects:
+  - entities:
+    - role: player
+      name: Cristopher Sánchez
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: '194'
+  uuid: f2c15e25-ba05-4909-8b39-fbcfd752a7a3
+  subjects:
+  - entities:
+    - role: player
+      name: Cam Smith
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: '195'
+  uuid: 8ff2fd27-72f0-492b-9725-70a1d7fbc19a
+  subjects:
+  - entities:
+    - role: player
+      name: Lawrence Butler
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: '196'
+  uuid: 2a9e6fc0-95a3-48d0-9730-ac236272a816
+  rookie_card: true
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Morales
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: '197'
+  uuid: 1183512f-48e2-4085-80f6-53d979a061d1
+  subjects:
+  - entities:
+    - role: player
+      name: Oneil Cruz
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: '198'
+  uuid: f9cff11f-4d5c-4355-a5e8-9bf8df54e043
+  subjects:
+  - entities:
+    - role: player
+      name: Jarren Duran
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: '199'
+  uuid: 8913539e-74e1-4a98-8b30-ecbbe5197835
+  subjects:
+  - entities:
+    - role: player
+      name: Eugenio Suárez
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: '200'
+  uuid: 4af49140-bd42-4bec-b61b-1316997c02c0
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Schwarber
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 

--- a/data/baseball/2026-topps-chrome-black/checklists/chrome-black-autographs.yaml
+++ b/data/baseball/2026-topps-chrome-black/checklists/chrome-black-autographs.yaml
@@ -1,0 +1,1110 @@
+- number: CBA-AF
+  uuid: 1b2fb0c0-9ac9-447f-9f6c-b9c3f3b24176
+  subjects:
+  - entities:
+    - role: player
+      name: Alex Freeland
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: CBA-AGI
+  uuid: 1eaaf327-34c3-4817-b315-9c9786079558
+  subjects:
+  - entities:
+    - role: player
+      name: Andrés Giménez
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: CBA-AJ
+  uuid: 67f9b0cd-71a8-410c-8a18-416672deaa71
+  subjects:
+  - entities:
+    - role: player
+      name: Aaron Judge
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: CBA-AM
+  uuid: b9b72f16-8d22-4dbb-9ff1-f2c1878a0db0
+  subjects:
+  - entities:
+    - role: player
+      name: Andrew McCutchen
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: CBA-AP
+  uuid: ddd70c78-6124-40df-b059-2ec179a24479
+  subjects:
+  - entities:
+    - role: player
+      name: Albert Pujols
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: CBA-ARA
+  uuid: 165069e3-3ae9-4812-bac9-2bd69bcc2920
+  subjects:
+  - entities:
+    - role: player
+      name: Agustín Ramírez
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: CBA-BB
+  uuid: 30eefb9b-3ff5-49f2-a3dc-fcc693925f16
+  subjects:
+  - entities:
+    - role: player
+      name: Barry Bonds
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: CBA-BBU
+  uuid: b825159b-5a01-46ec-a8da-a34449d4d0ab
+  subjects:
+  - entities:
+    - role: player
+      name: Byron Buxton
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: CBA-BC
+  uuid: c90a3111-c88c-43b7-972a-d622ecafff44
+  subjects:
+  - entities:
+    - role: player
+      name: Bubba Chandler
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: CBA-BE
+  uuid: 68cb103b-444e-4ee7-9c65-10d7824a44be
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Eldridge
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: CBA-BH
+  uuid: 86540ca8-088b-4b22-8f9e-56ad90872f6d
+  subjects:
+  - entities:
+    - role: player
+      name: Brady House
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: CBA-BM
+  uuid: 3c8c6849-9e90-4957-a6dc-fe1ceb50717d
+  subjects:
+  - entities:
+    - role: player
+      name: Brice Matthews
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: CBA-BR
+  uuid: 4a3c27cb-3cba-461d-b674-26919ddca925
+  subjects:
+  - entities:
+    - role: player
+      name: Brent Rooker
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: CBA-BT
+  uuid: 1f3c31c1-cfda-460a-8d38-da2ae4764649
+  subjects:
+  - entities:
+    - role: player
+      name: Brice Turang
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: CBA-BW
+  uuid: 55bb02ee-fd8b-47a4-9f78-02ec6b99d27a
+  subjects:
+  - entities:
+    - role: player
+      name: Bryan Woo
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: CBA-BZ
+  uuid: 4fa3d5e3-ae50-4e82-82d5-6561888a48fa
+  subjects:
+  - entities:
+    - role: player
+      name: Barry Zito
+      ref: 
+    - role: team
+      name: Oakland Athletics
+      ref: 
+- number: CBA-CA
+  uuid: 760000a1-360b-48a8-89f3-8094d56d0821
+  subjects:
+  - entities:
+    - role: player
+      name: CJ Abrams
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: CBA-CAG
+  uuid: d87be9a7-e58c-409b-850f-1128fac66a48
+  subjects:
+  - entities:
+    - role: player
+      name: Jac Caglianone
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: CBA-CB
+  uuid: 0f267285-954d-4270-82f5-a5804dc76805
+  subjects:
+  - entities:
+    - role: player
+      name: Chase Burns
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: CBA-CBL
+  uuid: 498473ea-3689-4a67-9c88-6779af160dfc
+  subjects:
+  - entities:
+    - role: player
+      name: Charlie Blackmon
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: CBA-CC
+  uuid: 03cea6d3-a389-4178-810a-47377b835094
+  subjects:
+  - entities:
+    - role: player
+      name: Corbin Carroll
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: CBA-CD
+  uuid: 525e54d0-48a9-40ac-ac2b-669c1c9919dc
+  subjects:
+  - entities:
+    - role: player
+      name: Chase Dollander
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: CBA-CDE
+  uuid: 94750be9-6738-4b38-813b-068a434f1485
+  subjects:
+  - entities:
+    - role: player
+      name: Chase DeLauter
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: CBA-CF
+  uuid: 22a51994-b024-46b7-bc65-efb5279d243a
+  subjects:
+  - entities:
+    - role: player
+      name: Cody Freeman
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: CBA-CH
+  uuid: e8813b26-880b-48a5-81c8-b1647c59cc8b
+  subjects:
+  - entities:
+    - role: player
+      name: Cade Horton
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: CBA-CJ
+  uuid: 40fa49e5-9344-49c2-961d-070a58b48482
+  subjects:
+  - entities:
+    - role: player
+      name: C.J. Kayfus
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: CBA-CM
+  uuid: 22cc091d-9c8d-4fe5-a6aa-b1a4ce84d38a
+  subjects:
+  - entities:
+    - role: player
+      name: Christian Moore
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: CBA-CME
+  uuid: e0542de1-b0db-482e-9b57-ac683b1b9c17
+  subjects:
+  - entities:
+    - role: player
+      name: Chase Meidroth
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: CBA-CMO
+  uuid: 59994301-8d27-4982-aded-a69ad670c1bd
+  subjects:
+  - entities:
+    - role: player
+      name: Colson Montgomery
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: CBA-CR
+  uuid: ad428302-3db6-46d4-8cf2-5ebd5f7fc235
+  subjects:
+  - entities:
+    - role: player
+      name: Cal Raleigh
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: CBA-CT
+  uuid: a6489a90-99e2-47c9-a4bf-371dab4dbf9a
+  subjects:
+  - entities:
+    - role: player
+      name: Colby Thomas
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: CBA-CWH
+  uuid: 8cdc2456-7393-41f4-87e6-da49d1250b77
+  subjects:
+  - entities:
+    - role: player
+      name: Carson Whisenhunt
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: CBA-CY
+  uuid: 574a7951-9fbf-4e42-82d0-a5d90b3b6a3c
+  subjects:
+  - entities:
+    - role: player
+      name: Cole Young
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: CBA-CYE
+  uuid: 5edf6ab9-c0d5-486a-96c1-64917e056f7b
+  subjects:
+  - entities:
+    - role: player
+      name: Christian Yelich
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: CBA-DB
+  uuid: d8138233-de8a-400c-8e17-484ad5223545
+  subjects:
+  - entities:
+    - role: player
+      name: Drake Baldwin
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: CBA-DBE
+  uuid: dfb861cb-8e1f-4d93-8649-37b80fe12414
+  subjects:
+  - entities:
+    - role: player
+      name: Dylan Beavers
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: CBA-DF
+  uuid: 792a1833-02ae-450f-885f-7bc41959392b
+  subjects:
+  - entities:
+    - role: player
+      name: Didier Fuentes
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: CBA-DG
+  uuid: c82676af-a5e4-4021-90c6-ac95dc69ec62
+  subjects:
+  - entities:
+    - role: player
+      name: Dwight Gooden
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: CBA-DGI
+  uuid: be91a737-7af2-4f53-b43c-abb47dd2877a
+  subjects:
+  - entities:
+    - role: player
+      name: Drew Gilbert
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: CBA-DJ
+  uuid: fac61549-08bf-4e54-aa47-61d49652e6cf
+  subjects:
+  - entities:
+    - role: player
+      name: Derek Jeter
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: CBA-DL
+  uuid: 8f3c97a0-1fab-4859-bebf-db35141fe00a
+  subjects:
+  - entities:
+    - role: player
+      name: Derrek Lee
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: CBA-DR
+  uuid: f4025f6f-69a4-49f5-86e7-7027364f948b
+  subjects:
+  - entities:
+    - role: player
+      name: Dalton Rushing
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: CBA-DW
+  uuid: 50fb14ee-cb2b-4353-9c6c-ee5ba02ab930
+  subjects:
+  - entities:
+    - role: player
+      name: Dave Winfield
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: CBA-ED
+  uuid: e165e08c-9de5-4551-93ba-55b7c443a433
+  subjects:
+  - entities:
+    - role: player
+      name: Elly De La Cruz
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: CBA-EM
+  uuid: 377b4fa3-6433-4910-a6dc-0577d99169ae
+  subjects:
+  - entities:
+    - role: player
+      name: Eddie Murray
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: CBA-EQ
+  uuid: 86195cca-b456-4997-b199-374f75e42058
+  subjects:
+  - entities:
+    - role: player
+      name: Edgar Quero
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: CBA-FT
+  uuid: d56d526a-cbd3-48d9-bcce-68a75af0a943
+  subjects:
+  - entities:
+    - role: player
+      name: Frank Thomas
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: CBA-FTJ
+  uuid: fbc040d5-9ef1-400b-841c-87b4ed5dc501
+  subjects:
+  - entities:
+    - role: player
+      name: Fernando Tatis Jr.
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: CBA-HK
+  uuid: 0d452b0b-86ab-4a5f-8333-983dc6d123c7
+  subjects:
+  - entities:
+    - role: player
+      name: Hyeseong Kim
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: CBA-HP
+  uuid: 658e5804-6f2b-40de-a151-908237625c2d
+  subjects:
+  - entities:
+    - role: player
+      name: Hunter Pence
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: CBA-HR
+  uuid: 9cf31873-d173-4923-88f9-2620d247ef51
+  subjects:
+  - entities:
+    - role: player
+      name: Hanley Ramirez
+      ref: 
+    - role: team
+      name: Florida Marlins
+      ref: 
+- number: CBA-IC
+  uuid: d165d2db-ecb3-4205-8cc2-8275ad9ef4af
+  subjects:
+  - entities:
+    - role: player
+      name: Isaac Collins
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: CBA-JA
+  uuid: b8eeb7c2-3259-493e-ab2c-6810c36e1c7e
+  subjects:
+  - entities:
+    - role: player
+      name: Jonathan Aranda
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: CBA-JB
+  uuid: 0776c13d-83e4-42f5-8ee8-e2c7d314c855
+  subjects:
+  - entities:
+    - role: player
+      name: Johnny Bench
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: CBA-JCA
+  uuid: 2fac083a-7758-4785-b019-edd358aa98df
+  subjects:
+  - entities:
+    - role: player
+      name: Jose Canseco
+      ref: 
+    - role: team
+      name: Oakland Athletics
+      ref: 
+- number: CBA-JCJ
+  uuid: 31751525-a786-447f-adce-46d0fabf4baa
+  subjects:
+  - entities:
+    - role: player
+      name: Jazz Chisholm Jr.
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: CBA-JD
+  uuid: 6c2190e3-29ea-4991-832b-1dc84a50e9b0
+  subjects:
+  - entities:
+    - role: player
+      name: Jasson Domínguez
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: CBA-JDA
+  uuid: 03becbfa-7402-4653-8ff5-ced70062b278
+  subjects:
+  - entities:
+    - role: player
+      name: Johnny Damon
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: CBA-JI
+  uuid: cfd090a3-aad5-4894-924d-88223be9bdea
+  subjects:
+  - entities:
+    - role: player
+      name: Jimmy Crooks
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: CBA-JLE
+  uuid: 24fc2783-cba6-4938-9c5c-9d9c30488c6d
+  subjects:
+  - entities:
+    - role: player
+      name: Jack Leiter
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: CBA-JM
+  uuid: 690107fd-7a55-45dc-aaec-a9a6357c10ff
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Melton
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: CBA-JMA
+  uuid: b830ae07-8be9-4cbe-b21b-57a5c1da9d84
+  subjects:
+  - entities:
+    - role: player
+      name: Jakob Marsee
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: CBA-JMI
+  uuid: 1891755b-adbb-45b8-801e-34957898b14a
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Misiorowski
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: CBA-JR
+  uuid: 8e2cf926-5bfe-4dd1-9ae5-7e72ad01e549
+  subjects:
+  - entities:
+    - role: player
+      name: Julio Rodríguez
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: CBA-JRE
+  uuid: 73095546-dc44-4938-99ee-61e2e901c8ec
+  subjects:
+  - entities:
+    - role: player
+      name: José Reyes
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: CBA-JRO
+  uuid: 54e1a436-3746-44bd-ad82-7a14c277d7c1
+  subjects:
+  - entities:
+    - role: player
+      name: Jimmy Rollins
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: CBA-JS
+  uuid: 5cd9bf6e-6173-40c0-a72e-1063687eb577
+  subjects:
+  - entities:
+    - role: player
+      name: Johan Santana
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: CBA-JT
+  uuid: 92ecd849-4736-4a72-9c1e-83941623c3b4
+  subjects:
+  - entities:
+    - role: player
+      name: Jonah Tong
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: CBA-JWE
+  uuid: a4e10745-fcae-4991-b661-5f170329448b
+  subjects:
+  - entities:
+    - role: player
+      name: Jordan Westburg
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: CBA-KCA
+  uuid: 80e5331b-43ee-48ff-8881-a2ef99026700
+  subjects:
+  - entities:
+    - role: player
+      name: Kristian Campbell
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: CBA-KK
+  uuid: 689dcc92-ec83-4a45-b513-617e17d2c9c2
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Karros
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: CBA-KO
+  uuid: 4c81f0e2-0ceb-4005-82c8-a619cf912c61
+  subjects:
+  - entities:
+    - role: player
+      name: Kazuma Okamoto
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: CBA-KS
+  uuid: 4f0e9a1a-9a90-4159-8c64-6b3a3421fc9c
+  subjects:
+  - entities:
+    - role: player
+      name: Kodai Senga
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: CBA-KW
+  uuid: 285a2373-0432-466a-83bd-cc3b97bc907b
+  subjects:
+  - entities:
+    - role: player
+      name: Kerry Wood
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: CBA-LA
+  uuid: 25f3afa1-c3a2-4d6c-8904-9698b2351de7
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Arraez
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: CBA-LG
+  uuid: b205c168-9078-4c3a-82cd-9b4ef46845e4
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Gonzalez
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: CBA-LW
+  uuid: f4d818eb-fea5-4504-84dd-87704065b936
+  subjects:
+  - entities:
+    - role: player
+      name: Logan Webb
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: CBA-LWA
+  uuid: b0a2d0f4-ea5c-4fb6-9558-88c11afc4ddb
+  subjects:
+  - entities:
+    - role: player
+      name: Larry Walker
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: CBA-MHA
+  uuid: 690ff453-e818-49fd-8049-055142456003
+  subjects:
+  - entities:
+    - role: player
+      name: Michael Harris II
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: CBA-MM
+  uuid: cb0e0b8d-58e0-4c46-af43-8fb802a1ee93
+  subjects:
+  - entities:
+    - role: player
+      name: Mark McGwire
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: CBA-MT
+  uuid: eb999da2-4918-4129-aeb2-b042fc2cb959
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Trout
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: CBA-MU
+  uuid: 02e2e5cb-b87d-48f1-b5c5-3293622de084
+  subjects:
+  - entities:
+    - role: player
+      name: Munetaka Murakami
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: CBA-NC
+  uuid: 8529b89b-292c-4c75-89fc-430fcee3242d
+  subjects:
+  - entities:
+    - role: player
+      name: Nathan Church
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: CBA-NK
+  uuid: f4b2de6c-6308-4c02-8845-031471bc5725
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Kurtz
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: CBA-NM
+  uuid: 597ef7a9-57fe-4d71-a5ad-9e0e9ea90f24
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan McLean
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: CBA-OC
+  uuid: f7e60a63-a46b-41fe-ad66-83edde05ab28
+  subjects:
+  - entities:
+    - role: player
+      name: Owen Caissie
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: CBA-OH
+  uuid: 65956dc1-e0e2-4abc-9a79-9054b2a65578
+  subjects:
+  - entities:
+    - role: player
+      name: Orlando Hernandez
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: CBA-OK
+  uuid: f9f75b2b-6c6b-4378-bed3-5286add0ac53
+  subjects:
+  - entities:
+    - role: player
+      name: Otto Kemp
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: CBA-PO
+  uuid: 9139bfa3-df48-4834-8d1e-a35734b0d5ec
+  subjects:
+  - entities:
+    - role: player
+      name: Paul O'Neill
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: CBA-PS
+  uuid: 37ba00ed-7203-40b8-b95d-887fe34095e6
+  subjects:
+  - entities:
+    - role: player
+      name: Paul Skenes
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: CBA-RA
+  uuid: 03c9fadd-ef57-47e6-8b58-e9194b81f457
+  subjects:
+  - entities:
+    - role: player
+      name: Roman Anthony
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: CBA-RAJ
+  uuid: 2abf9788-67f6-4195-9b44-45180f01a2c6
+  subjects:
+  - entities:
+    - role: player
+      name: Ronald Acuña Jr.
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: CBA-RAR
+  uuid: fba2b6b7-8b83-4cef-bc70-7255e29d15d1
+  subjects:
+  - entities:
+    - role: player
+      name: Randy Arozarena
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: CBA-RRI
+  uuid: b7fa910d-8264-42cf-8398-0a185a15495b
+  subjects:
+  - entities:
+    - role: player
+      name: Ryan Ritter
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: CBA-RS
+  uuid: b90f0efb-bbad-4824-aa46-d86a1ff44a85
+  subjects:
+  - entities:
+    - role: player
+      name: Roki Sasaki
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: CBA-SB
+  uuid: eab86b31-0092-4fb1-9228-a4ac602a03c6
+  subjects:
+  - entities:
+    - role: player
+      name: Samuel Basallo
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: CBA-SC
+  uuid: d45546ee-5013-4312-907c-745921adc11f
+  subjects:
+  - entities:
+    - role: player
+      name: Cam Schlittler
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: CBA-SK
+  uuid: 4363340f-bad2-4950-9a60-c4b12d124555
+  subjects:
+  - entities:
+    - role: player
+      name: Sandy Koufax
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: CBA-SOG
+  uuid: f93e4f17-29ee-46ee-85a3-83f31ca905b8
+  subjects:
+  - entities:
+    - role: player
+      name: Shinnosuke Ogasawara
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: CBA-SS
+  uuid: fcb54a6a-d3c0-40f7-abc2-661c80d08b63
+  subjects:
+  - entities:
+    - role: player
+      name: Sal Stewart
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: CBA-TI
+  uuid: 5264e2fa-a66a-461e-9d25-4b09bf361559
+  subjects:
+  - entities:
+    - role: player
+      name: Tatsuya Imai
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: CBA-TM
+  uuid: dbd98600-0aab-4846-9bf7-325cd3265848
+  subjects:
+  - entities:
+    - role: player
+      name: Troy Melton
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: CBA-TS
+  uuid: a23d30eb-1911-49fa-bf9a-72af69ad900a
+  subjects:
+  - entities:
+    - role: player
+      name: Ted Simmons
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: CBA-TY
+  uuid: 047b01d1-2d2d-4c4f-a039-48295ad03d36
+  subjects:
+  - entities:
+    - role: player
+      name: Trey Yesavage
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: CBA-VG
+  uuid: fccd7e18-7bfd-47b4-a13a-bca9f365a75c
+  subjects:
+  - entities:
+    - role: player
+      name: Vladimir Guerrero Jr.
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: CBA-VW
+  uuid: a6e774a3-e3f8-4393-8733-6807cf97cf04
+  subjects:
+  - entities:
+    - role: player
+      name: Vernon Wells
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: CBA-WB
+  uuid: c6a551fa-48a6-4613-b596-3257b33559fa
+  subjects:
+  - entities:
+    - role: player
+      name: Wade Boggs
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: CBA-WBE
+  uuid: 0473ce20-5351-4cab-8b25-402822718bc9
+  subjects:
+  - entities:
+    - role: player
+      name: Warming Bernabel
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: CBA-WC
+  uuid: 6e249fe8-cb9c-402f-a7dd-0067c950dd71
+  subjects:
+  - entities:
+    - role: player
+      name: Will Clark
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: CBA-YF
+  uuid: 0bc75266-fe15-41ab-8047-0af4187625f5
+  subjects:
+  - entities:
+    - role: player
+      name: Yanquiel Fernández
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: CBA-ZNE
+  uuid: a7f422d0-b750-48be-a1e6-47db7b99a2be
+  subjects:
+  - entities:
+    - role: player
+      name: Zach Neto
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 

--- a/data/baseball/2026-topps-chrome-black/checklists/damascus.yaml
+++ b/data/baseball/2026-topps-chrome-black/checklists/damascus.yaml
@@ -1,0 +1,300 @@
+- number: DAM-1
+  uuid: b4895b63-2038-404c-9082-b1e43a29094b
+  subjects:
+  - entities:
+    - role: player
+      name: Shohei Ohtani
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: DAM-2
+  uuid: 65ba6f34-d418-462a-9806-04b55bbe83f5
+  subjects:
+  - entities:
+    - role: player
+      name: Aaron Judge
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: DAM-3
+  uuid: 15690252-361c-4335-b109-a82ade8c9f4c
+  subjects:
+  - entities:
+    - role: player
+      name: Ronald Acuña Jr.
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: DAM-4
+  uuid: 9befdf96-7b72-45ff-b1d1-deb9ccb6f757
+  subjects:
+  - entities:
+    - role: player
+      name: Bobby Witt Jr.
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: DAM-5
+  uuid: 0ca19acc-17d7-463e-bf23-5eb9c43112c4
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: DAM-6
+  uuid: 3dc77330-40b8-48fe-8e74-d16f8e4ab1f5
+  subjects:
+  - entities:
+    - role: player
+      name: Cal Raleigh
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: DAM-7
+  uuid: fc0abde9-aed2-4832-9bab-535759d5ebbd
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Crow-Armstrong
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: DAM-8
+  uuid: a66d3b22-52fd-44f7-bf2c-7882668a4017
+  subjects:
+  - entities:
+    - role: player
+      name: Paul Skenes
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: DAM-9
+  uuid: 1d118c43-2150-4fb2-a214-f06512d55ddb
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Kurtz
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: DAM-10
+  uuid: 88b1cab9-2e14-4293-9167-bec51fc5890e
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Schwarber
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: DAM-11
+  uuid: ecc15113-d53e-4fc6-8940-61be8287bd51
+  subjects:
+  - entities:
+    - role: player
+      name: Fernando Tatis Jr.
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: DAM-12
+  uuid: 91647fa3-aff9-4dbe-b56b-a8dd040f33c4
+  subjects:
+  - entities:
+    - role: player
+      name: Francisco Lindor
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: DAM-13
+  uuid: 7d493a30-d012-461f-ba99-589b60f0e398
+  subjects:
+  - entities:
+    - role: player
+      name: Elly De La Cruz
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: DAM-14
+  uuid: 417bd20c-ce90-4780-ad34-1f5a64310ed0
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Harper
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: DAM-15
+  uuid: b80395ce-6e74-46e7-89bf-9375a02cb91e
+  subjects:
+  - entities:
+    - role: player
+      name: Vladimir Guerrero Jr.
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: DAM-16
+  uuid: 0d457358-a589-4d2b-8f38-8af476ae071c
+  subjects:
+  - entities:
+    - role: player
+      name: Tarik Skubal
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: DAM-17
+  uuid: dfa18504-d6bd-4170-9ce8-efba059b0075
+  subjects:
+  - entities:
+    - role: player
+      name: Jac Caglianone
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: DAM-18
+  uuid: beff7263-d10d-4494-a831-18b9bca47198
+  subjects:
+  - entities:
+    - role: player
+      name: Roman Anthony
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: DAM-19
+  uuid: 6d09a27d-5076-43a8-bae0-a3e01daf8e72
+  subjects:
+  - entities:
+    - role: player
+      name: Colson Montgomery
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: DAM-20
+  uuid: 9df54536-6edf-4368-a75e-eb63e4935459
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Teel
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: DAM-21
+  uuid: f0c2aff3-3436-4fe8-b696-68ca7a821888
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Misiorowski
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: DAM-22
+  uuid: 58dbcb2c-24eb-4dc6-95f7-07d5db6ea0ee
+  subjects:
+  - entities:
+    - role: player
+      name: Christian Moore
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: DAM-23
+  uuid: 97de07cd-4d60-4f34-98ce-a0352517a20f
+  subjects:
+  - entities:
+    - role: player
+      name: Chase Burns
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: DAM-24
+  uuid: 7f616930-8fe1-4d68-9098-2434158dfdfd
+  subjects:
+  - entities:
+    - role: player
+      name: Owen Caissie
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: DAM-25
+  uuid: c1641c0f-47d3-4625-83e9-6f1c793c8e51
+  subjects:
+  - entities:
+    - role: player
+      name: Samuel Basallo
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: DAM-26
+  uuid: 31f94147-40d5-48b3-bb83-6050882fa496
+  subjects:
+  - entities:
+    - role: player
+      name: Bubba Chandler
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: DAM-27
+  uuid: aec6989d-958d-44b9-939d-50e94d1327f0
+  subjects:
+  - entities:
+    - role: player
+      name: Sal Stewart
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: DAM-28
+  uuid: ac5718e3-84f2-4afb-8e39-a1ed418ebc53
+  subjects:
+  - entities:
+    - role: player
+      name: Harry Ford
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: DAM-30
+  uuid: f33c0cc4-feee-4b71-9698-e98f45d0b6f5
+  subjects:
+  - entities:
+    - role: player
+      name: Payton Tolle
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: DAM-31
+  uuid: d7ac4d3f-40ca-4462-a8e7-e40f9bcd53d4
+  subjects:
+  - entities:
+    - role: player
+      name: Carson Williams
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 

--- a/data/baseball/2026-topps-chrome-black/checklists/depth-of-darkness.yaml
+++ b/data/baseball/2026-topps-chrome-black/checklists/depth-of-darkness.yaml
@@ -1,0 +1,200 @@
+- number: DOD-1
+  uuid: '069d24bd-948d-46a9-ba88-2ae97d950511'
+  subjects:
+  - entities:
+    - role: player
+      name: Jac Caglianone
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: DOD-2
+  uuid: 628a201d-f58c-4ffa-8631-679bb5112373
+  subjects:
+  - entities:
+    - role: player
+      name: Roman Anthony
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: DOD-3
+  uuid: 6bb0e823-0ba6-4036-b542-43b720c4d877
+  subjects:
+  - entities:
+    - role: player
+      name: Colson Montgomery
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: DOD-4
+  uuid: 4a543006-7ae2-4d28-9407-041f42494fb3
+  subjects:
+  - entities:
+    - role: player
+      name: Samuel Basallo
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: DOD-5
+  uuid: 2dca9057-c4e6-4599-b258-6d39190c1c7a
+  subjects:
+  - entities:
+    - role: player
+      name: Bubba Chandler
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: DOD-6
+  uuid: cb26b309-a77c-498e-9851-1b0ec712f3f3
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Eldridge
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: DOD-7
+  uuid: 34283145-5fa9-40a2-83f4-6504075d9055
+  subjects:
+  - entities:
+    - role: player
+      name: Carson Williams
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: DOD-8
+  uuid: d291262d-4a5a-4272-933d-83dc6e78191a
+  subjects:
+  - entities:
+    - role: player
+      name: Shohei Ohtani
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: DOD-9
+  uuid: fee85f55-73f8-4829-bfe7-a9ff90eb67af
+  subjects:
+  - entities:
+    - role: player
+      name: Aaron Judge
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: DOD-10
+  uuid: 33bd7597-664e-496c-9498-2a0d06117c6d
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Harper
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: DOD-11
+  uuid: 25797dd6-ce5b-437a-8fdf-d086f7fbd966
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: DOD-12
+  uuid: 73c35887-4d78-48db-99e9-819af8df32b3
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Crow-Armstrong
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: DOD-13
+  uuid: 63b8f271-14a8-4b7a-af4e-78c8c17e4a1f
+  subjects:
+  - entities:
+    - role: player
+      name: Paul Skenes
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: DOD-14
+  uuid: 242bf08c-fb94-4109-9b66-a51d5e145642
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Trout
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: DOD-15
+  uuid: 57d06939-e533-4c76-b262-43a4eca0bd68
+  subjects:
+  - entities:
+    - role: player
+      name: Elly De La Cruz
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: DOD-16
+  uuid: f7d06133-3254-4c11-a163-a9b9323dc36e
+  subjects:
+  - entities:
+    - role: player
+      name: Cal Raleigh
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: DOD-17
+  uuid: 53e82e82-f7c0-4c56-a681-7469741a9c91
+  subjects:
+  - entities:
+    - role: player
+      name: Bobby Witt Jr.
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: DOD-18
+  uuid: aaf531b7-a03b-4614-adc4-051ca65bdb38
+  subjects:
+  - entities:
+    - role: player
+      name: Francisco Lindor
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: DOD-19
+  uuid: a1984862-868d-4d81-8e07-3baf35b962b4
+  subjects:
+  - entities:
+    - role: player
+      name: Ronald Acuña Jr.
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: DOD-20
+  uuid: f19dbe0b-aa02-4d88-9d26-0fe637b0bb8b
+  subjects:
+  - entities:
+    - role: player
+      name: Fernando Tatis Jr.
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 

--- a/data/baseball/2026-topps-chrome-black/checklists/home-field.yaml
+++ b/data/baseball/2026-topps-chrome-black/checklists/home-field.yaml
@@ -1,0 +1,200 @@
+- number: CBHA-1
+  uuid: 2a1c81e4-837b-4ed2-a92b-3afe048724fb
+  subjects:
+  - entities:
+    - role: player
+      name: Jac Caglianone
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: CBHA-2
+  uuid: b27d7e4a-f8ec-4299-8fe2-1d246e5b4fa7
+  subjects:
+  - entities:
+    - role: player
+      name: Roman Anthony
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: CBHA-3
+  uuid: 493e07e9-07c0-414c-86a1-436e19659ea6
+  subjects:
+  - entities:
+    - role: player
+      name: Aaron Judge
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: CBHA-4
+  uuid: 5b3a2a85-7509-47ed-886d-e7e80f9a7098
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Teel
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: CBHA-5
+  uuid: 23a02dc8-0a7c-4088-94c2-1ea31961ea5d
+  subjects:
+  - entities:
+    - role: player
+      name: Shohei Ohtani
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: CBHA-6
+  uuid: 60b9b5aa-6f38-496e-a365-851c4ec2ff82
+  subjects:
+  - entities:
+    - role: player
+      name: Harry Ford
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: CBHA-7
+  uuid: 06fa82ae-e2ea-4322-9ef5-e41cea0aaad6
+  subjects:
+  - entities:
+    - role: player
+      name: Bobby Witt Jr.
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: CBHA-8
+  uuid: 406437c7-f5fd-4724-8166-0760ed551153
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Crow-Armstrong
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: CBHA-9
+  uuid: 5e34e7ae-d658-449c-91bd-1a60f8dda455
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Harper
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: CBHA-10
+  uuid: cc8af6b1-d7d2-446e-8e1e-c51cc170c88b
+  subjects:
+  - entities:
+    - role: player
+      name: Trey Yesavage
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: CBHA-11
+  uuid: 258f6a7d-d338-4fc3-bcbf-b48f4f63561a
+  subjects:
+  - entities:
+    - role: player
+      name: Owen Caissie
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: CBHA-12
+  uuid: bf2946db-a91e-4f8a-90e9-bedbef1f61de
+  subjects:
+  - entities:
+    - role: player
+      name: Honus Wagner
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: CBHA-13
+  uuid: d6e3e8ae-7cb5-4d53-985d-e65e18936cba
+  subjects:
+  - entities:
+    - role: player
+      name: Bubba Chandler
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: CBHA-14
+  uuid: 23061070-929d-4f1a-afa5-a538048963cc
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Misiorowski
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: CBHA-15
+  uuid: 8f8de1ed-d59f-4a71-94ed-fffbe32a7294
+  subjects:
+  - entities:
+    - role: player
+      name: Samuel Basallo
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: CBHA-16
+  uuid: 739484e7-f1f0-4452-9556-ffede44025b2
+  subjects:
+  - entities:
+    - role: player
+      name: Chase Burns
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: CBHA-17
+  uuid: a897cbdc-837d-49ef-8cd4-a33789b82386
+  subjects:
+  - entities:
+    - role: player
+      name: Cal Raleigh
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: CBHA-18
+  uuid: 795525a1-f465-411f-8680-48d1b31cd79c
+  subjects:
+  - entities:
+    - role: player
+      name: Ken Griffey Jr.
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: CBHA-19
+  uuid: 2d914512-f3d8-426c-9bcc-38c94a930ab3
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Eldridge
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: CBHA-20
+  uuid: 1c6db5b9-2f03-401f-8bf1-0b6a96a77ba2
+  subjects:
+  - entities:
+    - role: player
+      name: Colson Montgomery
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 

--- a/data/baseball/2026-topps-chrome-black/checklists/ivory-autographs.yaml
+++ b/data/baseball/2026-topps-chrome-black/checklists/ivory-autographs.yaml
@@ -1,0 +1,360 @@
+- number: IVA-BB
+  uuid: a23a7a41-a897-4ba8-a030-af32f686f853
+  subjects:
+  - entities:
+    - role: player
+      name: Barry Bonds
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: IVA-BC
+  uuid: 807d7e33-3dec-487e-83f5-3b651938deed
+  subjects:
+  - entities:
+    - role: player
+      name: Bubba Chandler
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: IVA-CB
+  uuid: 371af2e7-47f2-4b7b-a3b2-f4d4fadea00d
+  subjects:
+  - entities:
+    - role: player
+      name: Chase Burns
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: IVA-CJ
+  uuid: 3eeb62ed-ee1e-425f-adfc-76aecbedbb40
+  subjects:
+  - entities:
+    - role: player
+      name: Chipper Jones
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: IVA-CM
+  uuid: 7fc2bacb-4e07-45d7-ac67-63bd8f4e35bf
+  subjects:
+  - entities:
+    - role: player
+      name: Christian Moore
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: IVA-CS
+  uuid: fac28303-abc7-413a-a624-1a10e12a0921
+  subjects:
+  - entities:
+    - role: player
+      name: CC Sabathia
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: IVA-DJ
+  uuid: 7453caa2-c51b-4005-ba35-20d3dd28c7da
+  subjects:
+  - entities:
+    - role: player
+      name: Derek Jeter
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: IVA-DM
+  uuid: c432b325-6df6-489e-9db7-b87bba201019
+  subjects:
+  - entities:
+    - role: player
+      name: Dale Murphy
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: IVA-DMA
+  uuid: d73ecab0-a676-4b5f-b17e-fdec92a8abdc
+  subjects:
+  - entities:
+    - role: player
+      name: Don Mattingly
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: IVA-DO
+  uuid: 1981a62d-3eab-43b2-847e-9d2a849dc710
+  subjects:
+  - entities:
+    - role: player
+      name: David Ortiz
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: IVA-FT
+  uuid: 5173d808-f187-47b1-a21a-58929d84d9b9
+  subjects:
+  - entities:
+    - role: player
+      name: Fernando Tatis Jr.
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: IVA-GB
+  uuid: 97b3d2fd-96cb-458e-83c4-d6d8b38336c2
+  subjects:
+  - entities:
+    - role: player
+      name: George Brett
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: IVA-I
+  uuid: a56deabf-6d35-4a13-9282-7c8efe4d7eaa
+  subjects:
+  - entities:
+    - role: player
+      name: Ichiro
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: IVA-JC
+  uuid: f7ce8cf1-4eb1-41c8-bcc2-f75a06f8344d
+  subjects:
+  - entities:
+    - role: player
+      name: Jac Caglianone
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: IVA-JS
+  uuid: 06f0c328-faef-4839-b4d1-2d6d3bff0576
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: IVA-JV
+  uuid: 5fc018b6-163c-429a-930d-573170705c6e
+  subjects:
+  - entities:
+    - role: player
+      name: Joey Votto
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: IVA-KC
+  uuid: 91f42b19-fadc-4b45-89ea-532ab08ec1fa
+  subjects:
+  - entities:
+    - role: player
+      name: Kristian Campbell
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: IVA-KT
+  uuid: 1ad2174b-db0f-464b-969a-90a54895eb6a
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Teel
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: IVA-MC
+  uuid: 6003ca0d-99b1-420b-8908-57871bd65b9d
+  subjects:
+  - entities:
+    - role: player
+      name: Miguel Cabrera
+      ref: 
+    - role: team
+      name: Florida Marlins
+      ref: 
+- number: IVA-MM
+  uuid: 49712ddc-fcc2-480b-8789-da125c75a4ef
+  subjects:
+  - entities:
+    - role: player
+      name: Mark McGwire
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: IVA-MS
+  uuid: 56a35edb-53cd-4f1a-8d2a-85ea79ec8d2d
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Schmidt
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: IVA-NR
+  uuid: 16af99c9-a4da-4dc3-b8be-3e02836a9c47
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan Ryan
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: IVA-OC
+  uuid: 25f97b1e-8724-42f7-84f0-fd03d3fbf744
+  subjects:
+  - entities:
+    - role: player
+      name: Owen Caissie
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: IVA-OH
+  uuid: ee175997-c7df-414d-af69-d1d30b22859b
+  subjects:
+  - entities:
+    - role: player
+      name: Orel Hershiser
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: IVA-RA
+  uuid: 59a2f0b5-4bba-4168-8217-41d021adecd4
+  subjects:
+  - entities:
+    - role: player
+      name: Ronald Acuña Jr.
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: IVA-RAN
+  uuid: 38764ff4-e26f-47c5-ac52-ce6d62dbbb1c
+  subjects:
+  - entities:
+    - role: player
+      name: Roman Anthony
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: IVA-RC
+  uuid: 4045fc69-68e0-4ee1-99e4-f9baf59644a5
+  subjects:
+  - entities:
+    - role: player
+      name: Roger Clemens
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: IVA-RJ
+  uuid: 020fc749-bf86-401f-a561-3578d1f98cf9
+  subjects:
+  - entities:
+    - role: player
+      name: Randy Johnson
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: IVA-RJA
+  uuid: 5fce9427-2752-4ae2-bd7f-ffb402a2e7b1
+  subjects:
+  - entities:
+    - role: player
+      name: Reggie Jackson
+      ref: 
+    - role: team
+      name: Oakland Athletics
+      ref: 
+- number: IVA-RY
+  uuid: eef80477-c33f-4912-b623-bff66ed3e8bc
+  subjects:
+  - entities:
+    - role: player
+      name: Robin Yount
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: IVA-SB
+  uuid: 7be15b34-df13-4f0d-8a3d-9bdac3419415
+  subjects:
+  - entities:
+    - role: player
+      name: Samuel Basallo
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: IVA-SC
+  uuid: 9b0b0eb5-81a3-4d9e-b3c6-de062a3d7860
+  subjects:
+  - entities:
+    - role: player
+      name: Steve Carlton
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: IVA-SK
+  uuid: a10e4d9d-6b18-49f9-8cff-3d4532802bdb
+  subjects:
+  - entities:
+    - role: player
+      name: Sandy Koufax
+      ref: 
+    - role: team
+      name: Brooklyn Dodgers
+      ref: 
+- number: IVA-SO
+  uuid: 99265be0-dbbc-474a-892a-78b9bfc8415b
+  subjects:
+  - entities:
+    - role: player
+      name: Shohei Ohtani
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: IVA-SS
+  uuid: b95121d3-6865-4d70-8f08-19dda29bc502
+  subjects:
+  - entities:
+    - role: player
+      name: Sammy Sosa
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: IVA-YY
+  uuid: de1c16f5-71f0-439a-9010-6290048f2c24
+  subjects:
+  - entities:
+    - role: player
+      name: Yoshinobu Yamamoto
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 

--- a/data/baseball/2026-topps-chrome-black/checklists/nocturnal.yaml
+++ b/data/baseball/2026-topps-chrome-black/checklists/nocturnal.yaml
@@ -1,0 +1,400 @@
+- number: NOC-1
+  uuid: 4c2178b4-9f2a-4e7e-a6e3-6c95b6c3bc13
+  subjects:
+  - entities:
+    - role: player
+      name: Jac Caglianone
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: NOC-2
+  uuid: af9a7206-776c-4f26-9a72-a021bdb1d660
+  subjects:
+  - entities:
+    - role: player
+      name: Roman Anthony
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: NOC-3
+  uuid: efea10bd-8c19-47ec-93d6-7f5fa4917e88
+  subjects:
+  - entities:
+    - role: player
+      name: Colson Montgomery
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: NOC-4
+  uuid: 2873ed03-e316-4b4a-9aa3-c82407a1aab3
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Teel
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: NOC-5
+  uuid: 23d02b70-911a-4b73-8426-1e454a42336b
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Misiorowski
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: NOC-6
+  uuid: b859bf54-613a-447f-a2f9-2bea6f5f311f
+  subjects:
+  - entities:
+    - role: player
+      name: Christian Moore
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: NOC-7
+  uuid: 3176cbe9-d2d6-4b19-8201-514f516e6288
+  subjects:
+  - entities:
+    - role: player
+      name: Chase Burns
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: NOC-8
+  uuid: ef219719-dade-4afd-bc03-ba83d9e67552
+  subjects:
+  - entities:
+    - role: player
+      name: Owen Caissie
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: NOC-9
+  uuid: cb2402c4-9b30-44c4-91ac-ca43b9da487e
+  subjects:
+  - entities:
+    - role: player
+      name: Samuel Basallo
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: NOC-10
+  uuid: 60dfd3e8-4fde-46cb-9526-1a94204eefb2
+  subjects:
+  - entities:
+    - role: player
+      name: Bubba Chandler
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: NOC-11
+  uuid: 3772ad95-69ea-43f4-b810-3e0d056cff65
+  subjects:
+  - entities:
+    - role: player
+      name: Sal Stewart
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: NOC-12
+  uuid: 640f93b8-b906-44b5-bd42-d230abbde096
+  subjects:
+  - entities:
+    - role: player
+      name: Harry Ford
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: NOC-13
+  uuid: f337ed77-3a8d-4b9f-850e-f82f74081586
+  subjects:
+  - entities:
+    - role: player
+      name: Alex Freeland
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: NOC-14
+  uuid: 52206e0c-e37c-46d7-95e2-48a5a963f85e
+  subjects:
+  - entities:
+    - role: player
+      name: Payton Tolle
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: NOC-15
+  uuid: c9f028c2-8907-4bf3-8479-7ebb8bd96697
+  subjects:
+  - entities:
+    - role: player
+      name: Carson Williams
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: NOC-16
+  uuid: 6d937737-56b2-4fc7-9ba7-3fcc9efc5985
+  subjects:
+  - entities:
+    - role: player
+      name: Manny Machado
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: NOC-17
+  uuid: 067ac54c-c035-42f5-84e8-62740171214a
+  subjects:
+  - entities:
+    - role: player
+      name: Mookie Betts
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: NOC-18
+  uuid: 53ccd202-30c6-4bb4-9ee8-98715fc4102b
+  subjects:
+  - entities:
+    - role: player
+      name: Freddie Freeman
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: NOC-19
+  uuid: b438855a-9017-4f1e-9c7d-81fb300b21cc
+  subjects:
+  - entities:
+    - role: player
+      name: Shohei Ohtani
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: NOC-20
+  uuid: ba34bfc2-5453-400e-acd2-327b7e0a2611
+  subjects:
+  - entities:
+    - role: player
+      name: Aaron Judge
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: NOC-21
+  uuid: 2f3c0e27-3b1b-4a92-a7f7-230ba021decd
+  subjects:
+  - entities:
+    - role: player
+      name: Yoshinobu Yamamoto
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: NOC-22
+  uuid: a0f07755-6273-4e3d-8a44-35dfba280251
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan Arenado
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: NOC-23
+  uuid: 416dece4-d32c-457c-a80c-e43e7718406c
+  subjects:
+  - entities:
+    - role: player
+      name: Bo Bichette
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: NOC-24
+  uuid: b0a4f938-721a-4cbe-b9f5-eddff0a616e1
+  subjects:
+  - entities:
+    - role: player
+      name: Junior Caminero
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: NOC-25
+  uuid: 750d96eb-e8c8-4d25-b16e-f170caa54e3c
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Harper
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: NOC-26
+  uuid: ab66f8f0-6592-4e14-96eb-3bbf5a3df4fd
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: NOC-27
+  uuid: f2bb3ae0-9acf-44c1-ac03-ecba5ba94e71
+  subjects:
+  - entities:
+    - role: player
+      name: Ronald Acuña Jr.
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: NOC-28
+  uuid: bd9039e0-2c31-4bd4-80a0-8ae9751c088e
+  subjects:
+  - entities:
+    - role: player
+      name: James Wood
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: NOC-29
+  uuid: 1605cfc7-dac5-42f1-a228-dc49fb1b643c
+  subjects:
+  - entities:
+    - role: player
+      name: Yordan Alvarez
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: NOC-30
+  uuid: f66cb96e-cf87-42ea-bfe4-4f5a4a9c873c
+  subjects:
+  - entities:
+    - role: player
+      name: Julio Rodríguez
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: NOC-31
+  uuid: 59a6fe12-f356-4c03-8f01-f86ab2498e6f
+  subjects:
+  - entities:
+    - role: player
+      name: José Ramírez
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: NOC-32
+  uuid: 3d08f437-1b80-4faf-960d-059d385a9f89
+  subjects:
+  - entities:
+    - role: player
+      name: Riley Greene
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: NOC-33
+  uuid: 32bcfc5e-682d-4c53-a753-78bc4de9ebf9
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Crow-Armstrong
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: NOC-34
+  uuid: 238fc6ec-5a45-4659-bb2c-31b4e97cb191
+  subjects:
+  - entities:
+    - role: player
+      name: Paul Skenes
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: NOC-35
+  uuid: 3209af07-6a16-4700-b79b-e161c97efd8e
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Kurtz
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: NOC-36
+  uuid: '0782fedb-565e-4819-b0cd-bf5f9d0e1b26'
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Wilson
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: NOC-37
+  uuid: f0d486b1-4e64-4fb5-875c-32b1af367d64
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Trout
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: NOC-38
+  uuid: 410dfe45-4dc7-4693-a940-d6ad57dab89f
+  subjects:
+  - entities:
+    - role: player
+      name: Elly De La Cruz
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: NOC-39
+  uuid: d5764f6f-4332-4571-8dfa-4bd7781093d1
+  subjects:
+  - entities:
+    - role: player
+      name: Corbin Carroll
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: NOC-40
+  uuid: 84a6dc0a-81b2-4202-acaf-f301b7120ac7
+  subjects:
+  - entities:
+    - role: player
+      name: Trea Turner
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 

--- a/data/baseball/2026-topps-chrome-black/checklists/paint-it.yaml
+++ b/data/baseball/2026-topps-chrome-black/checklists/paint-it.yaml
@@ -1,0 +1,190 @@
+- number: PIA-AP
+  uuid: 678bf022-4958-4f40-b02c-340bf31370b2
+  subjects:
+  - entities:
+    - role: player
+      name: Albert Pujols
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: PIA-BC
+  uuid: 8978d731-933b-4b68-9a9e-f955015e128a
+  subjects:
+  - entities:
+    - role: player
+      name: Bubba Chandler
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: PIA-CB
+  uuid: 785136c9-a819-4469-923e-9e4a7c9adc31
+  subjects:
+  - entities:
+    - role: player
+      name: Chase Burns
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: PIA-CM
+  uuid: c8c16e3b-5364-41ff-b89e-2dd90e4764a6
+  subjects:
+  - entities:
+    - role: player
+      name: Christian Moore
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: PIA-CMO
+  uuid: bc11e0c8-c068-4a56-8d72-9e2b723daa55
+  subjects:
+  - entities:
+    - role: player
+      name: Colson Montgomery
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: PIA-CS
+  uuid: 5101e3ab-02e2-4cef-ba7b-ded1a8b79e7b
+  subjects:
+  - entities:
+    - role: player
+      name: CC Sabathia
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: PIA-DJ
+  uuid: d49c6b63-3431-48c7-a07b-d5c62a1fe55f
+  subjects:
+  - entities:
+    - role: player
+      name: Derek Jeter
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: PIA-GB
+  uuid: af1d2a0c-e37b-4abb-b9ed-28de4239e7b2
+  subjects:
+  - entities:
+    - role: player
+      name: George Brett
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: PIA-I
+  uuid: 54d763d9-8522-45ae-acd0-762056af2aca
+  subjects:
+  - entities:
+    - role: player
+      name: Ichiro
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: PIA-JC
+  uuid: bc89daa3-33e2-488e-95a5-80058eef3c5a
+  subjects:
+  - entities:
+    - role: player
+      name: Jac Caglianone
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: PIA-KC
+  uuid: 139cbe2a-f1fb-4e7d-aae8-5c0aed0c7b10
+  subjects:
+  - entities:
+    - role: player
+      name: Kristian Campbell
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: PIA-KS
+  uuid: cd984244-9cfa-4bad-8bd5-add6b020cae4
+  subjects:
+  - entities:
+    - role: player
+      name: Kodai Senga
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: PIA-KT
+  uuid: 17490305-34df-4912-9963-834aaea17239
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Teel
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: PIA-MT
+  uuid: bbae71a3-be25-47e9-a655-08fa5646ad74
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Trout
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: PIA-NK
+  uuid: 400475bb-f807-4971-9afb-fb8f09c738da
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Kurtz
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: PIA-NR
+  uuid: 6defbb97-65a8-482b-8ac0-71a70d10807b
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan Ryan
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: PIA-OC
+  uuid: d9b12aeb-fcef-4c95-9fab-86bb42e63ae4
+  subjects:
+  - entities:
+    - role: player
+      name: Owen Caissie
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: PIA-RAN
+  uuid: 9a04f0ca-178b-4713-8c84-7414bec31df9
+  subjects:
+  - entities:
+    - role: player
+      name: Roman Anthony
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: PIA-YY
+  uuid: 7d99ecc2-ea9e-4a1d-bd88-f634cd1c5cda
+  subjects:
+  - entities:
+    - role: player
+      name: Yoshinobu Yamamoto
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 

--- a/data/baseball/2026-topps-chrome-black/checklists/pitch-black-pairings-dual-autographs.yaml
+++ b/data/baseball/2026-topps-chrome-black/checklists/pitch-black-pairings-dual-autographs.yaml
@@ -1,0 +1,238 @@
+- number: PDPA-AC
+  uuid: da4525ed-6c13-4335-ac48-4c3976d7ed6f
+  subjects:
+  - entities:
+    - role: player
+      name: Kristian Campbell
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+  - entities:
+    - role: player
+      name: Roman Anthony
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: PDPA-AJ
+  uuid: 5675d369-4f57-478c-8514-b81e0d4d26af
+  subjects:
+  - entities:
+    - role: player
+      name: Chipper Jones
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+  - entities:
+    - role: player
+      name: Ronald Acuña Jr.
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: PDPA-BC
+  uuid: 064b2342-8fc6-4cc3-8fd8-400523c6d375
+  subjects:
+  - entities:
+    - role: player
+      name: Wade Boggs
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+  - entities:
+    - role: player
+      name: Roger Clemens
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: PDPA-JG
+  uuid: 0b32e072-0bf5-4a53-96a0-7a2ff025c593
+  subjects:
+  - entities:
+    - role: player
+      name: Ken Griffey Jr.
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+  - entities:
+    - role: player
+      name: Randy Johnson
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: PDPA-JI
+  uuid: a2df6fc0-dbd2-424a-99ea-9af62a8ca8a1
+  subjects:
+  - entities:
+    - role: player
+      name: Ichiro
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+  - entities:
+    - role: player
+      name: Derek Jeter
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: PDPA-KP
+  uuid: 0f69fced-c119-44c0-9f81-f96e54d6ce8b
+  subjects:
+  - entities:
+    - role: player
+      name: Hyeseong Kim
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+  - entities:
+    - role: player
+      name: Chan Ho Park
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: PDPA-OY
+  uuid: 39ab0afe-c3c5-4114-9399-2eab0ec6b0fd
+  subjects:
+  - entities:
+    - role: player
+      name: Yoshinobu Yamamoto
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+  - entities:
+    - role: player
+      name: Shohei Ohtani
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: PDPA-PM
+  uuid: bd23c6e7-a40b-4bfa-9dea-5d4e6db80d42
+  subjects:
+  - entities:
+    - role: player
+      name: Mark McGwire
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+  - entities:
+    - role: player
+      name: Albert Pujols
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: PDPA-SC
+  uuid: 38f29f3f-f966-42ca-9efd-bd3edfd422b6
+  subjects:
+  - entities:
+    - role: player
+      name: Bubba Chandler
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+  - entities:
+    - role: player
+      name: Paul Skenes
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: PDPA-SD
+  uuid: 70dac5d3-1aaa-4694-b828-301120df250f
+  subjects:
+  - entities:
+    - role: player
+      name: Sammy Sosa
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+  - entities:
+    - role: player
+      name: Andre Dawson
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: PDPA-TJ
+  uuid: d55fc54e-b7c5-4efd-9d78-71944fb1d901
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Trout
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+  - entities:
+    - role: player
+      name: Reggie Jackson
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: PDPA-TK
+  uuid: 94fadaf7-b833-4af3-85f6-1fb8edc6b61e
+  subjects:
+  - entities:
+    - role: player
+      name: Frank Thomas
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+  - entities:
+    - role: player
+      name: Paul Konerko
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: PDPA-WG
+  uuid: 0fcd2126-b610-40a8-aeef-27894dda2026
+  subjects:
+  - entities:
+    - role: player
+      name: Vladimir Guerrero
+      ref: 
+    - role: team
+      name: Montréal Expos
+      ref: 
+  - entities:
+    - role: player
+      name: Larry Walker
+      ref: 
+    - role: team
+      name: Montréal Expos
+      ref: 
+- number: PDPA-WW
+  uuid: 2a7a998d-42c9-4e40-a7dc-996f7622c93c
+  subjects:
+  - entities:
+    - role: player
+      name: Jack Wilson
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+  - entities:
+    - role: player
+      name: Jacob Wilson
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 

--- a/data/baseball/2026-topps-chrome-black/checklists/super-futures-autographs.yaml
+++ b/data/baseball/2026-topps-chrome-black/checklists/super-futures-autographs.yaml
@@ -1,0 +1,220 @@
+- number: SFA-AF
+  uuid: b4a236f8-326e-4880-9af8-75057ec36b9e
+  subjects:
+  - entities:
+    - role: player
+      name: Alex Freeland
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: SFA-AR
+  uuid: 9bf83061-f333-4ab1-b4c8-a88c55bb6f60
+  subjects:
+  - entities:
+    - role: player
+      name: Agustín Ramírez
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: SFA-BC
+  uuid: fe4f5618-3776-47e1-b31c-d75476eccee4
+  subjects:
+  - entities:
+    - role: player
+      name: Bubba Chandler
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: SFA-BL
+  uuid: 63758eee-9b90-40eb-8d86-7b93c7e0c873
+  subjects:
+  - entities:
+    - role: player
+      name: Brooks Lee
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: SFA-BM
+  uuid: 545e9d5a-633e-4dbd-8b56-0c2850470c64
+  subjects:
+  - entities:
+    - role: player
+      name: Brice Matthews
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: SFA-CAG
+  uuid: 843621b4-dd5c-4566-8794-2713ad7887e9
+  subjects:
+  - entities:
+    - role: player
+      name: Jac Caglianone
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: SFA-CB
+  uuid: 454636b3-6942-4849-ab3c-ffd614af53e9
+  subjects:
+  - entities:
+    - role: player
+      name: Chase Burns
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: SFA-CM
+  uuid: 97494ba8-4f83-4d32-8ddf-2c79a8d850a1
+  subjects:
+  - entities:
+    - role: player
+      name: Christian Moore
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: SFA-CSI
+  uuid: d40692ef-1f83-48b4-897a-e827f825f8ec
+  subjects:
+  - entities:
+    - role: player
+      name: Chandler Simpson
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: SFA-CY
+  uuid: 1e4d9b14-93bf-4741-a616-c0a2c02d2eb6
+  subjects:
+  - entities:
+    - role: player
+      name: Cole Young
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: SFA-DB
+  uuid: e6bcd500-4a19-44e8-bf6d-7bba7a60a917
+  subjects:
+  - entities:
+    - role: player
+      name: Dylan Beavers
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: SFA-DR
+  uuid: 7b2f45f3-4a84-4c3f-9d2c-7667aa1d7c93
+  subjects:
+  - entities:
+    - role: player
+      name: Dalton Rushing
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: SFA-JM
+  uuid: 59521869-3c25-4847-b1ca-e8d70bda2bf7
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Melton
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: SFA-JMA
+  uuid: ec364077-cf80-424b-9127-d6ee35a1c061
+  subjects:
+  - entities:
+    - role: player
+      name: Jakob Marsee
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: SFA-KC
+  uuid: a4afbde2-4c80-479f-b6d7-7ac52d8dcba0
+  subjects:
+  - entities:
+    - role: player
+      name: Kristian Campbell
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: SFA-KT
+  uuid: 6a1da22c-877c-4f80-a106-d6b92e010a66
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Teel
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: SFA-NK
+  uuid: 28af85aa-b87e-4b77-a7e1-0c8024f8fa1e
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Kurtz
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: SFA-NM
+  uuid: 02b6dd1f-4868-4b3d-a570-57bce7540a6f
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan McLean
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: SFA-OC
+  uuid: 2da296a7-fd75-4ca3-b6fc-eb906d5d63ab
+  subjects:
+  - entities:
+    - role: player
+      name: Owen Caissie
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: SFA-RS
+  uuid: 1892c44f-07e7-4ff0-8a3f-345d55bb8929
+  subjects:
+  - entities:
+    - role: player
+      name: Roki Sasaki
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: SFA-SB
+  uuid: 3e0d117f-34aa-4401-894c-7c8f12ce3eb3
+  subjects:
+  - entities:
+    - role: player
+      name: Samuel Basallo
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: SFA-SS
+  uuid: b52c48c4-f133-4a12-916c-87f45b221ccb
+  subjects:
+  - entities:
+    - role: player
+      name: Sal Stewart
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 

--- a/data/baseball/2026-topps-chrome-black/manifest.yaml
+++ b/data/baseball/2026-topps-chrome-black/manifest.yaml
@@ -1,0 +1,250 @@
+set_id: 2026-topps-chrome-black
+base_sets:
+- id: base-set
+  name: Base Set
+  uuid: c576be8a-0e3f-5dda-986b-c01ce1baedbc
+  declared_card_count: 200
+  parallels:
+  - name: Blue Refractor
+    print_run: 150
+    serial_numbered: true
+  - name: Gold Mini Diamond Refractor
+    print_run: 50
+    serial_numbered: true
+  - name: Gold Refractor
+    print_run: 50
+    serial_numbered: true
+  - name: Gold Wave Refractor
+    print_run: 50
+    serial_numbered: true
+  - name: Green Refractor
+    print_run: 99
+    serial_numbered: true
+  - name: Orange Mini Diamond Refractor
+    print_run: 25
+    serial_numbered: true
+  - name: Orange Refractor
+    print_run: 25
+    serial_numbered: true
+  - name: Orange Wave Refractor
+    print_run: 25
+    serial_numbered: true
+  - name: Purple Mini-Diamond Refractor
+    print_run: 75
+    serial_numbered: true
+  - name: Purple Refractor
+    print_run: 75
+    serial_numbered: true
+  - name: Purple Wave Refractor
+    print_run: 75
+    serial_numbered: true
+  - name: Red Mini Diamond Refractor
+    print_run: 5
+    serial_numbered: true
+  - name: Red Refractor
+    print_run: 5
+    serial_numbered: true
+  - name: Red Wave Refractor
+    print_run: 5
+    serial_numbered: true
+  - name: Refractor
+    print_run: 199
+    serial_numbered: true
+  - name: Rose Gold Mini Diamond Refractor
+    print_run: 10
+    serial_numbered: true
+  - name: Rose Gold Refractor
+    print_run: 10
+    serial_numbered: true
+  - name: Rose Gold Wave Refractor
+    print_run: 10
+    serial_numbered: true
+  - name: SuperFractor
+    print_run: 1
+    serial_numbered: true
+  subsets:
+  - id: base-rookie-design-variations
+    name: Base - Rookie Design Variations
+    uuid: 144f5e02-0120-5b21-9a69-3f678f562e1e
+    type:
+    - variation
+    declared_card_count: 30
+    parallels:
+    - name: Gold Refractor
+      print_run: 50
+      serial_numbered: true
+    - name: Orange Refractor
+      print_run: 25
+      serial_numbered: true
+    - name: Purple Refractor
+      print_run: 75
+      serial_numbered: true
+    - name: Red Refractor
+      print_run: 5
+      serial_numbered: true
+    - name: Rose Gold Refractor
+      print_run: 10
+      serial_numbered: true
+    - name: SuperFractor
+      print_run: 1
+      serial_numbered: true
+subsets:
+- id: chrome-black-autographs
+  name: Chrome Black Autographs
+  uuid: 61f13177-33fa-5506-90f2-3d90e798d5fa
+  type:
+  - autograph
+  declared_card_count: 111
+  parallels:
+  - name: Blue Refractor
+    print_run: 150
+    serial_numbered: true
+  - name: Gold Mini Diamond Refractor
+    print_run: 50
+    serial_numbered: true
+  - name: Gold Refractor
+    print_run: 50
+    serial_numbered: true
+  - name: Green Refractor
+    print_run: 99
+    serial_numbered: true
+  - name: Orange Mini Diamond Refractor
+    print_run: 25
+    serial_numbered: true
+  - name: Orange Refractor
+    print_run: 25
+    serial_numbered: true
+  - name: Purple Refractor
+    print_run: 75
+    serial_numbered: true
+  - name: Red Mini Diamond Refractor
+    print_run: 5
+    serial_numbered: true
+  - name: Red Refractor
+    print_run: 5
+    serial_numbered: true
+  - name: Refractor
+    print_run: 199
+    serial_numbered: true
+  - name: Rose Gold Mini Diamond Refractor
+    print_run: 10
+    serial_numbered: true
+  - name: Rose Gold Refractor
+    print_run: 10
+    serial_numbered: true
+  - name: SuperFractor
+    print_run: 1
+    serial_numbered: true
+- id: damascus
+  name: Damascus
+  uuid: da698f2d-2d12-5300-a1e6-31289e600444
+  type:
+  - insert
+  declared_card_count: 30
+  parallels:
+  - name: SuperFractor
+    print_run: 1
+    serial_numbered: true
+- id: depth-of-darkness
+  name: Depth Of Darkness
+  uuid: 61f769a1-3506-5139-a8e9-aa60430c7e89
+  type:
+  - insert
+  declared_card_count: 20
+  parallels:
+  - name: Red Refractor
+    print_run: 5
+    serial_numbered: true
+  - name: SuperFractor
+    print_run: 1
+    serial_numbered: true
+- id: home-field
+  name: Home Field
+  uuid: 1ea0ad65-3ac1-5aca-a8c2-fd0247db8b1a
+  type:
+  - insert
+  declared_card_count: 20
+  parallels:
+  - name: Black Refractor
+    print_run: 1
+    serial_numbered: true
+- id: ivory-autographs
+  name: Ivory Autographs
+  uuid: 041733e8-e92f-5ed1-8e23-01ee68635598
+  type:
+  - autograph
+  declared_card_count: 36
+  parallels:
+  - name: Orange Trim
+    print_run: 25
+    serial_numbered: true
+  - name: Red Trim
+    print_run: 5
+    serial_numbered: true
+  - name: SuperFractor
+    print_run: 1
+    serial_numbered: true
+- id: nocturnal
+  name: Nocturnal
+  uuid: 4607fa08-0fd2-5610-9cc1-88e07b81bb85
+  type:
+  - insert
+  declared_card_count: 40
+  parallels:
+  - name: SuperFractor
+    print_run: 1
+    serial_numbered: true
+- id: paint-it
+  name: Paint It
+  uuid: cf0cf25e-e9d8-5485-9d45-2e007cef69c8
+  type:
+  - insert
+  declared_card_count: 19
+  parallels:
+  - name: Red Refractor
+    print_run: 5
+    serial_numbered: true
+  - name: SuperFractor
+    print_run: 1
+    serial_numbered: true
+- id: pitch-black-pairings-dual-autographs
+  name: Pitch Black Pairings Dual Autographs
+  uuid: 3a84af58-87af-5e6b-957e-a2b439c907f7
+  type:
+  - autograph
+  declared_card_count: 14
+  parallels:
+  - name: Orange Refractor
+    print_run: 25
+    serial_numbered: true
+  - name: Red Refractor
+    print_run: 5
+    serial_numbered: true
+  - name: Rose Gold Refractor
+    print_run: 10
+    serial_numbered: true
+  - name: SuperFractor
+    print_run: 1
+    serial_numbered: true
+- id: super-futures-autographs
+  name: Super Futures Autographs
+  uuid: e2dbefbb-5660-501f-a182-eb936eb50a6e
+  type:
+  - autograph
+  declared_card_count: 22
+  parallels:
+  - name: Gold Refractor
+    print_run: 50
+    serial_numbered: true
+  - name: Orange Refractor
+    print_run: 25
+    serial_numbered: true
+  - name: Red Refractor
+    print_run: 5
+    serial_numbered: true
+  - name: Rose Gold Refractor
+    print_run: 10
+    serial_numbered: true
+  - name: SuperFractor
+    print_run: 1
+    serial_numbered: true

--- a/data/baseball/2026-topps-chrome-black/manifest.yaml
+++ b/data/baseball/2026-topps-chrome-black/manifest.yaml
@@ -29,7 +29,7 @@ base_sets:
   - name: Orange Wave Refractor
     print_run: 25
     serial_numbered: true
-  - name: Purple Mini-Diamond Refractor
+  - name: Purple Mini Diamond Refractor
     print_run: 75
     serial_numbered: true
   - name: Purple Refractor

--- a/data/baseball/2026-topps-chrome-black/set.yaml
+++ b/data/baseball/2026-topps-chrome-black/set.yaml
@@ -1,0 +1,19 @@
+uuid: c2fe11e3-17f2-42f4-b4d7-89e3f42b5b1b
+set_id: 2026-topps-chrome-black
+name: 2026 Topps Chrome Black
+genre: Sports
+category:
+- MLB
+sports:
+- Baseball
+season: '2026'
+years:
+- 2026
+manufacturer: Topps
+release_date: '2026-04-29'
+description: 2026 Topps Chrome Black is a 200-card set released April 29th. Each box
+  contains two packs of six cards, plus one individually-wrapped encased autograph.
+source:
+  name: BaseballCardpedia
+  url: https://baseballcardpedia.com/index.php/2026_Topps_Chrome_Black#Checklist
+  file: import/2026-Topps-Chrome-Black-Baseball-Checklist.xlsx


### PR DESCRIPTION
Converts jmurphyrum's **2026 Topps Chrome Black** (#22, exploded) to the **v0.3 manifest form**. Same data, compact and reviewable. Passes the v0.3 validator. Supersedes #22.

1 base set (200) + Rookie Design Variations; autographs and dark-themed inserts at product level.

⚠️ Draft — leaving open so @jmurphyrum can review the structure before merge.