### PR TITLE
feat(data): 2025-26 Topps Definitive Collection in v0.3 (from #17)

### DIFF
--- a/data/baseball/2025-26-topps-definitive-collection/checklists/autographed-patch-booklets.yaml
+++ b/data/baseball/2025-26-topps-definitive-collection/checklists/autographed-patch-booklets.yaml
@@ -1,0 +1,400 @@
+- number: APBC-AB
+  uuid: 9c7ea040-a454-4cd1-ad99-2ed525fe1efc
+  subjects:
+  - entities:
+    - role: player
+      name: Alex Bregman
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: APBC-AJ
+  uuid: 41d8801e-870a-4cde-88d9-9e89d36a9374
+  subjects:
+  - entities:
+    - role: player
+      name: Aaron Judge
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: APBC-AJO
+  uuid: ab89b09a-32d0-4c26-95b1-f94c05ba54b9
+  subjects:
+  - entities:
+    - role: player
+      name: Andruw Jones
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: APBC-AM
+  uuid: b8d3a8d7-b4fb-4e61-8910-661e314ad6d7
+  subjects:
+  - entities:
+    - role: player
+      name: Andrew McCutchen
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: APBC-AP
+  uuid: 7e00a7fa-c1a5-40ad-bc2c-29be6513af27
+  subjects:
+  - entities:
+    - role: player
+      name: Albert Pujols
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: APBC-AR
+  uuid: e026ffc9-736c-4099-b4f5-bc6643ab5940
+  subjects:
+  - entities:
+    - role: player
+      name: Austin Riley
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: APBC-AROD
+  uuid: 5b3482c7-f1b4-404f-81cc-79022dd666ae
+  subjects:
+  - entities:
+    - role: player
+      name: Alex Rodriguez
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: APBC-ARU
+  uuid: 15eabb3d-1178-4b89-8a29-a1d5b1cdc71a
+  subjects:
+  - entities:
+    - role: player
+      name: Adley Rutschman
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: APBC-BB
+  uuid: 11cfdcbb-7be9-445f-9fc1-6b57677f9731
+  subjects:
+  - entities:
+    - role: player
+      name: Byron Buxton
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: APBC-BH
+  uuid: 53128828-de56-47e8-8a8a-f2c78ac9526f
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Harper
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: APBC-BL
+  uuid: bb3e8cb8-29b4-408c-b710-cfb4c6270978
+  subjects:
+  - entities:
+    - role: player
+      name: Brooks Lee
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: APBC-CAM
+  uuid: 769aa61b-a786-4acc-a9d2-22701305f0c6
+  subjects:
+  - entities:
+    - role: player
+      name: Cam Smith
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: APBC-CC
+  uuid: e3a8dd09-58b9-47c2-9fce-b3ccab59512f
+  subjects:
+  - entities:
+    - role: player
+      name: Corbin Carroll
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: APBC-CJ
+  uuid: 16298861-71d4-4886-9d69-f9a49b9de6f4
+  subjects:
+  - entities:
+    - role: player
+      name: Chipper Jones
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: APBC-CK
+  uuid: 19ab4dd3-5df5-4bd2-8a87-94644f12ce6f
+  subjects:
+  - entities:
+    - role: player
+      name: Clayton Kershaw
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: APBC-CS
+  uuid: d04662d4-ea50-4ea4-875d-c14ab4be389d
+  subjects:
+  - entities:
+    - role: player
+      name: CC Sabathia
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: APBC-CY
+  uuid: b8b8d413-3173-40be-824a-297d2d0a8279
+  subjects:
+  - entities:
+    - role: player
+      name: Christian Yelich
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: APBC-DC
+  uuid: 0ab03787-bc94-4072-ae8d-690b6e7d9501
+  subjects:
+  - entities:
+    - role: player
+      name: Dylan Crews
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: APBC-FF
+  uuid: 214192e6-ceb4-415e-b82a-fe39e894801d
+  subjects:
+  - entities:
+    - role: player
+      name: Freddie Freeman
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: APBC-FL
+  uuid: 0a3b7a9f-b1a5-447d-b72f-589235ccff7e
+  subjects:
+  - entities:
+    - role: player
+      name: Francisco Lindor
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: APBC-FT
+  uuid: 1f2e7985-fcf1-4ec1-a204-14120ce57fe9
+  subjects:
+  - entities:
+    - role: player
+      name: Fernando Tatis Jr.
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: APBC-I
+  uuid: b7e5908e-61e8-4cd7-b1f2-339c87b1c7d9
+  subjects:
+  - entities:
+    - role: player
+      name: Ichiro
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: APBC-JA
+  uuid: 2a0dee67-197a-448a-80b1-c10b944f7e4e
+  subjects:
+  - entities:
+    - role: player
+      name: Jose Altuve
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: APBC-JM
+  uuid: 5f95f1dc-bb59-4b67-b03b-5826519cac53
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Merrill
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: APBC-JR
+  uuid: 7d1e2691-a4b2-4a59-bdd9-8b903d680c33
+  subjects:
+  - entities:
+    - role: player
+      name: Julio Rodríguez
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: APBC-JT
+  uuid: 94ba21ff-72bd-4400-974a-110a5d2d6703
+  subjects:
+  - entities:
+    - role: player
+      name: J.T. Realmuto
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: APBC-JV
+  uuid: ed7eb928-e0b2-4d0e-84d2-ba339fb54151
+  subjects:
+  - entities:
+    - role: player
+      name: Joey Votto
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: APBC-JW
+  uuid: 912e243b-f1fe-4107-ba54-ef574d69796a
+  subjects:
+  - entities:
+    - role: player
+      name: James Wood
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: APBC-KT
+  uuid: 855bbf9f-8768-4b28-a59d-8cd43051de67
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Tucker
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: APBC-LW
+  uuid: 22fb90a1-cff3-422c-a3af-93ef9b77c038
+  subjects:
+  - entities:
+    - role: player
+      name: Larry Walker
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: APBC-MM
+  uuid: 97083b82-b2cb-4bd9-a6a9-db4199c8e2db
+  subjects:
+  - entities:
+    - role: player
+      name: Manny Machado
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: APBC-MT
+  uuid: 1cf3f750-111a-4502-acb2-66482445d327
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Trout
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: APBC-PA
+  uuid: fef9247f-3384-456e-97e7-fb8add7de9b4
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Alonso
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: APBC-PCA
+  uuid: bef867c1-ff4b-42a9-b8ab-e2d495adf3e6
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Crow-Armstrong
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: APBC-PF
+  uuid: c42cb8c4-3483-42b3-8f7b-f45ea33755ff
+  subjects:
+  - entities:
+    - role: player
+      name: Prince Fielder
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: APBC-RA
+  uuid: c772dbef-a8d3-4218-90b3-1d9bf73ca345
+  subjects:
+  - entities:
+    - role: player
+      name: Ronald Acuña Jr.
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: APBC-SO
+  uuid: 2066c420-dfc7-4eb7-acb1-9262fc2cd29f
+  subjects:
+  - entities:
+    - role: player
+      name: Shohei Ohtani
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: APBC-TT
+  uuid: 6c4cab59-5837-4e9e-8bfa-8814f880d9fe
+  subjects:
+  - entities:
+    - role: player
+      name: Trea Turner
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: APBC-VG
+  uuid: 9d3e4d90-dec6-4f7a-9e9d-742597bcd965
+  subjects:
+  - entities:
+    - role: player
+      name: Vladimir Guerrero Jr.
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: APBC-WB
+  uuid: 9b060b63-1f3a-406e-88b6-d9b5d99841cf
+  subjects:
+  - entities:
+    - role: player
+      name: Wade Boggs
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 

--- a/data/baseball/2025-26-topps-definitive-collection/checklists/base-autographed-relics.yaml
+++ b/data/baseball/2025-26-topps-definitive-collection/checklists/base-autographed-relics.yaml
@@ -1,0 +1,490 @@
+- number: ARC-AG
+  uuid: f2a66418-ed37-4a23-b360-44e21a17e7be
+  subjects:
+  - entities:
+    - role: player
+      name: Adolis García
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: ARC-AP
+  uuid: aff92fad-f9cb-4352-8b79-e04bef7f73c0
+  subjects:
+  - entities:
+    - role: player
+      name: Andy Pettitte
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: ARC-AR
+  uuid: f66d3c27-6009-4014-9473-e208b839ddd1
+  subjects:
+  - entities:
+    - role: player
+      name: Austin Riley
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: ARC-ARU
+  uuid: 2776b37b-a44e-4f12-92b6-2f15c0345f5e
+  subjects:
+  - entities:
+    - role: player
+      name: Adley Rutschman
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: ARC-BB
+  uuid: 9a3ea95f-296e-4169-899e-13f66caa3ac9
+  subjects:
+  - entities:
+    - role: player
+      name: Byron Buxton
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: ARC-BN
+  uuid: 0af19db8-36cb-4bf0-ba12-0bd8d23922c9
+  subjects:
+  - entities:
+    - role: player
+      name: Brandon Nimmo
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: ARC-BRO
+  uuid: 4d2de113-f959-42fd-a3ce-5f3f4d159eed
+  subjects:
+  - entities:
+    - role: player
+      name: Brent Rooker
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: ARC-CA
+  uuid: fb537e1c-cee7-4d09-8c42-5b083aa5cf77
+  subjects:
+  - entities:
+    - role: player
+      name: CJ Abrams
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: ARC-CAM
+  uuid: 4ed68bce-01c0-4ee0-bb14-98d998b5cec9
+  subjects:
+  - entities:
+    - role: player
+      name: Cam Smith
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: ARC-CCA
+  uuid: 2812cb95-56da-4a8e-92bb-06e11309e827
+  subjects:
+  - entities:
+    - role: player
+      name: Corbin Carroll
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: ARC-CS
+  uuid: 152c0980-8935-4bea-a1bc-db3607fd3b51
+  subjects:
+  - entities:
+    - role: player
+      name: Corey Seager
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: ARC-CSA
+  uuid: f49bcbdc-c419-4ee0-830d-27d291826ed6
+  subjects:
+  - entities:
+    - role: player
+      name: Chris Sale
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: ARC-CY
+  uuid: 27d18567-4b14-4167-95d4-a0074e9a3d90
+  subjects:
+  - entities:
+    - role: player
+      name: Christian Yelich
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: ARC-DC
+  uuid: e4e6cba5-0111-45d7-b051-2d6dc421b1ac
+  subjects:
+  - entities:
+    - role: player
+      name: Dylan Crews
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: ARC-FL
+  uuid: 2fb1891e-6558-4b87-ab0e-0134386f1a5e
+  subjects:
+  - entities:
+    - role: player
+      name: Francisco Lindor
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: ARC-FT
+  uuid: 024d0f0a-6416-465c-b806-67a1d78ea5d0
+  subjects:
+  - entities:
+    - role: player
+      name: Fernando Tatis Jr.
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: ARC-GH
+  uuid: 267c1fef-b79b-41ce-a3d4-1b91f4fcaec9
+  subjects:
+  - entities:
+    - role: player
+      name: Gunnar Henderson
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: ARC-HR
+  uuid: ed379aaf-9a13-41f1-8b35-07bd781bc0f8
+  subjects:
+  - entities:
+    - role: player
+      name: Hanley Ramirez
+      ref: 
+    - role: team
+      name: Florida Marlins
+      ref: 
+- number: ARC-JA
+  uuid: caf34894-e5bb-4dd3-9dc8-d514143d04d7
+  subjects:
+  - entities:
+    - role: player
+      name: Jose Altuve
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: ARC-JCA
+  uuid: 48a1231e-9ad3-4494-9d81-44553e323670
+  subjects:
+  - entities:
+    - role: player
+      name: Junior Caminero
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: ARC-JCJ
+  uuid: abc0768a-3cba-4372-a5e2-19f7e77e645d
+  subjects:
+  - entities:
+    - role: player
+      name: Jazz Chisholm Jr.
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: ARC-JD
+  uuid: 3a56cbf7-d74d-4eb9-adab-0254961000fb
+  subjects:
+  - entities:
+    - role: player
+      name: Jasson Domínguez
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: ARC-JDU
+  uuid: 4e559b0d-2159-44fc-bf28-0c51ecaf4188
+  subjects:
+  - entities:
+    - role: player
+      name: Jarren Duran
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: ARC-JHL
+  uuid: becf2bac-9706-4f14-a6ac-038b38e69375
+  subjects:
+  - entities:
+    - role: player
+      name: Jung Hoo Lee
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: ARC-JHM
+  uuid: fabb1a2a-3577-4137-8999-3a12d5f526e8
+  subjects:
+  - entities:
+    - role: player
+      name: Justyn-Henry Malloy
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: ARC-JM
+  uuid: 0d7424b6-ec6f-4a18-b123-ad88ed11555d
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Merrill
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: ARC-JR
+  uuid: 1dba848e-02bc-4866-93fd-93e8d0025d50
+  subjects:
+  - entities:
+    - role: player
+      name: José Ramírez
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: ARC-JRO
+  uuid: 42d9fbbb-6127-4a09-b698-f557ec2abb23
+  subjects:
+  - entities:
+    - role: player
+      name: Julio Rodríguez
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: ARC-JS
+  uuid: 20a01563-9fd5-4095-b4bd-5efc5d140463
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: ARC-JW
+  uuid: 7973af70-9c3b-4510-9e6d-af3ac4515796
+  subjects:
+  - entities:
+    - role: player
+      name: Jordan Westburg
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: ARC-JWO
+  uuid: 5da4524e-11d3-4a14-8343-7bdfb0ade8df
+  subjects:
+  - entities:
+    - role: player
+      name: James Wood
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: ARC-KA
+  uuid: 48de73ad-787a-4028-ad9f-83552f132e4e
+  subjects:
+  - entities:
+    - role: player
+      name: Kevin Alcántara
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: ARC-KC
+  uuid: 28344560-65c6-470a-9cf1-1b5c8050514c
+  subjects:
+  - entities:
+    - role: player
+      name: Kristian Campbell
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: ARC-LA
+  uuid: d5ecd022-1c0b-4a95-8eba-ea39823e129f
+  subjects:
+  - entities:
+    - role: player
+      name: Luisangel Acuña
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: ARC-LW
+  uuid: 6825f24c-afcb-401d-be72-f4283ec2b9d3
+  subjects:
+  - entities:
+    - role: player
+      name: Larry Walker
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: ARC-MH
+  uuid: 45268aaf-a747-46c1-b56f-ce0301d37558
+  subjects:
+  - entities:
+    - role: player
+      name: Michael Harris II
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: ARC-MM
+  uuid: 2b47cb2f-a1f6-4962-b20c-2c88322bac40
+  subjects:
+  - entities:
+    - role: player
+      name: Manny Machado
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: ARC-MO
+  uuid: 1ead5238-3dc3-4caa-900a-4c8c330b1eb7
+  subjects:
+  - entities:
+    - role: player
+      name: Matt Olson
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: ARC-MOZ
+  uuid: 370456d5-dda2-4d4e-abbd-b44823697b9e
+  subjects:
+  - entities:
+    - role: player
+      name: Marcell Ozuna
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: ARC-MSH
+  uuid: f4a3e11e-2edd-402a-b195-652f36ee06d6
+  subjects:
+  - entities:
+    - role: player
+      name: Matt Shaw
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: ARC-MT
+  uuid: 9ada91ef-9fee-481f-81f3-83f4ba4fcf8c
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Trout
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: ARC-MW
+  uuid: 16523417-9f37-4fad-8308-28a1bab5d7dc
+  subjects:
+  - entities:
+    - role: player
+      name: Masyn Winn
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: ARC-MY
+  uuid: a138847d-08cc-48bf-8e89-94768496ec45
+  subjects:
+  - entities:
+    - role: player
+      name: Masataka Yoshida
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: ARC-PA
+  uuid: 9de66faf-cd7a-47fa-9e37-d3d719d3e450
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Alonso
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: ARC-RA
+  uuid: 6b66c2ea-d994-430f-942e-05a02289cdc7
+  subjects:
+  - entities:
+    - role: player
+      name: Ronald Acuña Jr.
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: ARC-RD
+  uuid: 1a5bcc22-be6c-43a3-b24f-349dec64ff56
+  subjects:
+  - entities:
+    - role: player
+      name: Rafael Devers
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: ARC-SF
+  uuid: f2b4b3bf-e335-4fef-953b-c26010f9cf59
+  subjects:
+  - entities:
+    - role: player
+      name: Sal Frelick
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: ARC-TH
+  uuid: 8c0fe082-b1b0-43af-a189-90fcbe66fac6
+  subjects:
+  - entities:
+    - role: player
+      name: Torii Hunter
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: ARC-VG
+  uuid: 347846c7-f722-4235-b59e-97ad6bc740d1
+  subjects:
+  - entities:
+    - role: player
+      name: Vladimir Guerrero Jr.
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 

--- a/data/baseball/2025-26-topps-definitive-collection/checklists/defining-images-autographs.yaml
+++ b/data/baseball/2025-26-topps-definitive-collection/checklists/defining-images-autographs.yaml
@@ -1,0 +1,430 @@
+- number: DIAC-ABR
+  uuid: c5f63d7a-57cd-4850-864c-f0183bacbc3b
+  subjects:
+  - entities:
+    - role: player
+      name: Alex Bregman
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: DIAC-AR
+  uuid: f1968d13-38d1-4e5a-9810-2f32d132691b
+  subjects:
+  - entities:
+    - role: player
+      name: Adley Rutschman
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: DIAC-BB
+  uuid: 530df3c6-5434-4e50-88df-d7bebefe76b0
+  subjects:
+  - entities:
+    - role: player
+      name: Byron Buxton
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: DIAC-CC
+  uuid: 618f0163-4b3c-45c0-bf17-6c687b48b591
+  subjects:
+  - entities:
+    - role: player
+      name: Corbin Carroll
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: DIAC-CF
+  uuid: 7f84f77c-9f36-4409-9113-544bdb8bb5a7
+  subjects:
+  - entities:
+    - role: player
+      name: Carlton Fisk
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: DIAC-CJ
+  uuid: '0964732d-3871-4467-a7ae-9777efadc1ee'
+  subjects:
+  - entities:
+    - role: player
+      name: Chipper Jones
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: DIAC-CK
+  uuid: b456d0de-48c2-4c03-be78-a2c6c40f4848
+  subjects:
+  - entities:
+    - role: player
+      name: Clayton Kershaw
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: DIAC-CM
+  uuid: d5759e64-e878-420a-a544-62c170dcae48
+  subjects:
+  - entities:
+    - role: player
+      name: Coby Mayo
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: DIAC-CS
+  uuid: c81639ee-9923-4e52-8803-d0b8b6569ada
+  subjects:
+  - entities:
+    - role: player
+      name: Cam Smith
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: DIAC-DO
+  uuid: 2956ddeb-4c50-4f61-95d9-528294cd64e3
+  subjects:
+  - entities:
+    - role: player
+      name: David Ortiz
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: DIAC-FL
+  uuid: 03a1cd8d-78b0-4b91-a284-7aa07a852299
+  subjects:
+  - entities:
+    - role: player
+      name: Francisco Lindor
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: DIAC-FT
+  uuid: 745556e2-c859-47df-9dc3-7aa5cda0f259
+  subjects:
+  - entities:
+    - role: player
+      name: Frank Thomas
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: DIAC-FTJ
+  uuid: 53887ef1-220d-4cdf-a92e-0d2c08d5035d
+  subjects:
+  - entities:
+    - role: player
+      name: Fernando Tatis Jr.
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: DIAC-GB
+  uuid: 32075b4d-6f28-492e-86ea-1bd7f95ab255
+  subjects:
+  - entities:
+    - role: player
+      name: George Brett
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: DIAC-IR
+  uuid: 4ce3db3c-be3e-496f-8544-ece5a830bc68
+  subjects:
+  - entities:
+    - role: player
+      name: Ivan Rodriguez
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: DIAC-JCJ
+  uuid: c539a28a-ad75-4eee-9f48-c850894fe56c
+  subjects:
+  - entities:
+    - role: player
+      name: Jazz Chisholm Jr.
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: DIAC-JD
+  uuid: 7d8165b2-e318-49f7-9207-17e2f18ea80f
+  subjects:
+  - entities:
+    - role: player
+      name: Jasson Domínguez
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: DIAC-JH
+  uuid: 8f0b7d16-f5dc-43c5-854d-d09db323e4f4
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Holliday
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: DIAC-JL
+  uuid: 3ef3aaa3-8bdb-404f-8c02-8eca86960cf7
+  subjects:
+  - entities:
+    - role: player
+      name: Jung Hoo Lee
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: DIAC-JM
+  uuid: 62da8395-cb5d-4fbe-b8f8-695207c9788b
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Merrill
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: DIAC-JR
+  uuid: b8c91b2d-5e39-4a07-b6e6-7230091bc95c
+  subjects:
+  - entities:
+    - role: player
+      name: José Ramírez
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: DIAC-JS
+  uuid: a428a19a-759f-4a13-bd4d-547b56e7b42c
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: DIAC-JV
+  uuid: f0c5a54d-4b7f-4244-a612-644e589e0b71
+  subjects:
+  - entities:
+    - role: player
+      name: Joey Votto
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: DIAC-KC
+  uuid: e8bcdcfa-5618-4cdc-8c62-2b7d29cff2cc
+  subjects:
+  - entities:
+    - role: player
+      name: Kristian Campbell
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: DIAC-KTU
+  uuid: 3afec1bd-8615-49c3-9e4b-4818b9cbee70
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Tucker
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: DIAC-MC
+  uuid: 7946296d-3872-46e9-bfbb-b1922f5bee38
+  subjects:
+  - entities:
+    - role: player
+      name: Miguel Cabrera
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: DIAC-MO
+  uuid: 69d30625-d781-4c61-868a-74d6d874c76f
+  subjects:
+  - entities:
+    - role: player
+      name: Matt Olson
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: DIAC-MS
+  uuid: 88973de2-749c-4f3f-b4f1-723ffe15aa10
+  subjects:
+  - entities:
+    - role: player
+      name: Matt Shaw
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: DIAC-MT
+  uuid: 3d497b2d-b933-4a10-970b-2b93ef7ade84
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Trout
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: DIAC-PA
+  uuid: bcc7bd4d-caf1-4893-8679-b9c390540ce3
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Alonso
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: DIAC-PF
+  uuid: e0681a88-0133-42fd-a52c-3587ea318188
+  subjects:
+  - entities:
+    - role: player
+      name: Prince Fielder
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: DIAC-PM
+  uuid: 4ec20f27-5b57-4afd-8490-9ee7fe7cd234
+  subjects:
+  - entities:
+    - role: player
+      name: Paul Molitor
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: DIAC-RH
+  uuid: 740b9fe7-61f0-457e-b051-71e1578377dd
+  subjects:
+  - entities:
+    - role: player
+      name: Ryan Howard
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: DIAC-RJ
+  uuid: 4a9e4835-a316-4cf8-b449-62135edcbc72
+  subjects:
+  - entities:
+    - role: player
+      name: Randy Johnson
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: DIAC-RJA
+  uuid: 67bfc5e1-70fb-46f5-a222-a89d6cd26181
+  subjects:
+  - entities:
+    - role: player
+      name: Reggie Jackson
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: DIAC-RS
+  uuid: 7d3e0de7-e9e0-4c5d-9d6d-5bde1b886d61
+  subjects:
+  - entities:
+    - role: player
+      name: Roki Sasaki
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: DIAC-RY
+  uuid: 7d4f0459-3fac-4ffc-95e9-9c6f79fb3feb
+  subjects:
+  - entities:
+    - role: player
+      name: Robin Yount
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: DIAC-SI
+  uuid: 82eefd41-3868-4726-b07b-7b0d66caf4ba
+  subjects:
+  - entities:
+    - role: player
+      name: Shota Imanaga
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: DIAC-TT
+  uuid: 2118ea66-0045-46b1-8a99-8ca2944b76bf
+  subjects:
+  - entities:
+    - role: player
+      name: Trea Turner
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: DIAC-VG
+  uuid: 36a3664d-8163-4642-8376-701698db3972
+  subjects:
+  - entities:
+    - role: player
+      name: Vladimir Guerrero
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: DIAC-VGJ
+  uuid: d4fde73d-7539-4264-a3db-43a3f390c781
+  subjects:
+  - entities:
+    - role: player
+      name: Vladimir Guerrero Jr.
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: DIAC-WB
+  uuid: 34da68da-e75f-454f-b81c-b1b042197753
+  subjects:
+  - entities:
+    - role: player
+      name: Wade Boggs
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: DIAC-WL
+  uuid: 47b249a2-ff4f-41fb-b19c-b0c3362dc226
+  subjects:
+  - entities:
+    - role: player
+      name: Wyatt Langford
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 

--- a/data/baseball/2025-26-topps-definitive-collection/checklists/definitive-autographed-first-batting-gloves.yaml
+++ b/data/baseball/2025-26-topps-definitive-collection/checklists/definitive-autographed-first-batting-gloves.yaml
@@ -1,0 +1,490 @@
+- number: DABG-AAZ
+  uuid: 12596c07-dbd7-4f86-900b-c174f8d3628c
+  subjects:
+  - entities:
+    - role: player
+      name: Armando Alvarez
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: DABG-ARA
+  uuid: 4c611fef-7b92-440c-b01c-3aeb5be46ae3
+  subjects:
+  - entities:
+    - role: player
+      name: Agustín Ramírez
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: DABG-BB
+  uuid: 22bde6ec-beda-40b0-92d2-e4569a26e2d6
+  subjects:
+  - entities:
+    - role: player
+      name: Brooks Baldwin
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: DABG-BD
+  uuid: 49f39c92-5e24-47b5-a2dd-138dc4700379
+  subjects:
+  - entities:
+    - role: player
+      name: Blake Dunn
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: DABG-BLO
+  uuid: e4782a2d-9b30-4e9b-b691-00836f3afd4c
+  subjects:
+  - entities:
+    - role: player
+      name: Brandon Lockridge
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: DABG-BR
+  uuid: 202c0e8d-ea12-4075-865c-2bae2100dfbc
+  subjects:
+  - entities:
+    - role: player
+      name: Ben Rice
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: DABG-BT
+  uuid: e23f7dc1-84ea-4b57-adbb-ebfb01837ca7
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Teodosio
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: DABG-BWI
+  uuid: 031ae192-1750-450c-b206-6b61254d0b38
+  subjects:
+  - entities:
+    - role: player
+      name: Ben Williamson
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: DABG-CD
+  uuid: 2d4fa2a8-178d-4be7-a37b-8b2938ff1df4
+  subjects:
+  - entities:
+    - role: player
+      name: Caleb Durbin
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: DABG-CM
+  uuid: c492160d-97e4-4056-a87f-3b0a304f23c9
+  subjects:
+  - entities:
+    - role: player
+      name: Coby Mayo
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: DABG-CS
+  uuid: 45db30f9-f8c4-47e4-a9a3-c76939802ab5
+  subjects:
+  - entities:
+    - role: player
+      name: Cam Smith
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: DABG-CSI
+  uuid: c34c8f1f-9443-4be0-b181-eabeb838275c
+  subjects:
+  - entities:
+    - role: player
+      name: Chandler Simpson
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: DABG-DAR
+  uuid: 61063379-5959-4978-bf37-79a174951703
+  subjects:
+  - entities:
+    - role: player
+      name: Dalton Rushing
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: DABG-DBA
+  uuid: 92665c83-d850-4e09-9612-21249e5ef249
+  subjects:
+  - entities:
+    - role: player
+      name: Drake Baldwin
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: DABG-DD
+  uuid: e58cd288-c415-4c31-97b8-eddbd989f314
+  subjects:
+  - entities:
+    - role: player
+      name: Dillon Dingler
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: DABG-DH
+  uuid: 924e2648-e4d9-477e-af40-0d8d05e947d4
+  subjects:
+  - entities:
+    - role: player
+      name: Dustin Harris
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: DABG-DHA
+  uuid: 38b09b66-fc3a-4aef-a552-2340c52d5a1f
+  subjects:
+  - entities:
+    - role: player
+      name: Dustin Harris
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: DABG-DK
+  uuid: 710d89d6-06ae-47cc-a23b-634c96fe7442
+  subjects:
+  - entities:
+    - role: player
+      name: DaShawn Keirsey Jr.
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: DABG-EQ
+  uuid: 9f2c059a-a5b4-4465-aeb2-f44e4b669f78
+  subjects:
+  - entities:
+    - role: player
+      name: Edgar Quero
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: DABG-GC
+  uuid: 6a455090-6bf4-4de8-9691-6739e6b5629d
+  subjects:
+  - entities:
+    - role: player
+      name: Griffin Conine
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: DABG-HK
+  uuid: b525ca6f-646e-4901-8a9b-08fc19b4b1e6
+  subjects:
+  - entities:
+    - role: player
+      name: Hyeseong Kim
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: DABG-HS
+  uuid: 681b78bc-ebfe-4b20-bb8e-28a26933cb20
+  subjects:
+  - entities:
+    - role: player
+      name: Hayden Senger
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: DABG-JCE
+  uuid: 1e0e7f05-668a-4bed-a8c1-1dfe104fc999
+  subjects:
+  - entities:
+    - role: player
+      name: J.C. Escarra
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: DABG-JE
+  uuid: feb96d5f-ce28-47cb-890b-51325e7d54ac
+  subjects:
+  - entities:
+    - role: player
+      name: J.C. Escarra
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: DABG-JM
+  uuid: 7f28112d-18b3-49a3-9f56-d42cab51834e
+  subjects:
+  - entities:
+    - role: player
+      name: Justyn-Henry Malloy
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: DABG-JMA
+  uuid: 8bf3c4e0-9759-46ba-9e0b-abc18f95962a
+  subjects:
+  - entities:
+    - role: player
+      name: Jake Mangum
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: DABG-JR
+  uuid: 93d16ef3-cdd2-4e69-831d-913add355712
+  subjects:
+  - entities:
+    - role: player
+      name: John Rave
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: DABG-JV
+  uuid: 88a5d0a3-171a-44d7-abb9-b3bbe9b2f7a4
+  subjects:
+  - entities:
+    - role: player
+      name: Jorbit Vivas
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: DABG-JWI
+  uuid: 6df8babe-5523-4656-a3d7-fc608d0f2cde
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Wilson
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: DABG-KA
+  uuid: 2e6b4bc4-4b5e-42e4-85fd-965450753bd9
+  subjects:
+  - entities:
+    - role: player
+      name: Kevin Alcántara
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: DABG-KC
+  uuid: 8d689af4-1283-43fc-a1d4-26c1fab777eb
+  subjects:
+  - entities:
+    - role: player
+      name: Kristian Campbell
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: DABG-KCA
+  uuid: 5021627d-3f02-4f35-a1e7-655c74891b07
+  subjects:
+  - entities:
+    - role: player
+      name: Kristian Campbell
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: DABG-KM
+  uuid: ab443092-c496-42c2-aa82-a880f748c367
+  subjects:
+  - entities:
+    - role: player
+      name: Kameron Misner
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: DABG-LA
+  uuid: 1975488f-1341-4dff-a101-24d315015085
+  subjects:
+  - entities:
+    - role: player
+      name: Luisangel Acuña
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: DABG-LDA
+  uuid: 57b2fd13-4ec0-4aef-a21e-b4124e399f31
+  subjects:
+  - entities:
+    - role: player
+      name: Logan Davidson
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: DABG-LH
+  uuid: bac0daa8-eabd-4d71-be5e-7e63270b815b
+  subjects:
+  - entities:
+    - role: player
+      name: Liam Hicks
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: DABG-LK
+  uuid: db2a8ece-e1e2-4e85-ad9c-022e55ccf146
+  subjects:
+  - entities:
+    - role: player
+      name: Luke Keaschall
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: DABG-MB
+  uuid: c999ac35-66c8-490d-8015-ba5e0d355ba3
+  subjects:
+  - entities:
+    - role: player
+      name: Moisés Ballesteros
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: DABG-MMA
+  uuid: c1e505b5-cd2e-4d61-8e9c-b98dbf71712b
+  subjects:
+  - entities:
+    - role: player
+      name: Marcelo Mayer
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: DABG-MS
+  uuid: 520fb689-d594-4802-bd5a-1148f7c3c8d9
+  subjects:
+  - entities:
+    - role: player
+      name: Matt Shaw
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: DABG-NK
+  uuid: 9157ebb3-b2dd-4f16-8b21-b53415142a02
+  subjects:
+  - entities:
+    - role: player
+      name: Niko Kavadas
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: DABG-NKU
+  uuid: 9b59edd1-82fd-4adf-bb1a-8ee7451ea63a
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Kurtz
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: DABG-NS
+  uuid: 68ba9b4e-bbe0-4b0f-b4cd-f3647721455f
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Sogard
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: DABG-TC
+  uuid: 14ae6941-0e0c-4763-9836-cee95438740a
+  subjects:
+  - entities:
+    - role: player
+      name: Tyler Callihan
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: DABG-TL
+  uuid: 78125fab-c85d-4c5d-bc55-c9fe5152317c
+  subjects:
+  - entities:
+    - role: player
+      name: Tyler Locklear
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: DABG-TSW
+  uuid: aa14de3a-012b-4170-a4ae-40581449cdc6
+  subjects:
+  - entities:
+    - role: player
+      name: Trey Sweeney
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: DABG-VMJ
+  uuid: 9010a3b7-13e6-4017-bddc-2193457e5395
+  subjects:
+  - entities:
+    - role: player
+      name: Victor Mesa Jr.
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: DABG-WW
+  uuid: e9176aa7-e6b8-481b-8eaf-6888e0dd07ea
+  subjects:
+  - entities:
+    - role: player
+      name: Will Wagner
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: DABG-ZD
+  uuid: 64619760-9ea0-4f2c-bc18-6a8b375a2216
+  subjects:
+  - entities:
+    - role: player
+      name: Zach Dezenzo
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 

--- a/data/baseball/2025-26-topps-definitive-collection/checklists/definitive-autographed-relics.yaml
+++ b/data/baseball/2025-26-topps-definitive-collection/checklists/definitive-autographed-relics.yaml
@@ -1,0 +1,860 @@
+- number: DAR-AB
+  uuid: 4f712718-435e-4241-b82c-85dd7b0a4097
+  subjects:
+  - entities:
+    - role: player
+      name: Adrian Beltré
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: DAR-AD
+  uuid: a100f54f-bd68-4621-be76-c57420e59708
+  subjects:
+  - entities:
+    - role: player
+      name: Andre Dawson
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: DAR-AJ
+  uuid: 3f1eab12-daa1-4cde-9594-fe470dcfc2d0
+  subjects:
+  - entities:
+    - role: player
+      name: Andruw Jones
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: DAR-AJU
+  uuid: b21225fe-3c47-4d49-a06d-a9b4af9a8041
+  subjects:
+  - entities:
+    - role: player
+      name: Aaron Judge
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: DAR-AM
+  uuid: 9a32b7eb-2f92-46de-8faa-c9627ff5d449
+  subjects:
+  - entities:
+    - role: player
+      name: Andrew McCutchen
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: DAR-AP
+  uuid: 1f5722c7-9450-4dcf-bb07-a61d6a5a5c3e
+  subjects:
+  - entities:
+    - role: player
+      name: Andy Pettitte
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: DAR-APU
+  uuid: 52b56d1a-376f-40f2-9321-252e85a33121
+  subjects:
+  - entities:
+    - role: player
+      name: Albert Pujols
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: DAR-AR
+  uuid: 0a0582c0-8fde-432c-a1f6-f3a72fc8782d
+  subjects:
+  - entities:
+    - role: player
+      name: Austin Riley
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: DAR-AROD
+  uuid: ae43e36a-98bd-4bed-8cad-2c6fb5585396
+  subjects:
+  - entities:
+    - role: player
+      name: Alex Rodriguez
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: DAR-ARU
+  uuid: b1c20ea7-95ad-4951-b39b-234aef9cd8b0
+  subjects:
+  - entities:
+    - role: player
+      name: Adley Rutschman
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: DAR-BB
+  uuid: d53cd147-1837-4a8f-9bfc-854f839b04db
+  subjects:
+  - entities:
+    - role: player
+      name: Barry Bonds
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: DAR-BBY
+  uuid: d3cd0a02-8553-4452-8439-641579c7451e
+  subjects:
+  - entities:
+    - role: player
+      name: Bert Blyleven
+      ref: 
+    - role: team
+      name: California Angels
+      ref: 
+- number: DAR-BH
+  uuid: b7f5c817-47f7-48c5-9ee3-a25d1f9b4960
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Harper
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: DAR-BIG
+  uuid: a5db0636-98c3-4424-8185-ee3784bc1644
+  subjects:
+  - entities:
+    - role: player
+      name: Craig Biggio
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: DAR-BJ
+  uuid: 79474276-5276-4c4c-9fce-b7b9bb0dc014
+  subjects:
+  - entities:
+    - role: player
+      name: Bo Jackson
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: DAR-BL
+  uuid: 380599fa-1296-4d09-9526-2cf5fbbc3623
+  subjects:
+  - entities:
+    - role: player
+      name: Barry Larkin
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: DAR-BW
+  uuid: 39daaf39-b16d-437b-a60c-a1258b361952
+  subjects:
+  - entities:
+    - role: player
+      name: Bernie Williams
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: DAR-CB
+  uuid: 1f6d9c88-3fc3-4ccc-9e64-8051c3ac2e99
+  subjects:
+  - entities:
+    - role: player
+      name: Carlos Beltrán
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: DAR-CC
+  uuid: ed3a09ff-2742-4e8e-a728-bb787c431cb1
+  subjects:
+  - entities:
+    - role: player
+      name: CC Sabathia
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: DAR-CJ
+  uuid: ea01e146-96e5-4ada-b56e-eba0bd6fe464
+  subjects:
+  - entities:
+    - role: player
+      name: Chipper Jones
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: DAR-CR
+  uuid: 9e93cc60-c515-43a0-876e-5c64a8a0785d
+  subjects:
+  - entities:
+    - role: player
+      name: Cal Ripken Jr.
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: DAR-CS
+  uuid: 73c64e2a-e8a3-4ff8-acf8-cecac9d338a0
+  subjects:
+  - entities:
+    - role: player
+      name: Corey Seager
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: DAR-CU
+  uuid: 5022867c-a1bb-418e-8b0f-878ed5c36669
+  subjects:
+  - entities:
+    - role: player
+      name: Chase Utley
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: DAR-DG
+  uuid: 3f5203f7-4462-4eae-a3be-c4f72060b487
+  subjects:
+  - entities:
+    - role: player
+      name: Dwight Gooden
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: DAR-DJ
+  uuid: dd7049c8-87cc-4fc2-9e12-8d677bc00fa8
+  subjects:
+  - entities:
+    - role: player
+      name: Derek Jeter
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: DAR-DO
+  uuid: 4f8b833f-35c4-40f1-91f6-db1785eac3f3
+  subjects:
+  - entities:
+    - role: player
+      name: David Ortiz
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: DAR-DS
+  uuid: ba853dbd-5f0b-45ec-af8a-8c18f304bc52
+  subjects:
+  - entities:
+    - role: player
+      name: Darryl Strawberry
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: DAR-DW
+  uuid: e548a0e9-31c1-44e1-8125-2a04c3806adc
+  subjects:
+  - entities:
+    - role: player
+      name: Dave Winfield
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: DAR-DWR
+  uuid: 95435046-9c39-4acd-99f5-2483a1538961
+  subjects:
+  - entities:
+    - role: player
+      name: David Wright
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: DAR-EM
+  uuid: 3310fd82-e36e-463e-b295-341ee7eb7222
+  subjects:
+  - entities:
+    - role: player
+      name: Edgar Martinez
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: DAR-FF
+  uuid: 81ba08d6-e60b-4540-9210-d31be022e554
+  subjects:
+  - entities:
+    - role: player
+      name: Freddie Freeman
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: DAR-FH
+  uuid: bfc8baf5-179f-4817-835e-a376eab82e35
+  subjects:
+  - entities:
+    - role: player
+      name: Félix Hernández
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: DAR-FL
+  uuid: 8a420907-e66b-41b6-a94e-0ff540818028
+  subjects:
+  - entities:
+    - role: player
+      name: Francisco Lindor
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: DAR-FM
+  uuid: 53bb178f-8452-4be0-b0ed-b1f59b337155
+  subjects:
+  - entities:
+    - role: player
+      name: Fred McGriff
+      ref: 
+    - role: team
+      name: Tampa Bay Devil Rays
+      ref: 
+- number: DAR-FTJ
+  uuid: 38bb0c53-0ada-4185-88ea-92e1c09ccf77
+  subjects:
+  - entities:
+    - role: player
+      name: Fernando Tatis Jr.
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: DAR-GH
+  uuid: 81f8d4da-b7be-4851-8bb2-bbc8f6bb8a7e
+  subjects:
+  - entities:
+    - role: player
+      name: Gunnar Henderson
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: DAR-GS
+  uuid: 198b64da-8488-4148-89ef-b5bba820d644
+  subjects:
+  - entities:
+    - role: player
+      name: Gary Sheffield
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: DAR-HM
+  uuid: 9c01f927-30e9-4089-baae-6c1a7b351711
+  subjects:
+  - entities:
+    - role: player
+      name: Hideki Matsui
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: DAR-HR
+  uuid: e63ac171-37ed-46c5-acdb-680ea9120243
+  subjects:
+  - entities:
+    - role: player
+      name: Hanley Ramirez
+      ref: 
+    - role: team
+      name: Florida Marlins
+      ref: 
+- number: DAR-I
+  uuid: 4f1451dc-d722-4f9d-9764-72934c9ecd26
+  subjects:
+  - entities:
+    - role: player
+      name: Ichiro
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: DAR-IR
+  uuid: 5b30d9c3-4b1c-498b-bec1-5d06889e56a3
+  subjects:
+  - entities:
+    - role: player
+      name: Ivan Rodriguez
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: DAR-IS
+  uuid: cdef294b-56a0-4d8e-99f7-71b48f6af29b
+  subjects:
+  - entities:
+    - role: player
+      name: Ichiro
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: DAR-JB
+  uuid: e6ce4d16-ffb9-4ab8-ab07-7eec919887e5
+  subjects:
+  - entities:
+    - role: player
+      name: Jeff Bagwell
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: DAR-JD
+  uuid: 5fe73045-6ce5-4aa7-93f8-05bb93878756
+  subjects:
+  - entities:
+    - role: player
+      name: Johnny Damon
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: DAR-JH
+  uuid: 1ebb6285-863d-4315-8c4e-593793b4e7d2
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Holliday
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: DAR-JP
+  uuid: a87d2841-65d8-419b-8bb3-734dfc55438e
+  subjects:
+  - entities:
+    - role: player
+      name: Jim Palmer
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: DAR-JPO
+  uuid: 92e42d81-c21f-401e-99c0-9efcd4c9bebc
+  subjects:
+  - entities:
+    - role: player
+      name: Jorge Posada
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: DAR-JR
+  uuid: 983e0832-0c49-4047-9148-ddfc0f0036da
+  subjects:
+  - entities:
+    - role: player
+      name: Jimmy Rollins
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: DAR-JRA
+  uuid: b1f342ad-cacd-4cca-b8fe-d852c953fb21
+  subjects:
+  - entities:
+    - role: player
+      name: José Ramírez
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: DAR-JS
+  uuid: c8628a49-c20e-499e-9bc7-93037640b531
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: DAR-JSM
+  uuid: f22ffe08-ea3e-4c76-acfb-eb9aefcedd7f
+  subjects:
+  - entities:
+    - role: player
+      name: John Smoltz
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: DAR-JV
+  uuid: b44cc75f-491d-481d-8464-0c184746af36
+  subjects:
+  - entities:
+    - role: player
+      name: Joey Votto
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: DAR-KG
+  uuid: c3858fbb-80f4-4d3d-8f9e-04342a3e80a8
+  subjects:
+  - entities:
+    - role: player
+      name: Ken Griffey Jr.
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: DAR-KT
+  uuid: 15813593-2c12-4261-a0e3-7fde09d14fc7
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Tucker
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: DAR-LG
+  uuid: 20e781e3-0562-4026-b9c3-027b3b07c14f
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Gonzalez
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: DAR-LW
+  uuid: '083cead9-730b-4bfc-98de-4d06a7f56baf'
+  subjects:
+  - entities:
+    - role: player
+      name: Larry Walker
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: DAR-MM
+  uuid: 8ac7d3d7-4b22-43a7-a41c-2747b0d8609e
+  subjects:
+  - entities:
+    - role: player
+      name: Manny Machado
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: DAR-MP
+  uuid: 68a07f75-8825-4f7b-854d-17219fe8fa8e
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Piazza
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: DAR-MS
+  uuid: af41ad8d-5f45-449f-bfbd-9af366aad376
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Schmidt
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: DAR-MT
+  uuid: f8d49ae9-edca-4031-b0ee-d72e56560b8c
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Trout
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: DAR-MTX
+  uuid: ea4fbdfe-0087-477c-ace9-9b336c76e2fa
+  subjects:
+  - entities:
+    - role: player
+      name: Mark Teixeira
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: DAR-NG
+  uuid: 7731c325-c69b-4503-9b9c-9a628d7c0a38
+  subjects:
+  - entities:
+    - role: player
+      name: Nomar Garciaparra
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: DAR-OA
+  uuid: 8b9df9a4-fa86-40ad-a810-2cba01455d77
+  subjects:
+  - entities:
+    - role: player
+      name: Ozzie Albies
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: DAR-OH
+  uuid: a216f07a-4963-45c2-9782-65a3e161cb26
+  subjects:
+  - entities:
+    - role: player
+      name: Orel Hershiser
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: DAR-OS
+  uuid: be4d69d0-4e50-454a-b5e5-649e4e07e611
+  subjects:
+  - entities:
+    - role: player
+      name: Ozzie Smith
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: DAR-PF
+  uuid: c2b3cfb1-7ee8-436c-a244-fd86a7dfedf5
+  subjects:
+  - entities:
+    - role: player
+      name: Prince Fielder
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: DAR-PM
+  uuid: 2bafa46a-c790-44e4-a2ec-cc5fcaf0c563
+  subjects:
+  - entities:
+    - role: player
+      name: Paul Molitor
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: DAR-RA
+  uuid: f5045239-f590-46fa-963e-31252ac3df55
+  subjects:
+  - entities:
+    - role: player
+      name: Ronald Acuña Jr.
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: DAR-RC
+  uuid: dafd9415-e8de-40f8-a34f-add5ada38e3f
+  subjects:
+  - entities:
+    - role: player
+      name: Roger Clemens
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: DAR-RH
+  uuid: 8ee635b5-a05b-473b-b400-3524b4ba2be5
+  subjects:
+  - entities:
+    - role: player
+      name: Ryan Howard
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: DAR-RJ
+  uuid: 35c92094-9ea3-469e-be30-ef6357861076
+  subjects:
+  - entities:
+    - role: player
+      name: Randy Johnson
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: DAR-RJA
+  uuid: 3e51091f-cc65-4663-b684-da14b73ea9bb
+  subjects:
+  - entities:
+    - role: player
+      name: Reggie Jackson
+      ref: 
+    - role: team
+      name: California Angels
+      ref: 
+- number: DAR-ROD
+  uuid: 814521a8-80ad-48fb-ac7f-5a4d7a814fab
+  subjects:
+  - entities:
+    - role: player
+      name: Rod Carew
+      ref: 
+    - role: team
+      name: California Angels
+      ref: 
+- number: DAR-RY
+  uuid: 4a0ad84e-eacd-4db6-8646-2598b1abd393
+  subjects:
+  - entities:
+    - role: player
+      name: Robin Yount
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: DAR-SC
+  uuid: 3bc41e15-21f8-4397-83ef-474c527e21fe
+  subjects:
+  - entities:
+    - role: player
+      name: Steve Carlton
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: DAR-SO
+  uuid: d5be3911-4c57-41a4-994c-2a6e7ccabb23
+  subjects:
+  - entities:
+    - role: player
+      name: Shohei Ohtani
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: DAR-SR
+  uuid: 03fa2941-d8f0-4b32-8acd-031aa4ebc056
+  subjects:
+  - entities:
+    - role: player
+      name: Scott Rolen
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: DAR-SS
+  uuid: 227d439b-b0c0-452c-813a-5db592ce1bfd
+  subjects:
+  - entities:
+    - role: player
+      name: Sammy Sosa
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: DAR-TED
+  uuid: 9be71ded-4089-48f8-900e-c589f4327593
+  subjects:
+  - entities:
+    - role: player
+      name: Ted Simmons
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: DAR-TG
+  uuid: 514765e6-923a-4cce-834a-494e73b29daf
+  subjects:
+  - entities:
+    - role: player
+      name: Tom Glavine
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: DAR-TH
+  uuid: a7bfecfb-a0f6-4311-b3a3-98fba2a4f9f9
+  subjects:
+  - entities:
+    - role: player
+      name: Trevor Hoffman
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: DAR-THU
+  uuid: af0a7c0d-ea6d-41a9-9d4d-5202be43cdbb
+  subjects:
+  - entities:
+    - role: player
+      name: Torii Hunter
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: DAR-TP
+  uuid: eda86641-b0f4-40eb-a8a4-2971822c1f45
+  subjects:
+  - entities:
+    - role: player
+      name: Tony Perez
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: DAR-VG
+  uuid: 4c5c49f2-f240-4a9a-89aa-419a83ec5f16
+  subjects:
+  - entities:
+    - role: player
+      name: Vladimir Guerrero
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: DAR-VGJ
+  uuid: b391d9c4-93c9-4f83-80e8-08773ca501f4
+  subjects:
+  - entities:
+    - role: player
+      name: Vladimir Guerrero Jr.
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: DAR-WB
+  uuid: a2b6f6fc-34ba-4920-af4b-85f5b189d2c8
+  subjects:
+  - entities:
+    - role: player
+      name: Wade Boggs
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 

--- a/data/baseball/2025-26-topps-definitive-collection/checklists/definitive-autographed-ultra-patches.yaml
+++ b/data/baseball/2025-26-topps-definitive-collection/checklists/definitive-autographed-ultra-patches.yaml
@@ -1,0 +1,400 @@
+- number: DAUP-AJB
+  uuid: 2a93d533-b638-4599-9576-56a6b29a7908
+  subjects:
+  - entities:
+    - role: player
+      name: Aaron Judge
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: DAUP-AJOB
+  uuid: 7aa42cf4-2a87-4e94-8053-abe5a02fa215
+  subjects:
+  - entities:
+    - role: player
+      name: Andruw Jones
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: DAUP-AJOT
+  uuid: e29a8012-7399-4915-af9a-d385d72d6623
+  subjects:
+  - entities:
+    - role: player
+      name: Andruw Jones
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: DAUP-AJT
+  uuid: b36cd29c-b21d-414c-8290-7f0af9427abc
+  subjects:
+  - entities:
+    - role: player
+      name: Aaron Judge
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: DAUP-ARB
+  uuid: b26310da-c272-4740-ad69-c018f8a09087
+  subjects:
+  - entities:
+    - role: player
+      name: Alex Rodriguez
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: DAUP-ART
+  uuid: 4ac208ee-dbd0-450b-af83-4dae53a0d12b
+  subjects:
+  - entities:
+    - role: player
+      name: Alex Rodriguez
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: DAUP-ARUB
+  uuid: d4a99ea8-d065-460b-a9e8-35b9fc5b582b
+  subjects:
+  - entities:
+    - role: player
+      name: Adley Rutschman
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: DAUP-ARUT
+  uuid: e44e0453-b050-482c-aab2-51ff84a16584
+  subjects:
+  - entities:
+    - role: player
+      name: Adley Rutschman
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: DAUP-BHB
+  uuid: a651dd26-c299-4f71-827f-9458b3b4d926
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Harper
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: DAUP-BHT
+  uuid: 653cc608-6659-4846-8a4b-d64049a7516d
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Harper
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: DAUP-CBB
+  uuid: 60ca8d67-1384-45a8-be1c-abe020b1d771
+  subjects:
+  - entities:
+    - role: player
+      name: Craig Biggio
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: DAUP-CBT
+  uuid: 7eac0c16-5e6c-4602-a0ff-eee80da6b3ae
+  subjects:
+  - entities:
+    - role: player
+      name: Craig Biggio
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: DAUP-CJB
+  uuid: f315516a-4d77-459e-a1d7-4fc66049b516
+  subjects:
+  - entities:
+    - role: player
+      name: Chipper Jones
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: DAUP-CJT
+  uuid: 18a31f01-432a-45e4-aaf6-91446db068cc
+  subjects:
+  - entities:
+    - role: player
+      name: Chipper Jones
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: DAUP-CSB
+  uuid: 1f1b2b6c-7559-4852-8075-f68cb0c0507e
+  subjects:
+  - entities:
+    - role: player
+      name: CC Sabathia
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: DAUP-CST
+  uuid: 324424b6-1b37-409b-9fcb-8b915e66be9c
+  subjects:
+  - entities:
+    - role: player
+      name: CC Sabathia
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: DAUP-FHB
+  uuid: fee9cfd4-9057-4ae1-ab5e-9eb6b062b6f2
+  subjects:
+  - entities:
+    - role: player
+      name: Félix Hernández
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: DAUP-FHT
+  uuid: 17542217-4092-4810-8639-7b6aad56c15d
+  subjects:
+  - entities:
+    - role: player
+      name: Félix Hernández
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: DAUP-FLB
+  uuid: 79cafce3-7e6f-44c1-824d-67691467a3f9
+  subjects:
+  - entities:
+    - role: player
+      name: Francisco Lindor
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: DAUP-FLT
+  uuid: a00b108f-c69a-49cd-9c3c-c45b1199a11b
+  subjects:
+  - entities:
+    - role: player
+      name: Francisco Lindor
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: DAUP-HRB
+  uuid: fba03398-dd7f-4ef5-b1cb-9f32610089c2
+  subjects:
+  - entities:
+    - role: player
+      name: Hanley Ramirez
+      ref: 
+    - role: team
+      name: Florida Marlins
+      ref: 
+- number: DAUP-HRT
+  uuid: 3bffd208-417f-46ac-b5eb-56d2fe683a04
+  subjects:
+  - entities:
+    - role: player
+      name: Hanley Ramirez
+      ref: 
+    - role: team
+      name: Florida Marlins
+      ref: 
+- number: DAUP-JRAB
+  uuid: d65b327a-229b-4090-bdcd-738fb03809e5
+  subjects:
+  - entities:
+    - role: player
+      name: José Ramírez
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: DAUP-JRAT
+  uuid: 9caf0538-1f38-4b57-9ef2-76c2c752393a
+  subjects:
+  - entities:
+    - role: player
+      name: José Ramírez
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: DAUP-JRB
+  uuid: 5769de36-b8b0-49ca-a570-ddc64b3b171c
+  subjects:
+  - entities:
+    - role: player
+      name: Julio Rodríguez
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: DAUP-JRT
+  uuid: d6b8eeb7-5f73-4a9f-b30a-2a99088e2090
+  subjects:
+  - entities:
+    - role: player
+      name: Julio Rodríguez
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: DAUP-JWB
+  uuid: 41dab24d-01fd-484e-a6ce-e8d03fbe06d6
+  subjects:
+  - entities:
+    - role: player
+      name: James Wood
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: DAUP-JWT
+  uuid: faf0b68b-2fab-48db-b79b-1394ee84f0d7
+  subjects:
+  - entities:
+    - role: player
+      name: James Wood
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: DAUP-LWB
+  uuid: d4ab0b85-21f2-4168-be20-702b0228840e
+  subjects:
+  - entities:
+    - role: player
+      name: Larry Walker
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: DAUP-LWT
+  uuid: dfe269ba-f58f-46b3-93ad-c9f8c7f84438
+  subjects:
+  - entities:
+    - role: player
+      name: Larry Walker
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: DAUP-MCB
+  uuid: 878aa28c-fe84-47ca-87e4-4d1df75c6c10
+  subjects:
+  - entities:
+    - role: player
+      name: Miguel Cabrera
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: DAUP-MCT
+  uuid: 7be5eca9-298f-4abb-a6de-48113969b10f
+  subjects:
+  - entities:
+    - role: player
+      name: Miguel Cabrera
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: DAUP-MMB
+  uuid: b2303168-ec7b-424e-a832-30322f5e90c1
+  subjects:
+  - entities:
+    - role: player
+      name: Manny Machado
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: DAUP-MMT
+  uuid: f407380c-0f8c-4ced-ba9c-5540a0b5ec76
+  subjects:
+  - entities:
+    - role: player
+      name: Manny Machado
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: DAUP-PAB
+  uuid: eab43821-4aae-4787-92cc-7de5761f4ff9
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Alonso
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: DAUP-PAT
+  uuid: '01369221-b39e-4d5f-a36a-6c66e103e270'
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Alonso
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: DAUP-RAB
+  uuid: 8dbbfa98-a9fa-48b1-ac64-38ebe6ae90fe
+  subjects:
+  - entities:
+    - role: player
+      name: Ronald Acuña Jr.
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: DAUP-RAT
+  uuid: 8bdb38ad-9e01-4c00-83f5-42cbcd5a6f5a
+  subjects:
+  - entities:
+    - role: player
+      name: Ronald Acuña Jr.
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: DAUP-VGB
+  uuid: 79904f6d-b937-4ee5-ac41-5201da3b7026
+  subjects:
+  - entities:
+    - role: player
+      name: Vladimir Guerrero Jr.
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: DAUP-VGT
+  uuid: 8ab764e4-e4cf-4c98-9cc7-4c2b36b60b4c
+  subjects:
+  - entities:
+    - role: player
+      name: Vladimir Guerrero Jr.
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 

--- a/data/baseball/2025-26-topps-definitive-collection/checklists/definitive-city-connect-slogan-autographed-booklets.yaml
+++ b/data/baseball/2025-26-topps-definitive-collection/checklists/definitive-city-connect-slogan-autographed-booklets.yaml
@@ -1,0 +1,320 @@
+- number: CCSA-AB
+  uuid: 32bcd707-98f9-42c9-86cd-9e7b43713656
+  subjects:
+  - entities:
+    - role: player
+      name: Alex Bregman
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: CCSA-AG
+  uuid: 72f1ff37-03c9-4905-b56b-92d85335f1dd
+  subjects:
+  - entities:
+    - role: player
+      name: Adolis García
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: CCSA-AM
+  uuid: 1eb2aef8-3b11-492d-94b3-3659f4979e1e
+  subjects:
+  - entities:
+    - role: player
+      name: Andrew McCutchen
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: CCSA-AR
+  uuid: 4fc010f3-7e2c-4b0b-b051-1f89e841fa56
+  subjects:
+  - entities:
+    - role: player
+      name: Adley Rutschman
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: CCSA-BB
+  uuid: 28420494-005e-4178-8d93-207bf45ec111
+  subjects:
+  - entities:
+    - role: player
+      name: Byron Buxton
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: CCSA-BH
+  uuid: 6f3419ec-a8d7-4319-b7ed-5917a00afa75
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Harper
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: CCSA-BL
+  uuid: fcfad5cc-78a9-40ec-9e13-d69a8c18a151
+  subjects:
+  - entities:
+    - role: player
+      name: Brooks Lee
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: CCSA-CCA
+  uuid: d25a15c7-6fac-410c-9066-9cd58315b2b5
+  subjects:
+  - entities:
+    - role: player
+      name: Corbin Carroll
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: CCSA-CM
+  uuid: c9ba1dae-d92f-4adf-a0d1-07ef9468a1a7
+  subjects:
+  - entities:
+    - role: player
+      name: Christopher Morel
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: CCSA-CSA
+  uuid: fde5fda2-357f-4193-a9e5-7162ad8edbec
+  subjects:
+  - entities:
+    - role: player
+      name: Chris Sale
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: CCSA-DC
+  uuid: 26179a0d-1c7b-4d30-86fd-409468f2e2a9
+  subjects:
+  - entities:
+    - role: player
+      name: Dylan Crews
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: CCSA-DCR
+  uuid: 95bb5e00-55e1-4840-b596-8bceff18bc1a
+  subjects:
+  - entities:
+    - role: player
+      name: Dylan Crews
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: CCSA-FF
+  uuid: e1a1cb0c-fe87-48e9-90fc-309a8dd7ffb9
+  subjects:
+  - entities:
+    - role: player
+      name: Freddie Freeman
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: CCSA-FL
+  uuid: 40ccba87-81aa-4b8f-8e8d-71db43045ba1
+  subjects:
+  - entities:
+    - role: player
+      name: Francisco Lindor
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: CCSA-GH
+  uuid: 58fbcb7d-385a-44f8-84ef-e854faa27d26
+  subjects:
+  - entities:
+    - role: player
+      name: Gunnar Henderson
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: CCSA-GS
+  uuid: adb32f54-bc73-4b07-97aa-fd01d52b321b
+  subjects:
+  - entities:
+    - role: player
+      name: George Springer
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: CCSA-JA
+  uuid: bb14387d-d4a3-4fa2-b159-c22ea47f93c8
+  subjects:
+  - entities:
+    - role: player
+      name: Jose Altuve
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: CCSA-JC
+  uuid: 2e1a78fa-c082-41fb-8a47-61e1e47b86f2
+  subjects:
+  - entities:
+    - role: player
+      name: Jazz Chisholm Jr.
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: CCSA-JR
+  uuid: 97628fd3-9bef-4eca-9c2d-faf1acfad043
+  subjects:
+  - entities:
+    - role: player
+      name: Julio Rodríguez
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: CCSA-JRA
+  uuid: 1ed8d8b0-9e0d-4ce8-ae7b-e780613c0408
+  subjects:
+  - entities:
+    - role: player
+      name: José Ramírez
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: CCSA-JV
+  uuid: b7e00436-2b87-4462-800e-9efd76381846
+  subjects:
+  - entities:
+    - role: player
+      name: Joey Votto
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: CCSA-JW
+  uuid: ab598d81-ad21-43f4-97c4-33b1c0ff2e49
+  subjects:
+  - entities:
+    - role: player
+      name: James Wood
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: CCSA-JWE
+  uuid: 90c613fc-ed96-495a-8589-5ee908bd35f7
+  subjects:
+  - entities:
+    - role: player
+      name: Jordan Westburg
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: CCSA-KT
+  uuid: f0c4052f-79d0-4c74-993c-16fa9c8ff10d
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Tucker
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: CCSA-LC
+  uuid: 4c97fc4d-e5db-438f-bc96-60f82f4c5013
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Castillo
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: CCSA-MO
+  uuid: 99a2dcba-a143-43c7-9a44-195c8fd1b07d
+  subjects:
+  - entities:
+    - role: player
+      name: Matt Olson
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: CCSA-MT
+  uuid: 2b72aa9e-1465-47dc-9bd0-5e51d211d8bd
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Trout
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: CCSA-NA
+  uuid: f2573d9f-72b9-44c3-a87f-6d86d1937e2c
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan Arenado
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: CCSA-PC
+  uuid: db4b5a26-b325-4ee8-99fe-a0d0ce4347e6
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Crow-Armstrong
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: CCSA-RA
+  uuid: 708fd50f-ad3a-4322-8329-4456ce335c86
+  subjects:
+  - entities:
+    - role: player
+      name: Ronald Acuña Jr.
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: CCSA-SF
+  uuid: 28cc9195-35fb-480b-b4a5-8977dc409954
+  subjects:
+  - entities:
+    - role: player
+      name: Sal Frelick
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: CCSA-VG
+  uuid: f47c8689-b8f8-4b0d-8c2a-7902b69cfc86
+  subjects:
+  - entities:
+    - role: player
+      name: Vladimir Guerrero Jr.
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 

--- a/data/baseball/2025-26-topps-definitive-collection/checklists/definitive-cut-signatures.yaml
+++ b/data/baseball/2025-26-topps-definitive-collection/checklists/definitive-cut-signatures.yaml
@@ -1,0 +1,420 @@
+- number: DCS-AK
+  uuid: c30f2b59-8882-41eb-ab71-43575c4cddee
+  subjects:
+  - entities:
+    - role: player
+      name: Al Kaline
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: DCS-BG
+  uuid: 6ca44667-ff7d-40b1-a1a0-5db90abe58b7
+  subjects:
+  - entities:
+    - role: player
+      name: Bob Gibson
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: DCS-BR
+  uuid: 48eec31c-23a7-4cf5-b8c6-b22e99eef173
+  subjects:
+  - entities:
+    - role: player
+      name: Babe Ruth
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: DCS-CM
+  uuid: a9739fba-adde-4ae5-a077-96379270e1fe
+  subjects:
+  - entities:
+    - role: player
+      name: Connie Mack
+      ref: 
+    - role: team
+      name: Philadelphia Athletics
+      ref: 
+- number: DCS-DS
+  uuid: 191ef2bc-3008-497a-a140-9840a4ef3b04
+  subjects:
+  - entities:
+    - role: player
+      name: Don Sutton
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: DCS-DSN
+  uuid: 2434ec6c-f0c2-4941-b0f2-72e30945a229
+  subjects:
+  - entities:
+    - role: player
+      name: Duke Snider
+      ref: 
+    - role: team
+      name: Brooklyn Dodgers
+      ref: 
+- number: DCS-EB
+  uuid: 6325b9a8-b8a6-4ee4-ac34-7a5c6df6a6a4
+  subjects:
+  - entities:
+    - role: player
+      name: Ernie Banks
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: DCS-EM
+  uuid: d33719e2-5df6-492a-ad3f-7097ca4f7897
+  subjects:
+  - entities:
+    - role: player
+      name: Eddie Mathews
+      ref: 
+    - role: team
+      name: Milwaukee Braves
+      ref: 
+- number: DCS-ES
+  uuid: 606a827a-0510-4fe8-b6d5-9792a1891a8c
+  subjects:
+  - entities:
+    - role: player
+      name: Enos Slaughter
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: DCS-EW
+  uuid: 90eb1302-1212-4f04-9828-a01af636115d
+  subjects:
+  - entities:
+    - role: player
+      name: Earl Weaver
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: DCS-GC
+  uuid: da506131-e74a-4e03-9079-75dd90276c9c
+  subjects:
+  - entities:
+    - role: player
+      name: Gary Carter
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: DCS-GH
+  uuid: 46d6e81c-4a54-471d-ad40-deee47a157db
+  subjects:
+  - entities:
+    - role: player
+      name: Gabby Hartnett
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: DCS-GS
+  uuid: 70a6cbdd-9705-4496-acce-7cba045d15a7
+  subjects:
+  - entities:
+    - role: player
+      name: George Sisler
+      ref: 
+    - role: team
+      name: St. Louis Browns
+      ref: 
+- number: DCS-HA
+  uuid: f8ca3328-d0da-4d41-a33a-aacedd5857fe
+  subjects:
+  - entities:
+    - role: player
+      name: Hank Aaron
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: DCS-HG
+  uuid: 2db8d656-585d-40a9-8ae8-a4ee3ece3f5f
+  subjects:
+  - entities:
+    - role: player
+      name: Hank Greenberg
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: DCS-HK
+  uuid: 21aa385a-e6ca-480c-8da4-2a4ba825f1f5
+  subjects:
+  - entities:
+    - role: player
+      name: Harmon Killebrew
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: DCS-HW
+  uuid: ec78be63-e72e-40a6-bbba-b80d38d64e24
+  subjects:
+  - entities:
+    - role: player
+      name: Honus Wagner
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: DCS-JR
+  uuid: 6a722a92-43a7-40d0-97f5-e78ad55f4781
+  subjects:
+  - entities:
+    - role: player
+      name: Jackie Robinson
+      ref: 
+    - role: team
+      name: Brooklyn Dodgers
+      ref: 
+- number: DCS-KP
+  uuid: 79066651-4cbe-42bd-b6e7-7326da7c720c
+  subjects:
+  - entities:
+    - role: player
+      name: Kirby Puckett
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: DCS-LB
+  uuid: 4cec67bc-f0ab-4fc3-843a-26fc35334215
+  subjects:
+  - entities:
+    - role: player
+      name: Lou Brock
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: DCS-LD
+  uuid: '092cc6e7-31c1-41c2-a86f-2c065b41c6e3'
+  subjects:
+  - entities:
+    - role: player
+      name: Larry Doby
+      ref: 
+    - role: team
+      name: Cleveland
+      ref: 
+- number: DCS-MM
+  uuid: ab7cf108-4446-4269-9267-9d0899256f79
+  subjects:
+  - entities:
+    - role: player
+      name: Mickey Mantle
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: DCS-OC
+  uuid: 37cdcbab-f942-4704-872d-324b9227cb4c
+  subjects:
+  - entities:
+    - role: player
+      name: Orlando Cepeda
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: DCS-PN
+  uuid: 0b756cfe-0ede-439f-88a3-6527e293c8c0
+  subjects:
+  - entities:
+    - role: player
+      name: Phil Niekro
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: DCS-PR
+  uuid: f66a81d6-45c9-4aa2-8b2a-a0c73f88c5f8
+  subjects:
+  - entities:
+    - role: player
+      name: Pee Wee Reese
+      ref: 
+    - role: team
+      name: Brooklyn Dodgers
+      ref: 
+- number: DCS-RC
+  uuid: 33868f12-65b1-40dd-b447-d88b7bc2a87d
+  subjects:
+  - entities:
+    - role: player
+      name: Roberto Clemente
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: DCS-RH
+  uuid: '0059f23f-8973-4688-b0aa-41e1e6e1fa0d'
+  subjects:
+  - entities:
+    - role: player
+      name: Rickey Henderson
+      ref: 
+    - role: team
+      name: Oakland Athletics
+      ref: 
+- number: DCS-RM
+  uuid: 00c81d02-85e0-424f-b9bb-72e6a263c078
+  subjects:
+  - entities:
+    - role: player
+      name: Roger Maris
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: DCS-ROY
+  uuid: 148aceff-9344-4ba6-a195-b893c8c58357
+  subjects:
+  - entities:
+    - role: player
+      name: Roy Campanella
+      ref: 
+    - role: team
+      name: Brooklyn Dodgers
+      ref: 
+- number: DCS-RS
+  uuid: aed49153-af49-4256-a814-a4cd594e33cc
+  subjects:
+  - entities:
+    - role: player
+      name: Ron Santo
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: DCS-SM
+  uuid: '038fd462-09cd-49f9-8674-bbe5c177ac5a'
+  subjects:
+  - entities:
+    - role: player
+      name: Stan Musial
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: DCS-SP
+  uuid: 050c680f-0999-4f80-92e4-078ad7d07930
+  subjects:
+  - entities:
+    - role: player
+      name: Satchel Paige
+      ref: 
+    - role: team
+      name: St. Louis Browns
+      ref: 
+- number: DCS-TC
+  uuid: 4500b7b9-0156-4a66-ad58-5d2ff58963bf
+  subjects:
+  - entities:
+    - role: player
+      name: Ty Cobb
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: DCS-TG
+  uuid: 5f8e05f5-13ac-4716-9ea5-d42fe650777f
+  subjects:
+  - entities:
+    - role: player
+      name: Tony Gwynn
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: DCS-TL
+  uuid: d24d52d2-7de1-4b32-aee4-3dfcb18a706f
+  subjects:
+  - entities:
+    - role: player
+      name: Tommy Lasorda
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: DCS-TS
+  uuid: fffc76d6-8851-4a1b-929b-41d2fd1b4525
+  subjects:
+  - entities:
+    - role: player
+      name: Tris Speaker
+      ref: 
+    - role: team
+      name: Cleveland
+      ref: 
+- number: DCS-VS
+  uuid: f03b9ed8-5182-4e16-a00f-8a6b7551da48
+  subjects:
+  - entities:
+    - role: player
+      name: Vin Scully
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: DCS-WF
+  uuid: bcf081f0-2d1f-4d41-bc09-90112dd69e9d
+  subjects:
+  - entities:
+    - role: player
+      name: Whitey Ford
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: DCS-WM
+  uuid: a0201643-8597-42e5-ab47-7c3966f8a82c
+  subjects:
+  - entities:
+    - role: player
+      name: Willie Mays
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: DCS-WMC
+  uuid: 30044cd4-b779-4054-b957-683471d68abe
+  subjects:
+  - entities:
+    - role: player
+      name: Willie McCovey
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: DCS-WS
+  uuid: 53636e81-810b-45e4-bede-812131fb89eb
+  subjects:
+  - entities:
+    - role: player
+      name: Warren Spahn
+      ref: 
+    - role: team
+      name: Milwaukee Braves
+      ref: 
+- number: DCS-WST
+  uuid: 0046dca5-e938-4973-9faa-aabfea1e7f76
+  subjects:
+  - entities:
+    - role: player
+      name: Willie Stargell
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 

--- a/data/baseball/2025-26-topps-definitive-collection/checklists/definitive-cut-signatures.yaml
+++ b/data/baseball/2025-26-topps-definitive-collection/checklists/definitive-cut-signatures.yaml
@@ -206,7 +206,7 @@
       name: Larry Doby
       ref: 
     - role: team
-      name: Cleveland
+      name: Cleveland Indians
       ref: 
 - number: DCS-MM
   uuid: ab7cf108-4446-4269-9267-9d0899256f79
@@ -356,7 +356,7 @@
       name: Tris Speaker
       ref: 
     - role: team
-      name: Cleveland
+      name: Cleveland Indians
       ref: 
 - number: DCS-VS
   uuid: f03b9ed8-5182-4e16-a00f-8a6b7551da48

--- a/data/baseball/2025-26-topps-definitive-collection/checklists/definitive-dual-mlb-logo-patch-booklets.yaml
+++ b/data/baseball/2025-26-topps-definitive-collection/checklists/definitive-dual-mlb-logo-patch-booklets.yaml
@@ -1,0 +1,367 @@
+- number: DDLP-AA
+  uuid: 01b1a9f0-fffa-4568-ba8b-31fe0bdfdc76
+  subjects:
+  - entities:
+    - role: player
+      name: Yordan Alvarez
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+  - entities:
+    - role: player
+      name: Jose Altuve
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: DDLP-BB
+  uuid: 39b60f6b-48cf-4e34-9cbe-6bab85420b89
+  subjects:
+  - entities:
+    - role: player
+      name: Mookie Betts
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+  - entities:
+    - role: player
+      name: Mookie Betts
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: DDLP-BL
+  uuid: bf6e73ca-2dba-4879-ace7-1f9061c6bcf7
+  subjects:
+  - entities:
+    - role: player
+      name: Byron Buxton
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+  - entities:
+    - role: player
+      name: Brooks Lee
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: DDLP-CM
+  uuid: c70c7748-6234-4280-b031-decfcc32f1d1
+  subjects:
+  - entities:
+    - role: player
+      name: Ketel Marte
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+  - entities:
+    - role: player
+      name: Corbin Carroll
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: DDLP-CY
+  uuid: 98f13a5f-d6fc-44d2-a1d2-52fbe4efe9e2
+  subjects:
+  - entities:
+    - role: player
+      name: Christian Yelich
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+  - entities:
+    - role: player
+      name: Jackson Chourio
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: DDLP-DI
+  uuid: 30d865ff-c9e5-4841-a717-5501ea610840
+  subjects:
+  - entities:
+    - role: player
+      name: Yu Darvish
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+  - entities:
+    - role: player
+      name: Shota Imanaga
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: DDLP-FF
+  uuid: 2182cfce-0cad-4b25-ab47-8ec7d8b61fef
+  subjects:
+  - entities:
+    - role: player
+      name: Freddie Freeman
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+  - entities:
+    - role: player
+      name: Freddie Freeman
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: DDLP-GB
+  uuid: 36fba0c0-af35-467d-ace4-a577d27237a2
+  subjects:
+  - entities:
+    - role: player
+      name: Vladimir Guerrero Jr.
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+  - entities:
+    - role: player
+      name: Bo Bichette
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: DDLP-HH
+  uuid: 0201d845-0ff1-4998-a158-c7b76e851be5
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Harper
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+  - entities:
+    - role: player
+      name: Bryce Harper
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: DDLP-HHO
+  uuid: 5e94c02a-0bc1-4c02-9d4f-c728f8cb99bd
+  subjects:
+  - entities:
+    - role: player
+      name: Gunnar Henderson
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+  - entities:
+    - role: player
+      name: Jackson Holliday
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: DDLP-HT
+  uuid: 035a2b65-6f28-4fd4-9c17-8963c42a39f9
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Trout
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+  - entities:
+    - role: player
+      name: Bryce Harper
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: DDLP-IS
+  uuid: 0d0ad889-0898-470f-946e-100d756b732d
+  subjects:
+  - entities:
+    - role: player
+      name: Shota Imanaga
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+  - entities:
+    - role: player
+      name: Seiya Suzuki
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: DDLP-JC
+  uuid: 279da80f-9de3-42df-86fb-f8bef70d9762
+  subjects:
+  - entities:
+    - role: player
+      name: Gerrit Cole
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+  - entities:
+    - role: player
+      name: Aaron Judge
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: DDLP-MT
+  uuid: 7577cb89-368d-41cc-905e-b278d29c64c4
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Merrill
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+  - entities:
+    - role: player
+      name: Fernando Tatis Jr.
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: DDLP-OD
+  uuid: 952a7332-4065-4f56-9f4f-003f54fb77a5
+  subjects:
+  - entities:
+    - role: player
+      name: Rafael Devers
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+  - entities:
+    - role: player
+      name: David Ortiz
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: DDLP-RAJ
+  uuid: 7a161bcc-50e9-4682-8d14-89e7c5acc40b
+  subjects:
+  - entities:
+    - role: player
+      name: Julio Rodríguez
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+  - entities:
+    - role: player
+      name: Ronald Acuña Jr.
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: DDLP-SL
+  uuid: c81e1c33-5dbc-4b10-8aae-7f96e817696c
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+  - entities:
+    - role: player
+      name: Francisco Lindor
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: DDLP-SS
+  uuid: '07282a30-2da9-4d0a-af0e-2aa98145ad59'
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: DDLP-VC
+  uuid: 19837486-4c24-4c34-9219-db50d83964da
+  subjects:
+  - entities:
+    - role: player
+      name: Jazz Chisholm Jr.
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+  - entities:
+    - role: player
+      name: Anthony Volpe
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: DDLP-WC
+  uuid: 514281df-92ec-4655-9bae-83b5cdcbbde4
+  subjects:
+  - entities:
+    - role: player
+      name: James Wood
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+  - entities:
+    - role: player
+      name: Dylan Crews
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: DDLP-WH
+  uuid: e7be47ff-1861-4e8f-b7c5-3dde1d35eb8d
+  subjects:
+  - entities:
+    - role: player
+      name: Gunnar Henderson
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+  - entities:
+    - role: player
+      name: Bobby Witt Jr.
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: DDLP-WP
+  uuid: 873c9fa0-ee84-427d-a02c-84f981c1dfbb
+  subjects:
+  - entities:
+    - role: player
+      name: Salvador Perez
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+  - entities:
+    - role: player
+      name: Bobby Witt Jr.
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 

--- a/data/baseball/2025-26-topps-definitive-collection/checklists/definitive-dual-mlb-logo-patch-booklets.yaml
+++ b/data/baseball/2025-26-topps-definitive-collection/checklists/definitive-dual-mlb-logo-patch-booklets.yaml
@@ -297,6 +297,13 @@
     - role: team
       name: New York Mets
       ref: 
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
 - number: DDLP-VC
   uuid: 19837486-4c24-4c34-9219-db50d83964da
   subjects:

--- a/data/baseball/2025-26-topps-definitive-collection/checklists/definitive-helmet-collection-autographs.yaml
+++ b/data/baseball/2025-26-topps-definitive-collection/checklists/definitive-helmet-collection-autographs.yaml
@@ -1,0 +1,210 @@
+- number: DHCA-AB
+  uuid: 51ebf455-8890-4abe-bbc8-d5dd89188a26
+  subjects:
+  - entities:
+    - role: player
+      name: Alex Bregman
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: DHCA-AP
+  uuid: 19d8e672-b2e2-497b-a261-ae2b7dd6e6e7
+  subjects:
+  - entities:
+    - role: player
+      name: Albert Pujols
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: DHCA-BB
+  uuid: 55e117b6-35e9-4d02-90b3-7ef42f523f08
+  subjects:
+  - entities:
+    - role: player
+      name: Byron Buxton
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: DHCA-BL
+  uuid: ca1785c1-a534-43c5-8088-ebfaff2c0f32
+  subjects:
+  - entities:
+    - role: player
+      name: Brooks Lee
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: DHCA-CC
+  uuid: '09b14fe1-c2d8-4693-a36c-b2eee300158b'
+  subjects:
+  - entities:
+    - role: player
+      name: Corbin Carroll
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: DHCA-CR
+  uuid: 94275200-9e4b-4935-8538-162dd80d7b09
+  subjects:
+  - entities:
+    - role: player
+      name: Cal Raleigh
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: DHCA-DC
+  uuid: 241feecf-fa5c-4da8-b7f9-9b4ff9a999ab
+  subjects:
+  - entities:
+    - role: player
+      name: Dylan Crews
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: DHCA-FL
+  uuid: cf611512-d866-4a31-b731-d8b69102ed47
+  subjects:
+  - entities:
+    - role: player
+      name: Francisco Lindor
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: DHCA-FTJ
+  uuid: cf38b8cb-f66c-4914-b665-ff0c1ed59b8a
+  subjects:
+  - entities:
+    - role: player
+      name: Fernando Tatis Jr.
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: DHCA-JA
+  uuid: 110688a4-cd6e-4f4b-8e61-8eb4233c14db
+  subjects:
+  - entities:
+    - role: player
+      name: Jose Altuve
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: DHCA-JD
+  uuid: dc400b2d-63c7-4421-ba75-e45021e7b183
+  subjects:
+  - entities:
+    - role: player
+      name: Jarren Duran
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: DHCA-JR
+  uuid: 5e9950d0-cbdf-443b-9ff0-441f580d5127
+  subjects:
+  - entities:
+    - role: player
+      name: Julio Rodríguez
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: DHCA-JRA
+  uuid: 73c08aba-b520-4d30-8141-30cec8feb38d
+  subjects:
+  - entities:
+    - role: player
+      name: José Ramírez
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: DHCA-JW
+  uuid: 9b615e5b-8222-407d-8a08-e141f2400004
+  subjects:
+  - entities:
+    - role: player
+      name: James Wood
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: DHCA-MM
+  uuid: '0865c0fd-1233-4220-84c2-3b5016d96c29'
+  subjects:
+  - entities:
+    - role: player
+      name: Manny Machado
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: DHCA-MT
+  uuid: 5286cca2-768d-44d5-8bbe-c7d53fefea86
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Trout
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: DHCA-NA
+  uuid: 7c59f595-1a5f-47ee-bd9b-0e7ce88e1d2c
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan Arenado
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: DHCA-PCA
+  uuid: d698f816-e05c-47ad-9683-f9e2d9796461
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Crow-Armstrong
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: DHCA-RA
+  uuid: bac05d2b-2722-4b45-b271-9d91ea3e976f
+  subjects:
+  - entities:
+    - role: player
+      name: Ronald Acuña Jr.
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: DHCA-RD
+  uuid: f3b24735-ed66-494b-8848-ed75ddceae6c
+  subjects:
+  - entities:
+    - role: player
+      name: Rafael Devers
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: DHCA-TT
+  uuid: 91c55005-5a55-4cd3-8cb0-4f67ba4ca38c
+  subjects:
+  - entities:
+    - role: player
+      name: Trea Turner
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 

--- a/data/baseball/2025-26-topps-definitive-collection/checklists/definitive-helmet-collection.yaml
+++ b/data/baseball/2025-26-topps-definitive-collection/checklists/definitive-helmet-collection.yaml
@@ -1,0 +1,430 @@
+- number: DHC-AG
+  uuid: 3ec3b0c9-ac4f-4bba-abd5-0fe683c85494
+  subjects:
+  - entities:
+    - role: player
+      name: Adolis García
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: DHC-BB
+  uuid: 71de79ca-55f6-4606-853e-21f2c70ef56b
+  subjects:
+  - entities:
+    - role: player
+      name: Bo Bichette
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: DHC-BBX
+  uuid: 59494cfc-43f5-4dd1-b329-48dd22682897
+  subjects:
+  - entities:
+    - role: player
+      name: Byron Buxton
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: DHC-BH
+  uuid: '01018924-7ff9-4b32-b8df-6ef49d77a6dd'
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Harper
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: DHC-BL
+  uuid: ebee09d6-a5a0-4f0f-b6e4-5278b56c7efe
+  subjects:
+  - entities:
+    - role: player
+      name: Barry Larkin
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: DHC-BR
+  uuid: 510a01c1-17f3-499d-b4cb-0d512dd62705
+  subjects:
+  - entities:
+    - role: player
+      name: Bryan Reynolds
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: DHC-CC
+  uuid: a6284e1f-7da2-4c28-9142-48db9b8abd4b
+  subjects:
+  - entities:
+    - role: player
+      name: Corbin Carroll
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: DHC-CRA
+  uuid: b2e5f3b3-eb24-4c97-8359-41438df64e79
+  subjects:
+  - entities:
+    - role: player
+      name: Ceddanne Rafaela
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: DHC-DC
+  uuid: ca799d17-ce46-4f20-9553-cce4d271d9be
+  subjects:
+  - entities:
+    - role: player
+      name: Dylan Crews
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: DHC-ED
+  uuid: 3271c5d7-0ff6-4934-9b7b-a0e31b270f02
+  subjects:
+  - entities:
+    - role: player
+      name: Elly De La Cruz
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: DHC-ET
+  uuid: 7d6130e5-d7c1-444b-90fa-a723e9c99153
+  subjects:
+  - entities:
+    - role: player
+      name: Ezequiel Tovar
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: DHC-FA
+  uuid: 62f99446-d154-44c3-befd-eb1242553d2d
+  subjects:
+  - entities:
+    - role: player
+      name: Francisco Alvarez
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: DHC-FL
+  uuid: dd95d651-6e15-4178-b936-081dfd99be62
+  subjects:
+  - entities:
+    - role: player
+      name: Francisco Lindor
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: DHC-FT
+  uuid: 4c153460-a62b-455f-a9ea-c15ee8778966
+  subjects:
+  - entities:
+    - role: player
+      name: Fernando Tatis Jr.
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: DHC-GS
+  uuid: 1ff7e390-27f1-479e-8133-caa619cd6a9c
+  subjects:
+  - entities:
+    - role: player
+      name: Gary Sheffield
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: DHC-GSP
+  uuid: b76ccef3-f4b1-413f-ae8c-971d93532e5f
+  subjects:
+  - entities:
+    - role: player
+      name: George Springer
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: DHC-GST
+  uuid: 472e600e-b909-4182-97cd-73b56fd9a210
+  subjects:
+  - entities:
+    - role: player
+      name: Giancarlo Stanton
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: DHC-JA
+  uuid: 57abd564-9f6b-41ed-8562-b9e8415e02c0
+  subjects:
+  - entities:
+    - role: player
+      name: Jose Altuve
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: DHC-JCH
+  uuid: 5fcae257-06ae-4484-bb1d-ad44fbb9276a
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Chourio
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: DHC-JD
+  uuid: 07fe60d3-ee6e-43ef-b11a-6d31e27c9afb
+  subjects:
+  - entities:
+    - role: player
+      name: Jarren Duran
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: DHC-JDO
+  uuid: 60be0531-01b4-490f-9034-92809b63ff78
+  subjects:
+  - entities:
+    - role: player
+      name: Jasson Domínguez
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: DHC-JMU
+  uuid: 2478a530-8ab7-4665-8b63-321ee687e41b
+  subjects:
+  - entities:
+    - role: player
+      name: Justin Morneau
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: DHC-JP
+  uuid: 3946a042-6159-4a4b-844e-1436c9e9aa1f
+  subjects:
+  - entities:
+    - role: player
+      name: Jeremy Peña
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: DHC-JR
+  uuid: 328b6604-9e9a-40a0-9e12-c6c54cb171e6
+  subjects:
+  - entities:
+    - role: player
+      name: José Ramírez
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: DHC-JW
+  uuid: '0830e2e7-5f89-48ec-9792-0ec43c5f5202'
+  subjects:
+  - entities:
+    - role: player
+      name: James Wood
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: DHC-MC
+  uuid: b0cad93f-b15e-469c-8898-418f11526c90
+  subjects:
+  - entities:
+    - role: player
+      name: Matt Chapman
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: DHC-MM
+  uuid: 5c11009f-114c-4742-8843-99224f7247bb
+  subjects:
+  - entities:
+    - role: player
+      name: Manny Machado
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: DHC-MT
+  uuid: ca18befe-3e82-47e0-9f20-6a8308a7e3da
+  subjects:
+  - entities:
+    - role: player
+      name: Mark Teixeira
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: DHC-NA
+  uuid: cb68ad4b-ec9b-420c-973c-306ec905bc46
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan Arenado
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: DHC-OA
+  uuid: 952110fb-0932-4722-9a66-67fe2cfbcd31
+  subjects:
+  - entities:
+    - role: player
+      name: Ozzie Albies
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: DHC-OC
+  uuid: f9d0407c-cab5-4cf2-952a-6d71a60dfe97
+  subjects:
+  - entities:
+    - role: player
+      name: Oneil Cruz
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: DHC-PF
+  uuid: 3dca3c65-1d24-45b9-8187-94ccd1d6ebc1
+  subjects:
+  - entities:
+    - role: player
+      name: Prince Fielder
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: DHC-RA
+  uuid: 1701929d-9c35-4566-a115-f3a5c632f5e4
+  subjects:
+  - entities:
+    - role: player
+      name: Ronald Acuña Jr.
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: DHC-RD
+  uuid: f6783a0d-2a15-4ef5-b6a3-3dd2a0408baa
+  subjects:
+  - entities:
+    - role: player
+      name: Rafael Devers
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: DHC-RG
+  uuid: e50834b2-159d-4c87-a842-ca2fdfbd2721
+  subjects:
+  - entities:
+    - role: player
+      name: Riley Greene
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: DHC-RH
+  uuid: 8b0d418a-6285-47be-b2da-a30874d5806b
+  subjects:
+  - entities:
+    - role: player
+      name: Robert Hassell III
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: DHC-ST
+  uuid: dec28736-8b82-4f03-9f41-2fb673ed8e87
+  subjects:
+  - entities:
+    - role: player
+      name: Spencer Torkelson
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: DHC-TG
+  uuid: d21e3d7c-eede-4d10-97d4-6e61471f0f55
+  subjects:
+  - entities:
+    - role: player
+      name: Tony Gwynn
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: DHC-TT
+  uuid: e9d21def-05fe-491f-a161-15fea8241c11
+  subjects:
+  - entities:
+    - role: player
+      name: Trea Turner
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: DHC-VG
+  uuid: 1e7f02b5-bc93-47be-aa1d-6268c7d61fd2
+  subjects:
+  - entities:
+    - role: player
+      name: Vladimir Guerrero Jr.
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: DHC-WC
+  uuid: d1f2336d-9878-4cad-9bd8-1ebf394224b2
+  subjects:
+  - entities:
+    - role: player
+      name: William Contreras
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: DHC-YA
+  uuid: 37cc6296-5bf4-4cc3-bb19-e42bea32c7e6
+  subjects:
+  - entities:
+    - role: player
+      name: Yordan Alvarez
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: DHC-YM
+  uuid: e51c0b8b-9106-40b4-b168-e2fc657f3870
+  subjects:
+  - entities:
+    - role: player
+      name: Yadier Molina
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 

--- a/data/baseball/2025-26-topps-definitive-collection/checklists/definitive-mlb-logo-patches.yaml
+++ b/data/baseball/2025-26-topps-definitive-collection/checklists/definitive-mlb-logo-patches.yaml
@@ -1,0 +1,870 @@
+- number: DLP-AG
+  uuid: e9481548-e80d-467c-a86c-eeb0a741e04f
+  subjects:
+  - entities:
+    - role: player
+      name: Adolis García
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: DLP-AJ
+  uuid: a9f89017-ad3c-45c4-ae14-92b657f1ae8e
+  subjects:
+  - entities:
+    - role: player
+      name: Aaron Judge
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: DLP-AM
+  uuid: 6ec0577d-8cbe-4b17-b7a8-2225f5c14bb3
+  subjects:
+  - entities:
+    - role: player
+      name: Andrew McCutchen
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: DLP-AN
+  uuid: a345eff4-1115-4daa-ac93-3596d7c5784f
+  subjects:
+  - entities:
+    - role: player
+      name: Aaron Nola
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: DLP-AR
+  uuid: 8f66a3c0-8dca-4c61-8f10-2c5ad4f6aa8f
+  subjects:
+  - entities:
+    - role: player
+      name: Austin Riley
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: DLP-ARU
+  uuid: 1614632d-ec1c-476c-89d5-725a391b0571
+  subjects:
+  - entities:
+    - role: player
+      name: Adley Rutschman
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: DLP-AV
+  uuid: bf200dda-21cc-46b3-afe9-cc7ddffc2cb7
+  subjects:
+  - entities:
+    - role: player
+      name: Anthony Volpe
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: DLP-BBX
+  uuid: dc8e61d6-82e5-48a8-be2d-5740f95b8da4
+  subjects:
+  - entities:
+    - role: player
+      name: Byron Buxton
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: DLP-BH
+  uuid: 2adfb1c8-c05f-4a92-b6b3-da95bfbb5c1d
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Harper
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: DLP-BL
+  uuid: dfca7bd8-4a81-4f94-876b-206d0eaba6ec
+  subjects:
+  - entities:
+    - role: player
+      name: Brooks Lee
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: DLP-BO
+  uuid: e447663e-523b-485b-bcfc-ebfdc275dae8
+  subjects:
+  - entities:
+    - role: player
+      name: Bo Bichette
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: DLP-BW
+  uuid: 905e5213-efe7-4232-9877-3cb87cefaf34
+  subjects:
+  - entities:
+    - role: player
+      name: Bobby Witt Jr.
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: DLP-CA
+  uuid: d1316d8e-718e-4628-9c2a-1fee2e96cc8c
+  subjects:
+  - entities:
+    - role: player
+      name: CJ Abrams
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: DLP-CC
+  uuid: e667de84-c34d-414a-8957-2a67a749d830
+  subjects:
+  - entities:
+    - role: player
+      name: Carlos Correa
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: DLP-CCA
+  uuid: 67c2800a-cd75-4003-aa62-81d44bd2ef70
+  subjects:
+  - entities:
+    - role: player
+      name: Corbin Carroll
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: DLP-CCS
+  uuid: 4123c966-77ee-48eb-ada5-489d61634d3e
+  subjects:
+  - entities:
+    - role: player
+      name: CC Sabathia
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: DLP-CK
+  uuid: 2a3358d8-c9da-4dd6-b882-b250360fe1f5
+  subjects:
+  - entities:
+    - role: player
+      name: Colt Keith
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: DLP-CY
+  uuid: 74afee6e-0e54-46a4-a273-2b05763db8cf
+  subjects:
+  - entities:
+    - role: player
+      name: Christian Yelich
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: DLP-DC
+  uuid: cf28ff2b-ac3f-4e48-98d5-a85cb7896199
+  subjects:
+  - entities:
+    - role: player
+      name: Dylan Crews
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: DLP-DO
+  uuid: a2de10a0-e3c9-4a7c-b7e7-b8f7fec93e37
+  subjects:
+  - entities:
+    - role: player
+      name: David Ortiz
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: DLP-DP
+  uuid: de49c96c-91ea-4868-9827-b11a13eb7c5b
+  subjects:
+  - entities:
+    - role: player
+      name: Dustin Pedroia
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: DLP-DS
+  uuid: 5dfc60e5-db2f-455b-83f4-6bf262841460
+  subjects:
+  - entities:
+    - role: player
+      name: Dansby Swanson
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: DLP-DW
+  uuid: 1cb82850-d20b-4897-b8e6-2138083d5c58
+  subjects:
+  - entities:
+    - role: player
+      name: David Wright
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: DLP-ET
+  uuid: 844d0aad-23d5-4340-9990-2e134cef1347
+  subjects:
+  - entities:
+    - role: player
+      name: Ezequiel Tovar
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: DLP-FA
+  uuid: 9f759567-531b-41e6-bce5-e59219c4ca58
+  subjects:
+  - entities:
+    - role: player
+      name: Francisco Alvarez
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: DLP-FF
+  uuid: 94071f4b-8fde-4c47-a13e-e956fd6f68bd
+  subjects:
+  - entities:
+    - role: player
+      name: Freddie Freeman
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: DLP-FH
+  uuid: bfafdc84-a38e-40b4-b026-2d16175a6e3e
+  subjects:
+  - entities:
+    - role: player
+      name: Félix Hernández
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: DLP-FL
+  uuid: 9de8c7a5-225f-446c-91ca-cf443d1c9487
+  subjects:
+  - entities:
+    - role: player
+      name: Francisco Lindor
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: DLP-FRF
+  uuid: 78280cef-7802-4c4f-9a98-7bd58832e9f1
+  subjects:
+  - entities:
+    - role: player
+      name: Freddie Freeman
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: DLP-FT
+  uuid: ef45b161-4853-484c-9d37-2368a062a1c2
+  subjects:
+  - entities:
+    - role: player
+      name: Fernando Tatis Jr.
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: DLP-GC
+  uuid: 8a1c5b92-1549-443e-a201-c0e9e1808b54
+  subjects:
+  - entities:
+    - role: player
+      name: Gerrit Cole
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: DLP-GH
+  uuid: 7e2f263b-c013-4e9a-b29d-1e8e3e364e41
+  subjects:
+  - entities:
+    - role: player
+      name: Gunnar Henderson
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: DLP-GS
+  uuid: 6a02c81b-9663-4816-9b95-f818877b8c49
+  subjects:
+  - entities:
+    - role: player
+      name: Giancarlo Stanton
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: DLP-HG
+  uuid: 4530c139-4e4e-47a9-a153-c63392f86cfc
+  subjects:
+  - entities:
+    - role: player
+      name: Hunter Greene
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: DLP-I
+  uuid: 553c65f7-ca4d-42f9-ae5c-44e466fcd88d
+  subjects:
+  - entities:
+    - role: player
+      name: Ichiro
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: DLP-JA
+  uuid: b1320e25-e293-431e-88e5-aa36041ab886
+  subjects:
+  - entities:
+    - role: player
+      name: Jose Altuve
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: DLP-JC
+  uuid: fe5403f9-2c78-4589-a678-4886928e20ac
+  subjects:
+  - entities:
+    - role: player
+      name: Junior Caminero
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: DLP-JCH
+  uuid: 9e11092e-fd70-4bd3-8d36-89144487b023
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Chourio
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: DLP-JCJ
+  uuid: f489565b-bb28-4525-ae6f-811be18de5e3
+  subjects:
+  - entities:
+    - role: player
+      name: Jazz Chisholm Jr.
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: DLP-JH
+  uuid: 4ac6cbe8-d0ec-4e36-816b-357ac9d2c262
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Holliday
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: DLP-JL
+  uuid: e7fd2a98-ed74-46d7-8f8a-93abe472b254
+  subjects:
+  - entities:
+    - role: player
+      name: Jung Hoo Lee
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: DLP-JM
+  uuid: 85f6e7ab-82ad-40e2-a570-71fdd3520de1
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Merrill
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: DLP-JRO
+  uuid: 162860f3-3427-461c-9843-ad42fd2701a6
+  subjects:
+  - entities:
+    - role: player
+      name: Julio Rodríguez
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: DLP-JS
+  uuid: 952aa0fc-438d-45d9-b959-b4a25972c9a4
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: DLP-JT
+  uuid: f3750206-6809-43b7-835b-373cce7da958
+  subjects:
+  - entities:
+    - role: player
+      name: J.T. Realmuto
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: DLP-JV
+  uuid: 778d9e57-01b0-4af9-ad9a-53247e974a05
+  subjects:
+  - entities:
+    - role: player
+      name: Joey Votto
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: DLP-JW
+  uuid: 9ac2253a-fa48-42e3-8044-c7f64eb3e6d1
+  subjects:
+  - entities:
+    - role: player
+      name: James Wood
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: DLP-KB
+  uuid: 956965e7-f915-4f16-9165-2f9b8c997e30
+  subjects:
+  - entities:
+    - role: player
+      name: Kris Bryant
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: DLP-KC
+  uuid: 317a7563-1ff0-41d1-a364-62ea640eef42
+  subjects:
+  - entities:
+    - role: player
+      name: Kristian Campbell
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: DLP-KM
+  uuid: f3afb789-5b34-47ac-846a-d5688a5ead33
+  subjects:
+  - entities:
+    - role: player
+      name: Ketel Marte
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: DLP-KS
+  uuid: 21264ed2-3888-4cc2-87ca-8e8ef527f7d3
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Schwarber
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: DLP-LA
+  uuid: 8d9fadbe-a5c7-4075-8c0d-cdd8dcff3fe4
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Arraez
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: DLP-LB
+  uuid: 8f7d6969-07d6-4a79-be53-84c4f5c16b73
+  subjects:
+  - entities:
+    - role: player
+      name: Lawrence Butler
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: DLP-LC
+  uuid: 855b93df-29af-46dd-be21-01a976ef1b79
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Castillo
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: DLP-LR
+  uuid: 71ce4a0f-1662-48af-b22b-cef56c8abcc9
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Robert Jr.
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: DLP-LW
+  uuid: 647fd45f-ee3a-4591-8925-329a775a41b4
+  subjects:
+  - entities:
+    - role: player
+      name: Logan Webb
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: DLP-MB
+  uuid: f608fc30-f83a-4b06-9b08-7287dea9d9ea
+  subjects:
+  - entities:
+    - role: player
+      name: Mookie Betts
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: DLP-MC
+  uuid: 638774ef-3114-4769-b205-cf9032ab9a9a
+  subjects:
+  - entities:
+    - role: player
+      name: Miguel Cabrera
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: DLP-MF
+  uuid: ecd9c12f-9954-4a06-935a-f3236469acd8
+  subjects:
+  - entities:
+    - role: player
+      name: Max Fried
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: DLP-MH
+  uuid: d7609750-18cc-4eb1-b13e-5ab4d06d178c
+  subjects:
+  - entities:
+    - role: player
+      name: Michael Harris II
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: DLP-MM
+  uuid: a14f5859-c1b3-41f5-91c7-3d456252caa3
+  subjects:
+  - entities:
+    - role: player
+      name: Manny Machado
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: DLP-MM2
+  uuid: 2b01299e-7208-49aa-a0c9-fa4bfdf9262e
+  subjects:
+  - entities:
+    - role: player
+      name: Max Muncy
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: DLP-MO
+  uuid: ddce0925-82e1-4857-9ab6-4db2b5ec33dd
+  subjects:
+  - entities:
+    - role: player
+      name: Matt Olson
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: DLP-MT
+  uuid: 61354264-57a7-4d59-9495-17cad8dcb284
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Trout
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: DLP-MTX
+  uuid: abc41ddd-2c1f-452a-b38b-352ec38e3e92
+  subjects:
+  - entities:
+    - role: player
+      name: Mark Teixeira
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: DLP-MW
+  uuid: f791dc76-b3a3-47b6-ba47-c5dd4a2bec55
+  subjects:
+  - entities:
+    - role: player
+      name: Masyn Winn
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: DLP-NA
+  uuid: 35310c71-de58-4a5e-9f60-ab1b619d6fa8
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan Arenado
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: DLP-OA
+  uuid: a056d96d-9498-47c6-b094-1549738f8f70
+  subjects:
+  - entities:
+    - role: player
+      name: Ozzie Albies
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: DLP-OC
+  uuid: ea8aca22-f17c-4095-8bd1-b2a8a5649901
+  subjects:
+  - entities:
+    - role: player
+      name: Oneil Cruz
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: DLP-PA
+  uuid: c4a2b560-eb5e-4f8d-a103-9398f33fb67e
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Alonso
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: DLP-RG
+  uuid: 9a980692-32fb-4c56-9bd1-6881bbea61d7
+  subjects:
+  - entities:
+    - role: player
+      name: Riley Greene
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: DLP-SA
+  uuid: 2d1ab798-1fdd-4ce2-96ef-9837e416caff
+  subjects:
+  - entities:
+    - role: player
+      name: Sandy Alcantara
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: DLP-SI
+  uuid: 1dae769c-cb04-46bf-bb78-ce38d1ef32f9
+  subjects:
+  - entities:
+    - role: player
+      name: Shota Imanaga
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: DLP-SP
+  uuid: bbe3cf8d-fb64-4545-8208-1eb8487c3aeb
+  subjects:
+  - entities:
+    - role: player
+      name: Salvador Perez
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: DLP-SS
+  uuid: 9eb702dc-2681-400f-ace1-6b3ca9b34c61
+  subjects:
+  - entities:
+    - role: player
+      name: Spencer Strider
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: DLP-SSZ
+  uuid: 5237e4e2-1979-40a3-a402-0796645e6aef
+  subjects:
+  - entities:
+    - role: player
+      name: Seiya Suzuki
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: DLP-TS
+  uuid: 6ef735aa-1f7e-4962-ac55-ee7665d56eb2
+  subjects:
+  - entities:
+    - role: player
+      name: Tyler Soderstrom
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: DLP-TT
+  uuid: 44ff920b-b9a8-445a-abef-1500e9c88dfe
+  subjects:
+  - entities:
+    - role: player
+      name: Trea Turner
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: DLP-VG
+  uuid: dd0b9f4a-0339-4335-93b6-892a0a7403de
+  subjects:
+  - entities:
+    - role: player
+      name: Vladimir Guerrero Jr.
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: DLP-WC
+  uuid: fe1987a1-465e-49c9-882e-32cd19709769
+  subjects:
+  - entities:
+    - role: player
+      name: William Contreras
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: DLP-WS
+  uuid: 88b94e09-a71d-40cf-a973-d40cb68fcae9
+  subjects:
+  - entities:
+    - role: player
+      name: Will Smith
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: DLP-XB
+  uuid: 57df6734-2fd6-473d-8e9c-b3081ed019b6
+  subjects:
+  - entities:
+    - role: player
+      name: Xander Bogaerts
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: DLP-YA
+  uuid: d6681f62-2b4c-4a72-a1b1-68cb9b345a4c
+  subjects:
+  - entities:
+    - role: player
+      name: Yordan Alvarez
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: DLP-YD
+  uuid: 8cc835f7-fb27-4e38-a72b-f0a49034f0d1
+  subjects:
+  - entities:
+    - role: player
+      name: Yu Darvish
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: DLP-YM
+  uuid: 86c0e56d-9635-4e58-9ab6-0b93200b9479
+  subjects:
+  - entities:
+    - role: player
+      name: Yadier Molina
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: DLP-ZV
+  uuid: d993f643-a4ac-4aca-af24-7e1b96825b5c
+  subjects:
+  - entities:
+    - role: player
+      name: Zac Veen
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: DLP-ZW
+  uuid: 4f1d74ca-5329-4192-99d9-4aab222aa32c
+  subjects:
+  - entities:
+    - role: player
+      name: Zack Wheeler
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 

--- a/data/baseball/2025-26-topps-definitive-collection/checklists/definitive-moments-autographs.yaml
+++ b/data/baseball/2025-26-topps-definitive-collection/checklists/definitive-moments-autographs.yaml
@@ -1,0 +1,230 @@
+- number: DMA-BH
+  uuid: 6de84142-e508-46bc-9eb0-ab3880236535
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Harper
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: DMA-BW
+  uuid: c7f24bef-8a2e-43a2-a583-10b49dd7253e
+  subjects:
+  - entities:
+    - role: player
+      name: Bobby Witt Jr.
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: DMA-DC
+  uuid: 0dfa04ef-0aeb-4e61-8d96-9f31288e22e1
+  subjects:
+  - entities:
+    - role: player
+      name: Dylan Crews
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: DMA-DJ
+  uuid: af9916f1-0e35-48ee-9c8a-7be5b5782981
+  subjects:
+  - entities:
+    - role: player
+      name: Derek Jeter
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: DMA-DO
+  uuid: 51b826ff-7325-4450-a32c-3ac5b829f41a
+  subjects:
+  - entities:
+    - role: player
+      name: David Ortiz
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: DMA-FF
+  uuid: cf16bc9a-e4de-47b9-a938-bb5892a72767
+  subjects:
+  - entities:
+    - role: player
+      name: Freddie Freeman
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: DMA-GB
+  uuid: 5dde4d55-5136-463f-b0bd-f7a9633d56ef
+  subjects:
+  - entities:
+    - role: player
+      name: George Brett
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: DMA-GM
+  uuid: 07a50a57-e8bf-4bf5-806e-65bbe7e87192
+  subjects:
+  - entities:
+    - role: player
+      name: Greg Maddux
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: DMA-I
+  uuid: a4f0bc6d-ba18-4a21-b03b-fe79656e4ddf
+  subjects:
+  - entities:
+    - role: player
+      name: Ichiro
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: DMA-JH
+  uuid: a8535fe0-9c10-4cd9-82ce-05109ae6fe9f
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Holliday
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: DMA-JW
+  uuid: f0d06c25-8ec6-4d13-9b6e-e26d63136223
+  subjects:
+  - entities:
+    - role: player
+      name: James Wood
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: DMA-MP
+  uuid: b1c64a35-0db0-40d3-9076-b2f12b66286f
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Piazza
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: DMA-MS
+  uuid: 347af467-872a-4936-ae06-26efe3fb39f9
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Schmidt
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: DMA-MT
+  uuid: 8de739db-1a8f-4561-a3df-7eae8c52bedd
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Trout
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: DMA-NR
+  uuid: 9b218b90-9d7e-4de1-88fc-76cef2cce592
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan Ryan
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: DMA-OH
+  uuid: 79bbca15-3a6e-46c1-82a0-2b08c3ce1fd6
+  subjects:
+  - entities:
+    - role: player
+      name: Orel Hershiser
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: DMA-RA
+  uuid: 587bac9f-f2b3-4a17-b5dc-36fe482edad7
+  subjects:
+  - entities:
+    - role: player
+      name: Ronald Acuña Jr.
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: DMA-RC
+  uuid: 125edd83-9f47-44e2-9ab6-81092ebc537b
+  subjects:
+  - entities:
+    - role: player
+      name: Roger Clemens
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: DMA-RJ
+  uuid: 5705e270-252b-4ab8-86cd-00712f2a71c0
+  subjects:
+  - entities:
+    - role: player
+      name: Randy Johnson
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: DMA-RJA
+  uuid: 1108bb4b-f798-4e9e-9b6a-30c6a2823410
+  subjects:
+  - entities:
+    - role: player
+      name: Reggie Jackson
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: DMA-SS
+  uuid: a0c25285-f838-4315-959d-4ba091219b21
+  subjects:
+  - entities:
+    - role: player
+      name: Sammy Sosa
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: DMA-VG
+  uuid: e2667967-79e2-4228-a528-fa203e5c0892
+  subjects:
+  - entities:
+    - role: player
+      name: Vladimir Guerrero Jr.
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: DMA-YY
+  uuid: 243f2f43-da14-4967-b882-05d94af6faac
+  subjects:
+  - entities:
+    - role: player
+      name: Yoshinobu Yamamoto
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 

--- a/data/baseball/2025-26-topps-definitive-collection/checklists/definitive-nameplate-collection.yaml
+++ b/data/baseball/2025-26-topps-definitive-collection/checklists/definitive-nameplate-collection.yaml
@@ -1,0 +1,800 @@
+- number: DNC-AA
+  uuid: 45ba7773-92bd-40cf-9dd6-988e45c2eb4b
+  subjects:
+  - entities:
+    - role: player
+      name: Adael Amador
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: DNC-AM
+  uuid: e64c385f-d877-43ba-9c8b-6a10956c4c93
+  subjects:
+  - entities:
+    - role: player
+      name: Andrew McCutchen
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: DNC-AN
+  uuid: 3f01a7ae-8fd1-4843-9fb5-a97f934de6d5
+  subjects:
+  - entities:
+    - role: player
+      name: Aaron Nola
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: DNC-AR
+  uuid: 3a3932e4-5c3b-42ef-b362-d67374aa52ce
+  subjects:
+  - entities:
+    - role: player
+      name: Austin Riley
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: DNC-AROD
+  uuid: eadfa819-bb96-4696-aa82-b03fcb2db08b
+  subjects:
+  - entities:
+    - role: player
+      name: Alex Rodriguez
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: DNC-ARU
+  uuid: ce7800a5-08f0-4193-8fa0-6da689e28256
+  subjects:
+  - entities:
+    - role: player
+      name: Adley Rutschman
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: DNC-BB
+  uuid: 03de4b42-56af-4f59-a161-b55a919264a4
+  subjects:
+  - entities:
+    - role: player
+      name: Bo Bichette
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: DNC-BBX
+  uuid: 6600f67c-cec1-42be-ad1c-5715f1d070b9
+  subjects:
+  - entities:
+    - role: player
+      name: Byron Buxton
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: DNC-BH
+  uuid: 10f4d2e6-e544-4b8f-a3bd-eae0ec6f5e03
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Harper
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: DNC-BL
+  uuid: 01627f8a-707f-4f4a-ac32-78c8d7ab208d
+  subjects:
+  - entities:
+    - role: player
+      name: Brooks Lee
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: DNC-BW
+  uuid: 690a5336-8917-424e-8b88-b88089c04c0a
+  subjects:
+  - entities:
+    - role: player
+      name: Bobby Witt Jr.
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: DNC-CA
+  uuid: 7541cc2e-8e72-4d82-a411-2a41dc6b64e2
+  subjects:
+  - entities:
+    - role: player
+      name: CJ Abrams
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: DNC-CC
+  uuid: ef83a1d0-0240-46dc-9902-7a474e492010
+  subjects:
+  - entities:
+    - role: player
+      name: Carlos Correa
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: DNC-CCA
+  uuid: 22170106-4dd0-4b06-8334-1af4d919e29c
+  subjects:
+  - entities:
+    - role: player
+      name: Corbin Carroll
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: DNC-CD
+  uuid: 986863b6-5451-4028-836b-194cc163fabb
+  subjects:
+  - entities:
+    - role: player
+      name: Chase Dollander
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: DNC-CJ
+  uuid: 9378af4c-2c80-404d-af4b-59bbc31b5fd0
+  subjects:
+  - entities:
+    - role: player
+      name: Chipper Jones
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: DNC-CK
+  uuid: cb16c460-2f9b-4b81-a128-ad9710bd12c6
+  subjects:
+  - entities:
+    - role: player
+      name: Clayton Kershaw
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: DNC-CN
+  uuid: 902f2c1c-c614-4914-9181-161c19ce8b0c
+  subjects:
+  - entities:
+    - role: player
+      name: Connor Norby
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: DNC-CY
+  uuid: ab556cfa-4829-4492-8e2c-2753a1dc3797
+  subjects:
+  - entities:
+    - role: player
+      name: Christian Yelich
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: DNC-DC
+  uuid: d5b36d37-4de3-43f8-ba4b-e68ed8c8acc8
+  subjects:
+  - entities:
+    - role: player
+      name: Dylan Crews
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: DNC-FA
+  uuid: 1652691a-413c-417d-818d-8dc0f4776ead
+  subjects:
+  - entities:
+    - role: player
+      name: Francisco Alvarez
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: DNC-FF
+  uuid: e03f9ac4-447b-49df-b176-53f8c06f6f71
+  subjects:
+  - entities:
+    - role: player
+      name: Freddie Freeman
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: DNC-FL
+  uuid: 9a12de28-db9b-44bb-8792-56ce8e638ea2
+  subjects:
+  - entities:
+    - role: player
+      name: Francisco Lindor
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: DNC-FT
+  uuid: dc44a317-de6d-4c8a-a286-f908cb731cd3
+  subjects:
+  - entities:
+    - role: player
+      name: Fernando Tatis Jr.
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: DNC-GH
+  uuid: 1ec852f8-cc89-457a-bf32-10ff58711a9d
+  subjects:
+  - entities:
+    - role: player
+      name: Gunnar Henderson
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: DNC-HG
+  uuid: 56662df6-be9d-457b-908f-1d245992b807
+  subjects:
+  - entities:
+    - role: player
+      name: Hunter Greene
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: DNC-I
+  uuid: c3ce6d35-efba-4075-a825-7799cce49c50
+  subjects:
+  - entities:
+    - role: player
+      name: Ichiro
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: DNC-JA
+  uuid: d39c29fb-4162-4765-91a6-0d84fd7f73cc
+  subjects:
+  - entities:
+    - role: player
+      name: Jose Altuve
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: DNC-JC
+  uuid: 01cc5599-28d3-46e0-99d5-fd54a95fdd20
+  subjects:
+  - entities:
+    - role: player
+      name: Junior Caminero
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: DNC-JCH
+  uuid: 111b7512-512d-4d0d-8754-c10d3ea9d62c
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Chourio
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: DNC-JH
+  uuid: d3b56e82-94ef-4a20-8f54-50dee820262c
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Holliday
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: DNC-JL
+  uuid: fda389dd-1820-4333-87ef-c3e46f75732f
+  subjects:
+  - entities:
+    - role: player
+      name: Jung Hoo Lee
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: DNC-JM
+  uuid: e74cf0e1-6514-478b-9c5c-43ce48bb2089
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Merrill
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: DNC-JP
+  uuid: 27c2461b-8b30-4f0a-b5f6-bbd8ee8156b6
+  subjects:
+  - entities:
+    - role: player
+      name: Jeremy Peña
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: DNC-JRA
+  uuid: d15c6834-3262-45d6-a78f-1c6c78e8fee6
+  subjects:
+  - entities:
+    - role: player
+      name: José Ramírez
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: DNC-JRO
+  uuid: f96266f3-15e2-4099-9743-d9a6b026e76a
+  subjects:
+  - entities:
+    - role: player
+      name: Julio Rodríguez
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: DNC-JS
+  uuid: 611939f3-4ee8-4d0b-8866-0f5296d0e93e
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: DNC-JT
+  uuid: 16d67f47-3f11-42e1-97d4-451681abdca0
+  subjects:
+  - entities:
+    - role: player
+      name: J.T. Realmuto
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: DNC-JV
+  uuid: 427e1acc-8381-4e27-8f5a-11e380eebd22
+  subjects:
+  - entities:
+    - role: player
+      name: Joey Votto
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: DNC-JW
+  uuid: 5cb7e80e-0734-4c74-bad0-a8b030c950da
+  subjects:
+  - entities:
+    - role: player
+      name: James Wood
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: DNC-KM
+  uuid: eb883a6a-73e6-4565-bc74-8940eb5497d1
+  subjects:
+  - entities:
+    - role: player
+      name: Ketel Marte
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: DNC-LA
+  uuid: 1cf4563d-d8e1-497a-966a-d627450aa312
+  subjects:
+  - entities:
+    - role: player
+      name: Luisangel Acuña
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: DNC-LAZ
+  uuid: 2a9067ad-09be-4a3d-a2bf-af561731cfa9
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Arraez
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: DNC-LB
+  uuid: ac686712-fc42-42eb-aed7-0cf04fc26b3a
+  subjects:
+  - entities:
+    - role: player
+      name: Lawrence Butler
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: DNC-LR
+  uuid: 2b13f0bb-e76b-45f9-b07a-c1cf03d638cd
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Robert Jr.
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: DNC-LWA
+  uuid: 0631d2ed-3c61-43a2-ae1b-cf299fcd7c21
+  subjects:
+  - entities:
+    - role: player
+      name: Larry Walker
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: DNC-MB
+  uuid: '0694ce57-4c17-45bc-9317-ae367b2524a9'
+  subjects:
+  - entities:
+    - role: player
+      name: Mookie Betts
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: DNC-MC
+  uuid: d85cdf4f-3f92-4614-99d3-c1f55500dba0
+  subjects:
+  - entities:
+    - role: player
+      name: Miguel Cabrera
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: DNC-MH
+  uuid: 483adb38-5b90-4568-98f0-760931a0d096
+  subjects:
+  - entities:
+    - role: player
+      name: Michael Harris II
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: DNC-MM
+  uuid: a1590cab-c2e1-4238-8436-8f00cff4f604
+  subjects:
+  - entities:
+    - role: player
+      name: Manny Machado
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: DNC-MT
+  uuid: 65b1e2ab-d9ed-48c7-9739-6a4805c91177
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Trout
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: DNC-NA
+  uuid: 775cc9c2-88cc-40a5-99ef-e3d44456bf6f
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan Arenado
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: DNC-OA
+  uuid: 53a5498b-ce6b-407d-b5cb-2b04f478b623
+  subjects:
+  - entities:
+    - role: player
+      name: Ozzie Albies
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: DNC-OC
+  uuid: 4082ee12-2028-4df1-aee9-9ba8817a20db
+  subjects:
+  - entities:
+    - role: player
+      name: Oneil Cruz
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: DNC-PA
+  uuid: 2c3f726d-12cf-4fb5-b952-a06cf9ae3da0
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Alonso
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: DNC-PC
+  uuid: a2d7d9f4-3564-412f-813a-84a1063bf4d2
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Crow-Armstrong
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: DNC-PF
+  uuid: ac83585d-51a8-4167-83e0-6a94b1c0abcd
+  subjects:
+  - entities:
+    - role: player
+      name: Prince Fielder
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: DNC-RG
+  uuid: a479f858-8e3b-47a2-b349-cca3c51d7764
+  subjects:
+  - entities:
+    - role: player
+      name: Riley Greene
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: DNC-RH
+  uuid: bff04026-00e2-4c34-9b4c-ba0d94bad781
+  subjects:
+  - entities:
+    - role: player
+      name: Rickey Henderson
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: DNC-SA
+  uuid: a080f8ec-8460-4a94-b7a9-e0ef6cac9d01
+  subjects:
+  - entities:
+    - role: player
+      name: Sandy Alcantara
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: DNC-SI
+  uuid: a193296b-d5c9-44ae-805e-e9449055cc16
+  subjects:
+  - entities:
+    - role: player
+      name: Shota Imanaga
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: DNC-SO
+  uuid: 56300b52-1dbf-4c23-bf9e-5edf99f49e01
+  subjects:
+  - entities:
+    - role: player
+      name: Shohei Ohtani
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: DNC-SP
+  uuid: 934778af-836f-49ab-8616-9358b266bddd
+  subjects:
+  - entities:
+    - role: player
+      name: Salvador Perez
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: DNC-SS
+  uuid: 270c9f03-c61f-4dfb-bc6b-7ff5d509cd33
+  subjects:
+  - entities:
+    - role: player
+      name: Seiya Suzuki
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: DNC-SST
+  uuid: e7cc3dea-e093-405a-991c-88bfeba54987
+  subjects:
+  - entities:
+    - role: player
+      name: Spencer Strider
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: DNC-ST
+  uuid: f7f40b4a-0a19-4a66-868f-8a53e03226e4
+  subjects:
+  - entities:
+    - role: player
+      name: Spencer Torkelson
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: DNC-TG
+  uuid: 7e3289c7-4481-46c8-8403-1a63b1bfe09f
+  subjects:
+  - entities:
+    - role: player
+      name: Tony Gwynn
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: DNC-TH
+  uuid: 8f3fb803-396e-4cf0-b61b-0e7078d171ea
+  subjects:
+  - entities:
+    - role: player
+      name: Torii Hunter
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: DNC-TS
+  uuid: 6b19121c-6b34-49b0-869f-4a4c78b74f50
+  subjects:
+  - entities:
+    - role: player
+      name: Trevor Story
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: DNC-TSK
+  uuid: e33db9e1-905f-4ab6-a8e4-9a70c2ef0edf
+  subjects:
+  - entities:
+    - role: player
+      name: Tarik Skubal
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: DNC-TSO
+  uuid: e5c56276-c64d-4156-99ee-6dd55afe4fd3
+  subjects:
+  - entities:
+    - role: player
+      name: Tyler Soderstrom
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: DNC-TT
+  uuid: 78518871-1cc4-4af8-aab2-ae3927c28d6b
+  subjects:
+  - entities:
+    - role: player
+      name: Trea Turner
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: DNC-VG
+  uuid: 1c857912-4f1c-4486-a32f-e5fd987377cb
+  subjects:
+  - entities:
+    - role: player
+      name: Vladimir Guerrero Jr.
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: DNC-WS
+  uuid: 47009faa-8823-439b-aff3-ff313c8dd4aa
+  subjects:
+  - entities:
+    - role: player
+      name: Will Smith
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: DNC-XB
+  uuid: 782af6cb-d102-43ae-8294-f1f537d5b482
+  subjects:
+  - entities:
+    - role: player
+      name: Xander Bogaerts
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: DNC-YA
+  uuid: bd02f429-659a-4fac-b2e9-024108bd49c4
+  subjects:
+  - entities:
+    - role: player
+      name: Yordan Alvarez
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: DNC-YD
+  uuid: 4732ddae-6108-423c-a695-435c8cb0d13c
+  subjects:
+  - entities:
+    - role: player
+      name: Yu Darvish
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: DNC-YY
+  uuid: c8384538-22e3-4a31-8e5e-d3b11e8cd65b
+  subjects:
+  - entities:
+    - role: player
+      name: Yoshinobu Yamamoto
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: DNC-ZV
+  uuid: 92106130-c345-41c5-abc9-a1fe51576897
+  subjects:
+  - entities:
+    - role: player
+      name: Zac Veen
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: DNC-ZW
+  uuid: 1f29b642-daf2-4548-9e1a-45333adb8306
+  subjects:
+  - entities:
+    - role: player
+      name: Zack Wheeler
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 

--- a/data/baseball/2025-26-topps-definitive-collection/checklists/definitive-patch-collection.yaml
+++ b/data/baseball/2025-26-topps-definitive-collection/checklists/definitive-patch-collection.yaml
@@ -1,0 +1,870 @@
+- number: DPC-AB
+  uuid: 363da7d2-621c-49ba-8ff9-1138c7a94c1f
+  subjects:
+  - entities:
+    - role: player
+      name: Alex Bregman
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: DPC-AJ
+  uuid: 5e0c0ba2-bace-4326-b412-d251289b8256
+  subjects:
+  - entities:
+    - role: player
+      name: Aaron Judge
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: DPC-AJU
+  uuid: 3065dfff-c1b9-4094-a53e-993da91a5181
+  subjects:
+  - entities:
+    - role: player
+      name: Aaron Judge
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: DPC-AK
+  uuid: bb3a2640-7221-42f1-a6ff-326c708e7a66
+  subjects:
+  - entities:
+    - role: player
+      name: Al Kaline
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: DPC-AM
+  uuid: 4229c516-a8e7-4375-81cd-f08d25f1e939
+  subjects:
+  - entities:
+    - role: player
+      name: Andrew McCutchen
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: DPC-AP
+  uuid: 88e111c8-1b52-453b-8494-b106a04c9480
+  subjects:
+  - entities:
+    - role: player
+      name: Albert Pujols
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: DPC-AR
+  uuid: 47667430-6ef3-4797-bbee-80b80766ed8f
+  subjects:
+  - entities:
+    - role: player
+      name: Austin Riley
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: DPC-AROD
+  uuid: db15cafd-6a61-4fc7-ba17-3624fbfa6ba6
+  subjects:
+  - entities:
+    - role: player
+      name: Alex Rodriguez
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: DPC-ARU
+  uuid: 4a27b819-e36d-4d3e-b80a-f1c20ee87451
+  subjects:
+  - entities:
+    - role: player
+      name: Adley Rutschman
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: DPC-AV
+  uuid: fab0eab7-1004-47ce-b7b8-b7d9ed43f9a9
+  subjects:
+  - entities:
+    - role: player
+      name: Anthony Volpe
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: DPC-BB
+  uuid: 25856313-bc04-407b-89eb-dc94e9e317cc
+  subjects:
+  - entities:
+    - role: player
+      name: Byron Buxton
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: DPC-BH
+  uuid: d374a71c-575a-4d25-9b8f-7c7d6ce1caba
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Harper
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: DPC-BO
+  uuid: 7cef648c-5b1e-426a-9e52-d3094f1cb326
+  subjects:
+  - entities:
+    - role: player
+      name: Bo Bichette
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: DPC-BW
+  uuid: 2ea5425d-25cc-4df1-b352-ac62a6aa315b
+  subjects:
+  - entities:
+    - role: player
+      name: Bobby Witt Jr.
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: DPC-CC
+  uuid: 6f13d13c-b18b-46c0-bfa9-79c41b7aa46d
+  subjects:
+  - entities:
+    - role: player
+      name: Corbin Carroll
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: DPC-CCO
+  uuid: 650e4df7-b175-42fc-98ef-8ecedb96797b
+  subjects:
+  - entities:
+    - role: player
+      name: Carlos Correa
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: DPC-CCS
+  uuid: aa048a17-a9b7-435f-a5f2-71577576f7f1
+  subjects:
+  - entities:
+    - role: player
+      name: CC Sabathia
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: DPC-CD
+  uuid: 6d4a1b9f-0f78-4abb-b5a6-25473e415933
+  subjects:
+  - entities:
+    - role: player
+      name: Chase Dollander
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: DPC-CJ
+  uuid: f581f4dc-b2bc-4147-b8b0-994c6b7e94ff
+  subjects:
+  - entities:
+    - role: player
+      name: Chipper Jones
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: DPC-CR
+  uuid: f3f07619-9413-4f0d-9f9b-a81decc684e5
+  subjects:
+  - entities:
+    - role: player
+      name: Cal Ripken Jr.
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: DPC-CS
+  uuid: 2f26ae00-75e7-4eff-a746-bfa719eddf12
+  subjects:
+  - entities:
+    - role: player
+      name: Corey Seager
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: DPC-CY
+  uuid: 9ed7a410-bf91-4aca-89db-88cd5efa2cfc
+  subjects:
+  - entities:
+    - role: player
+      name: Christian Yelich
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: DPC-DC
+  uuid: a4e25c45-3587-43f1-af88-0dd643a35b88
+  subjects:
+  - entities:
+    - role: player
+      name: Dylan Crews
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: DPC-DJ
+  uuid: d42bd21c-1dbf-417e-9fe8-401cdcb139d9
+  subjects:
+  - entities:
+    - role: player
+      name: Derek Jeter
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: DPC-DO
+  uuid: ea69bf7d-705e-47fc-9106-3134d28f10a5
+  subjects:
+  - entities:
+    - role: player
+      name: David Ortiz
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: DPC-DP
+  uuid: aad41107-9096-4c5d-a77a-cc93db832538
+  subjects:
+  - entities:
+    - role: player
+      name: Dustin Pedroia
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: DPC-ED
+  uuid: 22bc5873-51b2-4b94-a0b9-e57786af11fb
+  subjects:
+  - entities:
+    - role: player
+      name: Elly De La Cruz
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: DPC-FA
+  uuid: 764a991c-66f6-4361-bfe2-9770296ba076
+  subjects:
+  - entities:
+    - role: player
+      name: Francisco Alvarez
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: DPC-FF
+  uuid: e6ab9f6f-4a01-48b5-aa72-73ed684a64d3
+  subjects:
+  - entities:
+    - role: player
+      name: Freddie Freeman
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: DPC-FH
+  uuid: b36bc726-2a43-491a-83f7-0e68c9752007
+  subjects:
+  - entities:
+    - role: player
+      name: Félix Hernández
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: DPC-FL
+  uuid: 0fff0c0d-2569-4ad2-b150-13378fb83e15
+  subjects:
+  - entities:
+    - role: player
+      name: Francisco Lindor
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: DPC-FT
+  uuid: 04de0c45-c7ff-49ad-b4c6-0e88abc1de2a
+  subjects:
+  - entities:
+    - role: player
+      name: Fernando Tatis Jr.
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: DPC-GC
+  uuid: 214d1143-f08c-4a9e-8fde-1a283efecec5
+  subjects:
+  - entities:
+    - role: player
+      name: Gerrit Cole
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: DPC-GH
+  uuid: b414fdf5-56bd-45d1-898b-8ce127cce92d
+  subjects:
+  - entities:
+    - role: player
+      name: Gunnar Henderson
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: DPC-GS
+  uuid: 53cb68e5-9fd0-40c7-be2d-3df6acb8bb4f
+  subjects:
+  - entities:
+    - role: player
+      name: Gary Sheffield
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: DPC-GST
+  uuid: d7cf2bb3-4423-4e29-92c0-1d4b4bfaa1e3
+  subjects:
+  - entities:
+    - role: player
+      name: Giancarlo Stanton
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: DPC-HG
+  uuid: 77a41cd8-b3af-40b0-8e2a-3904c1e3ea96
+  subjects:
+  - entities:
+    - role: player
+      name: Hunter Greene
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: DPC-I
+  uuid: 77befd47-ec0a-4da7-9d48-a1ee4918e3ff
+  subjects:
+  - entities:
+    - role: player
+      name: Ichiro
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: DPC-ICH
+  uuid: f2562c18-992c-4b73-8f4c-3fa572b3dc28
+  subjects:
+  - entities:
+    - role: player
+      name: Ichiro
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: DPC-JA
+  uuid: 40e70395-ba93-486f-9c7e-bf7cab07dbc5
+  subjects:
+  - entities:
+    - role: player
+      name: Jose Altuve
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: DPC-JC
+  uuid: b6e7cb20-7234-41a3-b406-03ef2ba1d5d2
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Chourio
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: DPC-JCA
+  uuid: 2f30a19f-476c-4804-a64a-dc449504af90
+  subjects:
+  - entities:
+    - role: player
+      name: Junior Caminero
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: DPC-JCJ
+  uuid: 5019f412-e294-462c-9b47-688a020047d7
+  subjects:
+  - entities:
+    - role: player
+      name: Jazz Chisholm Jr.
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: DPC-JH
+  uuid: '0843a068-0a8f-4462-8a66-bbba5085edb4'
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Holliday
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: DPC-JL
+  uuid: '09097d54-7b98-4d02-b8a0-c6bf0155fb45'
+  subjects:
+  - entities:
+    - role: player
+      name: Jung Hoo Lee
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: DPC-JM
+  uuid: 2198853f-47e3-4d69-9339-78281c12cc11
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Merrill
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: DPC-JP
+  uuid: 20c92548-6d2e-46fd-98b7-6201168f2700
+  subjects:
+  - entities:
+    - role: player
+      name: Jeremy Peña
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: DPC-JPO
+  uuid: 1135bc1d-edef-4072-b81f-3124ce44ddc7
+  subjects:
+  - entities:
+    - role: player
+      name: Jorge Posada
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: DPC-JR
+  uuid: e6e774e8-4f62-40bc-b824-95bdfe09211e
+  subjects:
+  - entities:
+    - role: player
+      name: José Ramírez
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: DPC-JRO
+  uuid: c666a29b-c4d4-46e9-8924-3523f79c83e7
+  subjects:
+  - entities:
+    - role: player
+      name: Julio Rodríguez
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: DPC-JSO
+  uuid: 8398c511-b014-4966-aaff-62faf48b683c
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: DPC-JW
+  uuid: 84cf5edb-b6f5-4047-98c6-9a6ae242a643
+  subjects:
+  - entities:
+    - role: player
+      name: James Wood
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: DPC-KM
+  uuid: c861040f-0dca-4136-a90d-76dc10dda2b0
+  subjects:
+  - entities:
+    - role: player
+      name: Ketel Marte
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: DPC-LA
+  uuid: a2456f07-00a5-4723-b55e-5c5a9a0b4c06
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Arraez
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: DPC-LB
+  uuid: edfb3bd8-3b32-4724-b108-94a8c81035b8
+  subjects:
+  - entities:
+    - role: player
+      name: Lawrence Butler
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: DPC-LW
+  uuid: 0a9c9783-ea6d-4622-b626-d94c319579f3
+  subjects:
+  - entities:
+    - role: player
+      name: Larry Walker
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: DPC-MB
+  uuid: 1f434d8e-bf8d-4e3e-976d-4363e5aa6a67
+  subjects:
+  - entities:
+    - role: player
+      name: Mookie Betts
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: DPC-MC
+  uuid: f86e12a3-3f36-4dfe-9c1c-9df77241f95b
+  subjects:
+  - entities:
+    - role: player
+      name: Miguel Cabrera
+      ref: 
+    - role: team
+      name: Florida Marlins
+      ref: 
+- number: DPC-MCA
+  uuid: c8425612-c1a1-4df8-bc6a-6bdb7e5ba15b
+  subjects:
+  - entities:
+    - role: player
+      name: Miguel Cabrera
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: DPC-MF
+  uuid: 5e729823-db35-43e5-9f95-a733b93a5e17
+  subjects:
+  - entities:
+    - role: player
+      name: Max Fried
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: DPC-MM
+  uuid: b12fd568-0649-430f-8979-575166583787
+  subjects:
+  - entities:
+    - role: player
+      name: Manny Machado
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: DPC-MO
+  uuid: 7ac7e20e-c360-42e7-8c1a-e38708ac9cd7
+  subjects:
+  - entities:
+    - role: player
+      name: Matt Olson
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: DPC-MS
+  uuid: ad051953-a7a8-4d3a-9583-6302d02b76d3
+  subjects:
+  - entities:
+    - role: player
+      name: Matt Shaw
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: DPC-MT
+  uuid: c2fbcf7a-47a3-4750-9392-9200430327db
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Trout
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: DPC-NA
+  uuid: 2d481d7b-1442-464d-9c51-7e0ddeef02c2
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan Arenado
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: DPC-OA
+  uuid: 28924717-709b-4893-8f64-93c718ab2de2
+  subjects:
+  - entities:
+    - role: player
+      name: Ozzie Albies
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: DPC-OC
+  uuid: 934b9056-9537-424e-a9db-fa211e57311c
+  subjects:
+  - entities:
+    - role: player
+      name: Oneil Cruz
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: DPC-PA
+  uuid: bc017ead-0860-41ae-8a61-5ea472930486
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Alonso
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: DPC-PAL
+  uuid: f7972422-4b1b-4d54-9719-acc21175686b
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Alonso
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: DPC-PC
+  uuid: 6c2c33f5-8a80-44d5-bbce-d89408620523
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Crow-Armstrong
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: DPC-PS
+  uuid: f8e24c75-a59f-4c45-9174-350bb9bca034
+  subjects:
+  - entities:
+    - role: player
+      name: Paul Skenes
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: DPC-RG
+  uuid: 1131f4bd-aeff-4adf-93c4-bfda60eb50b4
+  subjects:
+  - entities:
+    - role: player
+      name: Riley Greene
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: DPC-RH
+  uuid: 89fcca6a-88f7-4cfd-b031-757832b2d9d0
+  subjects:
+  - entities:
+    - role: player
+      name: Rickey Henderson
+      ref: 
+    - role: team
+      name: Oakland Athletics
+      ref: 
+- number: DPC-RJ
+  uuid: 26859a93-537f-4424-b119-29f80ed00880
+  subjects:
+  - entities:
+    - role: player
+      name: Reggie Jackson
+      ref: 
+    - role: team
+      name: California Angels
+      ref: 
+- number: DPC-SA
+  uuid: 75665310-e358-4d26-91ee-acd34f774948
+  subjects:
+  - entities:
+    - role: player
+      name: Sandy Alcantara
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: DPC-SO
+  uuid: 55edd76e-ccaf-4e6d-92a1-09bfdeda37f1
+  subjects:
+  - entities:
+    - role: player
+      name: Shohei Ohtani
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: DPC-SP
+  uuid: d2e8ec22-fdcf-4d9f-afbb-7f97f0ec55e1
+  subjects:
+  - entities:
+    - role: player
+      name: Salvador Perez
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: DPC-TG
+  uuid: ed3c2c1d-bc6c-490c-80ab-c52c59307241
+  subjects:
+  - entities:
+    - role: player
+      name: Tony Gwynn
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: DPC-TS
+  uuid: 718a7041-9c1b-4952-a30e-2ded2903dd67
+  subjects:
+  - entities:
+    - role: player
+      name: Tarik Skubal
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: DPC-TSO
+  uuid: 1035c024-e798-499d-8bbc-8405eeced8bc
+  subjects:
+  - entities:
+    - role: player
+      name: Tyler Soderstrom
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: DPC-TT
+  uuid: 79f0546c-1a2b-44a8-a9c4-7b5c4c669642
+  subjects:
+  - entities:
+    - role: player
+      name: Trea Turner
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: DPC-VGJ
+  uuid: 0230033e-d047-47e9-9b6f-2764fafb74c0
+  subjects:
+  - entities:
+    - role: player
+      name: Vladimir Guerrero Jr.
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: DPC-WM
+  uuid: b5a37309-eca9-4292-921d-c6817ba74ced
+  subjects:
+  - entities:
+    - role: player
+      name: Willie McCovey
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: DPC-WS
+  uuid: 2a6de277-c509-4f60-9967-8a2d893b12cc
+  subjects:
+  - entities:
+    - role: player
+      name: Willie Stargell
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: DPC-YA
+  uuid: 5ff598be-1a7d-42a8-b27e-ad909b3d9501
+  subjects:
+  - entities:
+    - role: player
+      name: Yordan Alvarez
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: DPC-YD
+  uuid: ed93592c-be73-4a28-8918-91cb843f35a9
+  subjects:
+  - entities:
+    - role: player
+      name: Yu Darvish
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: DPC-ZW
+  uuid: ba70fff2-9b01-43bd-9512-81fb4679982a
+  subjects:
+  - entities:
+    - role: player
+      name: Zack Wheeler
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 

--- a/data/baseball/2025-26-topps-definitive-collection/checklists/definitive-quad-autographs.yaml
+++ b/data/baseball/2025-26-topps-definitive-collection/checklists/definitive-quad-autographs.yaml
@@ -1,0 +1,217 @@
+- number: DQAC-BGST
+  uuid: ec4e6626-53db-42a1-a1fb-1f97f036de9e
+  subjects:
+  - entities:
+    - role: player
+      name: Ken Griffey Jr.
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+  - entities:
+    - role: player
+      name: Sammy Sosa
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+  - entities:
+    - role: player
+      name: Barry Bonds
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+  - entities:
+    - role: player
+      name: Mike Trout
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: DQAC-GSTR
+  uuid: 6deee248-5064-4640-80c8-8e5d553ec745
+  subjects:
+  - entities:
+    - role: player
+      name: Vladimir Guerrero Jr.
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+  - entities:
+    - role: player
+      name: Fernando Tatis Jr.
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+  - entities:
+    - role: player
+      name: José Ramírez
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: DQAC-IMOY
+  uuid: d0742aef-a52e-49a6-b032-824ab719cdb5
+  subjects:
+  - entities:
+    - role: player
+      name: Hideki Matsui
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+  - entities:
+    - role: player
+      name: Ichiro
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+  - entities:
+    - role: player
+      name: Yoshinobu Yamamoto
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+  - entities:
+    - role: player
+      name: Shohei Ohtani
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: DQAC-JMJJ
+  uuid: 82ce746f-7b16-40a5-a0e8-b71e000a745d
+  subjects:
+  - entities:
+    - role: player
+      name: Don Mattingly
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+  - entities:
+    - role: player
+      name: Reggie Jackson
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+  - entities:
+    - role: player
+      name: Aaron Judge
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+  - entities:
+    - role: player
+      name: Derek Jeter
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: DQAC-ONYS
+  uuid: 8cec4eae-7677-4f84-8962-987f2081df3f
+  subjects:
+  - entities:
+    - role: player
+      name: Yoshinobu Yamamoto
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+  - entities:
+    - role: player
+      name: Shohei Ohtani
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+  - entities:
+    - role: player
+      name: Roki Sasaki
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+  - entities:
+    - role: player
+      name: Hideo Nomo
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: DQAC-PWLS
+  uuid: 3ce4e125-8038-4fd2-a9b9-da11858068ba
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Piazza
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+  - entities:
+    - role: player
+      name: David Wright
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+  - entities:
+    - role: player
+      name: Francisco Lindor
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: DQAC-RMHH
+  uuid: 3634cea3-0a44-412e-9863-ffe3fd517b44
+  subjects:
+  - entities:
+    - role: player
+      name: Eddie Murray
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+  - entities:
+    - role: player
+      name: Cal Ripken Jr.
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+  - entities:
+    - role: player
+      name: Gunnar Henderson
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+  - entities:
+    - role: player
+      name: Jackson Holliday
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 

--- a/data/baseball/2025-26-topps-definitive-collection/checklists/definitive-rookie-autographs.yaml
+++ b/data/baseball/2025-26-topps-definitive-collection/checklists/definitive-rookie-autographs.yaml
@@ -1,0 +1,420 @@
+- number: DRA-ARA
+  uuid: 327733a2-aa8d-4eee-b1ee-50ab06369ff4
+  subjects:
+  - entities:
+    - role: player
+      name: Agustín Ramírez
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: DRA-BL
+  uuid: d0f366df-5c3d-40c7-a117-749b6d7f502e
+  subjects:
+  - entities:
+    - role: player
+      name: Brooks Lee
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: DRA-BR
+  uuid: 68b4cf7b-7a7e-4af0-be2a-03ff1eb352d8
+  subjects:
+  - entities:
+    - role: player
+      name: Ben Rice
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: DRA-BW
+  uuid: b5aabd06-03e9-4f3b-b3a1-595302912eed
+  subjects:
+  - entities:
+    - role: player
+      name: Ben Williamson
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: DRA-CDO
+  uuid: 572d14b8-7192-4ce0-bf0d-d3446b194e6a
+  subjects:
+  - entities:
+    - role: player
+      name: Chase Dollander
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: DRA-CDU
+  uuid: 19803dc8-9d3a-468a-bea0-221cc666cb25
+  subjects:
+  - entities:
+    - role: player
+      name: Caleb Durbin
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: DRA-CH
+  uuid: 985d5c04-ecc0-420e-ae5c-b24473eb296a
+  subjects:
+  - entities:
+    - role: player
+      name: Cade Horton
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: DRA-CMA
+  uuid: d10aad15-97a6-4620-a0bc-322a50693458
+  subjects:
+  - entities:
+    - role: player
+      name: Coby Mayo
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: DRA-CME
+  uuid: 31b535a8-0994-46a1-8ce4-a3ddb5eb0864
+  subjects:
+  - entities:
+    - role: player
+      name: Chase Meidroth
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: DRA-CNO
+  uuid: 71de659b-d89d-4f3c-85c4-341f8858fc14
+  subjects:
+  - entities:
+    - role: player
+      name: Connor Norby
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: DRA-CS
+  uuid: 974e9df0-208d-4467-a2d4-105f7e1c87d8
+  subjects:
+  - entities:
+    - role: player
+      name: Cam Smith
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: DRA-CSI
+  uuid: d81eeae0-2f68-4a7c-aa04-0846a8b65879
+  subjects:
+  - entities:
+    - role: player
+      name: Chandler Simpson
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: DRA-DAR
+  uuid: eab1ee95-5a3d-4e4c-941b-1229d9c2b110
+  subjects:
+  - entities:
+    - role: player
+      name: Dalton Rushing
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: DRA-DB
+  uuid: e613d735-db7f-4f0b-870b-0e6ee85543bb
+  subjects:
+  - entities:
+    - role: player
+      name: Drake Baldwin
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: DRA-DC
+  uuid: da51a326-20d2-411f-86fc-84ede5972590
+  subjects:
+  - entities:
+    - role: player
+      name: Dylan Crews
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: DRA-DCR
+  uuid: 91db9df1-e97d-4c40-afe3-5722f7d6dee7
+  subjects:
+  - entities:
+    - role: player
+      name: Dylan Crews
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: DRA-DR
+  uuid: 0bcb3ae9-25b9-4169-9c7d-4b2d66079068
+  subjects:
+  - entities:
+    - role: player
+      name: Dalton Rushing
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: DRA-EQ
+  uuid: 46fe84b9-9b42-4488-b9ab-e33e7bd40d8f
+  subjects:
+  - entities:
+    - role: player
+      name: Edgar Quero
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: DRA-HK
+  uuid: b15a4bbe-5af0-43b9-8bfa-7bceb295b2e5
+  subjects:
+  - entities:
+    - role: player
+      name: Hyeseong Kim
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: DRA-HW
+  uuid: d56dfcc8-f965-42ac-a9d0-83953fc7d230
+  subjects:
+  - entities:
+    - role: player
+      name: Hurston Waldrep
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: DRA-HYK
+  uuid: 4654f8f0-90d9-4de7-9979-55981e9ad9be
+  subjects:
+  - entities:
+    - role: player
+      name: Hyeseong Kim
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: DRA-JJO
+  uuid: ed864a30-23f7-4bb7-9909-4cea287fe605
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Jobe
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: DRA-JJU
+  uuid: f1b881d8-30c6-432f-9a4e-c13398f25e2f
+  subjects:
+  - entities:
+    - role: player
+      name: Jace Jung
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: DRA-JW
+  uuid: b7686ca8-33e3-41ef-9ba9-044737e3c9e5
+  subjects:
+  - entities:
+    - role: player
+      name: James Wood
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: DRA-JWI
+  uuid: fa408c4a-70dc-4268-9296-9faa1f8e3c2b
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Wilson
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: DRA-JWO
+  uuid: 25a3a4a3-89f4-46ab-b0e0-833ebf48dc7f
+  subjects:
+  - entities:
+    - role: player
+      name: James Wood
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: DRA-KA
+  uuid: 8645e658-5266-4f75-9772-cdc8c79acd02
+  subjects:
+  - entities:
+    - role: player
+      name: Kevin Alcántara
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: DRA-KC
+  uuid: d517b906-9bc6-4845-a9db-a4d97ce24a69
+  subjects:
+  - entities:
+    - role: player
+      name: Kristian Campbell
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: DRA-KCA
+  uuid: 541e0603-94fd-4273-8246-c08fa6a13a51
+  subjects:
+  - entities:
+    - role: player
+      name: Kristian Campbell
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: DRA-KR
+  uuid: 5c8ad59e-4d82-434e-9f7f-31902488dd2f
+  subjects:
+  - entities:
+    - role: player
+      name: Kumar Rocker
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: DRA-LA
+  uuid: e45c51b0-6e9a-4558-b8b7-fe34cea89640
+  subjects:
+  - entities:
+    - role: player
+      name: Luisangel Acuña
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: DRA-LK
+  uuid: bd8bfee3-21ca-4fa2-b4ab-ab4896540c40
+  subjects:
+  - entities:
+    - role: player
+      name: Luke Keaschall
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: DRA-MB
+  uuid: '08cbca37-be94-4d3d-9257-83350d4c4875'
+  subjects:
+  - entities:
+    - role: player
+      name: Moisés Ballesteros
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: DRA-MMU
+  uuid: c6e47297-39af-4ac6-8971-e23f9311bd8b
+  subjects:
+  - entities:
+    - role: player
+      name: Max Muncy
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: DRA-MS
+  uuid: ed673291-a50c-4263-94dc-65291c633bf4
+  subjects:
+  - entities:
+    - role: player
+      name: Matt Shaw
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: DRA-NK
+  uuid: 2caf7c3b-deb8-4e19-b7bd-e5879216158a
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Kurtz
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: DRA-NKU
+  uuid: b863c4e0-628a-4484-8e4b-597c9a674fcf
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Kurtz
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: DRA-RL
+  uuid: 5910dddd-0bd3-4491-9117-d6143332b226
+  subjects:
+  - entities:
+    - role: player
+      name: Rhett Lowder
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: DRA-RS
+  uuid: 38e3b7d8-7fc3-4cba-8ac6-b731b02c9c89
+  subjects:
+  - entities:
+    - role: player
+      name: Roki Sasaki
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: DRA-RSA
+  uuid: 146eceea-7e35-44a5-a257-8d0bc9105e11
+  subjects:
+  - entities:
+    - role: player
+      name: Roki Sasaki
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: DRA-SS
+  uuid: 83e3eedd-1cb2-4a7c-8a38-d2b1d81c3522
+  subjects:
+  - entities:
+    - role: player
+      name: Spencer Schwellenbach
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: DRA-TS
+  uuid: 2a333a73-a984-44ef-99e0-836e81510e67
+  subjects:
+  - entities:
+    - role: player
+      name: Thomas Saggese
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 

--- a/data/baseball/2025-26-topps-definitive-collection/checklists/definitive-rookie-patch-autographs.yaml
+++ b/data/baseball/2025-26-topps-definitive-collection/checklists/definitive-rookie-patch-autographs.yaml
@@ -1,0 +1,340 @@
+- number: DRPA-ARA
+  uuid: b2ada177-ae4c-4711-940b-c5b9b1bb0d93
+  subjects:
+  - entities:
+    - role: player
+      name: Agustín Ramírez
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: DRPA-BL
+  uuid: 35af9f89-b3fd-433d-8993-c1bbd57187e7
+  subjects:
+  - entities:
+    - role: player
+      name: Brooks Lee
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: DRPA-BR
+  uuid: 6868774f-b537-40b9-824f-73874d412ecd
+  subjects:
+  - entities:
+    - role: player
+      name: Ben Rice
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: DRPA-CD
+  uuid: 3a992688-2a74-4694-ad19-8e2a5e124f67
+  subjects:
+  - entities:
+    - role: player
+      name: Caden Dana
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: DRPA-CDO
+  uuid: 9991a6bb-36b6-4893-a67f-23d321070edc
+  subjects:
+  - entities:
+    - role: player
+      name: Chase Dollander
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: DRPA-CH
+  uuid: 694091ce-8164-482f-8de6-fc48ca25def8
+  subjects:
+  - entities:
+    - role: player
+      name: Cade Horton
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: DRPA-CM
+  uuid: 9e27fee0-d71f-4918-98dd-b3066b55b600
+  subjects:
+  - entities:
+    - role: player
+      name: Coby Mayo
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: DRPA-CME
+  uuid: 6a51268e-05f6-46f6-9255-ba278ff90e0d
+  subjects:
+  - entities:
+    - role: player
+      name: Chase Meidroth
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: DRPA-CSI
+  uuid: 5d084ea3-a0ec-4d21-81c7-f22c350ac6ab
+  subjects:
+  - entities:
+    - role: player
+      name: Chandler Simpson
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: DRPA-DAR
+  uuid: b4725ad9-1ee2-487a-bc25-5577b3b1aed9
+  subjects:
+  - entities:
+    - role: player
+      name: Dalton Rushing
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: DRPA-DB
+  uuid: c77a2451-3240-4101-9465-10d242142de7
+  subjects:
+  - entities:
+    - role: player
+      name: Drake Baldwin
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: DRPA-DC
+  uuid: 59f6a727-b4d5-4294-82b5-ae677d8b3614
+  subjects:
+  - entities:
+    - role: player
+      name: Dylan Crews
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: DRPA-DL
+  uuid: 3e1e1ae8-49be-4efa-bf4d-5efc8c1a30a0
+  subjects:
+  - entities:
+    - role: player
+      name: Daylen Lile
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: DRPA-EQ
+  uuid: 77223254-8bb7-4125-8080-aa5ea6848543
+  subjects:
+  - entities:
+    - role: player
+      name: Edgar Quero
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: DRPA-GM
+  uuid: f0ab310e-a3ea-473b-b0d5-8874faf5e3e9
+  subjects:
+  - entities:
+    - role: player
+      name: Grant McCray
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: DRPA-HB
+  uuid: 82f64c7b-c682-445c-a77a-a89be67e4d5b
+  subjects:
+  - entities:
+    - role: player
+      name: Hayden Birdsong
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: DRPA-HW
+  uuid: 68457040-1e61-4a31-92db-74fa078b41e0
+  subjects:
+  - entities:
+    - role: player
+      name: Hurston Waldrep
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: DRPA-JJ
+  uuid: 4ac22b19-bc51-4043-8144-72e2f37c77e1
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Jobe
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: DRPA-JJU
+  uuid: 0e4bb857-1759-4363-8762-3e2fea3b2b7c
+  subjects:
+  - entities:
+    - role: player
+      name: Jace Jung
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: DRPA-JM
+  uuid: cb1e5cec-ea90-4e3a-b54d-1ca5eb91ed96
+  subjects:
+  - entities:
+    - role: player
+      name: Justyn-Henry Malloy
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: DRPA-JW
+  uuid: 944275e4-e61c-4372-a4bc-7abd04519cc8
+  subjects:
+  - entities:
+    - role: player
+      name: James Wood
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: DRPA-JWI
+  uuid: dba49106-5e8a-4791-bc58-3ea3b57da7ac
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Wilson
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: DRPA-KC
+  uuid: 8a2f8c66-88df-4b6a-bde6-a0f4fbc2db22
+  subjects:
+  - entities:
+    - role: player
+      name: Kristian Campbell
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: DRPA-LA
+  uuid: '09bbb4e1-af56-468c-b6f9-5e3d97f97629'
+  subjects:
+  - entities:
+    - role: player
+      name: Luisangel Acuña
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: DRPA-LHE
+  uuid: 53029394-ee04-473b-ae3f-2592de6744a9
+  subjects:
+  - entities:
+    - role: player
+      name: Logan Henderson
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: DRPA-MMA
+  uuid: e220a602-303b-40ec-8544-c31bc526e740
+  subjects:
+  - entities:
+    - role: player
+      name: Marcelo Mayer
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: DRPA-MS
+  uuid: ff9cd814-edcd-459e-8c5b-613066473648
+  subjects:
+  - entities:
+    - role: player
+      name: Matt Shaw
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: DRPA-NK
+  uuid: d8eaf8b1-aa64-4af8-b6da-91be71afb4a0
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Kurtz
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: DRPA-NY
+  uuid: 6cd43810-1f79-43ef-96a4-819031497d17
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Yorke
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: DRPA-RS
+  uuid: 7e3217f8-21f9-4c1e-920c-332545bef81c
+  subjects:
+  - entities:
+    - role: player
+      name: Roki Sasaki
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: DRPA-SS
+  uuid: 608c363f-dbb9-4775-a925-3aad510ea770
+  subjects:
+  - entities:
+    - role: player
+      name: Spencer Schwellenbach
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: DRPA-SW
+  uuid: ab1e8a44-45fd-41ff-a4dd-f6fdd64dca2a
+  subjects:
+  - entities:
+    - role: player
+      name: Shay Whitcomb
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: DRPA-TS
+  uuid: f8f71e4b-2746-4422-b559-00c383ef67e0
+  subjects:
+  - entities:
+    - role: player
+      name: Thomas Saggese
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: DRPA-TSW
+  uuid: a7c56f07-1444-4d06-b905-039f24d226c4
+  subjects:
+  - entities:
+    - role: player
+      name: Trey Sweeney
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 

--- a/data/baseball/2025-26-topps-definitive-collection/checklists/definitive-triple-autographs.yaml
+++ b/data/baseball/2025-26-topps-definitive-collection/checklists/definitive-triple-autographs.yaml
@@ -1,0 +1,192 @@
+- number: DTAC-BJW
+  uuid: 4f42f760-7a07-45ba-bd71-4d7a19b2c4fa
+  subjects:
+  - entities:
+    - role: player
+      name: George Brett
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+  - entities:
+    - role: player
+      name: Bo Jackson
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+  - entities:
+    - role: player
+      name: Bobby Witt Jr.
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: DTAC-BPR
+  uuid: 981cc449-74dd-4862-8c72-e03b09c88246
+  subjects:
+  - entities:
+    - role: player
+      name: Albert Pujols
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+  - entities:
+    - role: player
+      name: Barry Bonds
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+  - entities:
+    - role: player
+      name: Alex Rodriguez
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: DTAC-GIR
+  uuid: 070de7f9-78e5-44db-9906-9b26c3178b82
+  subjects:
+  - entities:
+    - role: player
+      name: Ichiro
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+  - entities:
+    - role: player
+      name: Julio Rodríguez
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+  - entities:
+    - role: player
+      name: Ken Griffey Jr.
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: DTAC-KKY
+  uuid: 8cd50fc8-8f19-4198-a854-020dbb1cea36
+  subjects:
+  - entities:
+    - role: player
+      name: Sandy Koufax
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+  - entities:
+    - role: player
+      name: Clayton Kershaw
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+  - entities:
+    - role: player
+      name: Yoshinobu Yamamoto
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: DTAC-OYS
+  uuid: 84d6df87-7a95-4e1f-a3a3-0b7ec4b0172c
+  subjects:
+  - entities:
+    - role: player
+      name: Yoshinobu Yamamoto
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+  - entities:
+    - role: player
+      name: Roki Sasaki
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+  - entities:
+    - role: player
+      name: Shohei Ohtani
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: DTAC-PWS
+  uuid: 2469fccd-b9b3-4456-904e-e037a185123b
+  subjects:
+  - entities:
+    - role: player
+      name: David Wright
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+  - entities:
+    - role: player
+      name: Mike Piazza
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: DTAC-RCS
+  uuid: d3d80271-943b-4d77-bdda-f3a4f3a36431
+  subjects:
+  - entities:
+    - role: player
+      name: Paul Skenes
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+  - entities:
+    - role: player
+      name: Roger Clemens
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+  - entities:
+    - role: player
+      name: Nolan Ryan
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: DTAC-RUH
+  uuid: 5b5829e4-14bf-4b96-95e1-facd93025408
+  subjects:
+  - entities:
+    - role: player
+      name: Ryan Howard
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+  - entities:
+    - role: player
+      name: Jimmy Rollins
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+  - entities:
+    - role: player
+      name: Chase Utley
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 

--- a/data/baseball/2025-26-topps-definitive-collection/checklists/definitive-triple-mlb-logo-patch-booklets.yaml
+++ b/data/baseball/2025-26-topps-definitive-collection/checklists/definitive-triple-mlb-logo-patch-booklets.yaml
@@ -1,0 +1,360 @@
+- number: DTLP-AAP
+  uuid: 46c01cbb-be7c-4b97-946c-c8938b154493
+  subjects:
+  - entities:
+    - role: player
+      name: Jose Altuve
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+  - entities:
+    - role: player
+      name: Jeremy Peña
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+  - entities:
+    - role: player
+      name: Yordan Alvarez
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: DTLP-ALK
+  uuid: 8eb09d61-ee95-43a8-ab4a-b6e56cffaeba
+  subjects:
+  - entities:
+    - role: player
+      name: Francisco Lindor
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+  - entities:
+    - role: player
+      name: Pete Alonso
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+  - entities:
+    - role: player
+      name: Kodai Senga
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: DTLP-AMC
+  uuid: e85d0910-4456-4dc4-ac59-4b88bd841c7f
+  subjects:
+  - entities:
+    - role: player
+      name: Andrew McCutchen
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+  - entities:
+    - role: player
+      name: Andrew McCutchen
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+  - entities:
+    - role: player
+      name: Andrew McCutchen
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: DTLP-BTH
+  uuid: a517d158-9798-40b5-a597-c22d0300a4c4
+  subjects:
+  - entities:
+    - role: player
+      name: Mookie Betts
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+  - entities:
+    - role: player
+      name: Mike Trout
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+  - entities:
+    - role: player
+      name: Bryce Harper
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: DTLP-CJS
+  uuid: 998ef7d5-02ef-4dae-ae3c-12c8a0c9d703
+  subjects:
+  - entities:
+    - role: player
+      name: Gerrit Cole
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+  - entities:
+    - role: player
+      name: Aaron Judge
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+  - entities:
+    - role: player
+      name: Giancarlo Stanton
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: DTLP-CTS
+  uuid: 46678e6b-848b-4653-aef2-e2cdaed66c45
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Crow-Armstrong
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+  - entities:
+    - role: player
+      name: Kyle Tucker
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+  - entities:
+    - role: player
+      name: Dansby Swanson
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: DTLP-CWC
+  uuid: bd1cce71-3d3c-47af-ad15-aba4824064a9
+  subjects:
+  - entities:
+    - role: player
+      name: Corbin Carroll
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+  - entities:
+    - role: player
+      name: Pete Crow-Armstrong
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+  - entities:
+    - role: player
+      name: Bobby Witt Jr.
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: DTLP-FBK
+  uuid: f2132af8-7fb6-404a-967c-ae354fa008e3
+  subjects:
+  - entities:
+    - role: player
+      name: Mookie Betts
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+  - entities:
+    - role: player
+      name: Freddie Freeman
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+  - entities:
+    - role: player
+      name: Clayton Kershaw
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: DTLP-MMT
+  uuid: 92fd8796-cf4d-4649-b5b6-954858d62a28
+  subjects:
+  - entities:
+    - role: player
+      name: Fernando Tatis Jr.
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+  - entities:
+    - role: player
+      name: Jackson Merrill
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+  - entities:
+    - role: player
+      name: Manny Machado
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: DTLP-OAR
+  uuid: 9cb7a9af-695b-4a69-beaa-2543ebbc8c03
+  subjects:
+  - entities:
+    - role: player
+      name: Austin Riley
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+  - entities:
+    - role: player
+      name: Ronald Acuña Jr.
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+  - entities:
+    - role: player
+      name: Matt Olson
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: DTLP-PBMP
+  uuid: 6f7165c5-ca98-436f-821a-926b8b5d0c4d
+  subjects:
+  - entities:
+    - role: player
+      name: Marcelo Mayer
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+  - entities:
+    - role: player
+      name: Dustin Pedroia
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+  - entities:
+    - role: player
+      name: Alex Bregman
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: DTLP-RGC
+  uuid: 3b564116-c836-46c4-82f3-bc3758843de1
+  subjects:
+  - entities:
+    - role: player
+      name: Junior Caminero
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+  - entities:
+    - role: player
+      name: Vladimir Guerrero Jr.
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+  - entities:
+    - role: player
+      name: Julio Rodríguez
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: DTLP-SJC
+  uuid: 92371658-1a60-48c9-a5fb-09bd97bfdf29
+  subjects:
+  - entities:
+    - role: player
+      name: Aaron Judge
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+  - entities:
+    - role: player
+      name: CC Sabathia
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+  - entities:
+    - role: player
+      name: Gerrit Cole
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: DTLP-THS
+  uuid: cc0a6285-558b-4a05-9da7-0fe6a86d431c
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Harper
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+  - entities:
+    - role: player
+      name: Trea Turner
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+  - entities:
+    - role: player
+      name: Kyle Schwarber
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: DTLP-TJW
+  uuid: 9090855f-7fd0-4fbc-bc94-4694e3bb4c89
+  subjects:
+  - entities:
+    - role: player
+      name: Aaron Judge
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+  - entities:
+    - role: player
+      name: Mike Trout
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+  - entities:
+    - role: player
+      name: Bobby Witt Jr.
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 

--- a/data/baseball/2025-26-topps-definitive-collection/checklists/definitive-world-series-baseball-autographed-relics.yaml
+++ b/data/baseball/2025-26-topps-definitive-collection/checklists/definitive-world-series-baseball-autographed-relics.yaml
@@ -1,0 +1,90 @@
+- number: WSAR-AJ
+  uuid: 4d1bfa93-79ff-4fcf-9376-17e26ee44782
+  subjects:
+  - entities:
+    - role: player
+      name: Aaron Judge
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: WSAR-AV
+  uuid: cc2139ad-14f6-4645-ba92-2ca96c2ece78
+  subjects:
+  - entities:
+    - role: player
+      name: Anthony Volpe
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: WSAR-FF
+  uuid: 77acf07c-255e-4bca-93d6-9d4d620de595
+  subjects:
+  - entities:
+    - role: player
+      name: Freddie Freeman
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: WSAR-JC
+  uuid: 0b521973-6627-4e3a-b277-33b63540e8db
+  subjects:
+  - entities:
+    - role: player
+      name: Jazz Chisholm Jr.
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: WSAR-JS
+  uuid: 2c9ea501-fdfb-4638-be77-c3263aaf56c3
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: WSAR-SHO
+  uuid: 719b15ee-f567-4d0c-8c83-f14fcd4043fa
+  subjects:
+  - entities:
+    - role: player
+      name: Shohei Ohtani
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: WSAR-SO
+  uuid: 752ce839-2d89-402f-a584-1984b3f79bdb
+  subjects:
+  - entities:
+    - role: player
+      name: Shohei Ohtani
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: WSAR-SOH
+  uuid: 3acfb2aa-cc4a-4fb0-82da-5ffb900709fd
+  subjects:
+  - entities:
+    - role: player
+      name: Shohei Ohtani
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: WSAR-YY
+  uuid: e9aba785-8359-4fb0-9242-1bc5eb9b4941
+  subjects:
+  - entities:
+    - role: player
+      name: Yoshinobu Yamamoto
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 

--- a/data/baseball/2025-26-topps-definitive-collection/checklists/dual-autograph-relic-collection.yaml
+++ b/data/baseball/2025-26-topps-definitive-collection/checklists/dual-autograph-relic-collection.yaml
@@ -1,0 +1,493 @@
+- number: DARC-BA
+  uuid: fa44ad47-301f-4a4d-af4f-62c6b5bce522
+  subjects:
+  - entities:
+    - role: player
+      name: Craig Biggio
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+  - entities:
+    - role: player
+      name: Jose Altuve
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: DARC-BB
+  uuid: 6bf1cd74-7758-45be-9184-4ed2cace0b5b
+  subjects:
+  - entities:
+    - role: player
+      name: Jeff Bagwell
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+  - entities:
+    - role: player
+      name: Craig Biggio
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: DARC-BR
+  uuid: 1348ee52-8f40-4f45-ab55-cf049493c3d9
+  subjects:
+  - entities:
+    - role: player
+      name: José Ramírez
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+  - entities:
+    - role: player
+      name: Adrian Beltré
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: DARC-CH
+  uuid: ec82205f-bd1c-4b0d-bfaf-e550ab44bd5a
+  subjects:
+  - entities:
+    - role: player
+      name: Torii Hunter
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+  - entities:
+    - role: player
+      name: Rod Carew
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: DARC-CW
+  uuid: 415e8bce-e6b6-48dd-b6f6-baee7341bb75
+  subjects:
+  - entities:
+    - role: player
+      name: James Wood
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+  - entities:
+    - role: player
+      name: Dylan Crews
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: DARC-DV
+  uuid: 2e7e6fe2-24af-4210-ac5f-43677bb35d00
+  subjects:
+  - entities:
+    - role: player
+      name: Jasson Domínguez
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+  - entities:
+    - role: player
+      name: Anthony Volpe
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: DARC-GJJ
+  uuid: 28886e55-be11-4b89-bc80-bfcf443eea56
+  subjects:
+  - entities:
+    - role: player
+      name: Ken Griffey Jr.
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+  - entities:
+    - role: player
+      name: Bo Jackson
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: DARC-HA
+  uuid: e7f74c96-8edd-4b68-a64f-daee2ef3f095
+  subjects:
+  - entities:
+    - role: player
+      name: Ozzie Albies
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+  - entities:
+    - role: player
+      name: Michael Harris II
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: DARC-HB
+  uuid: f7d56b1d-8d32-47b2-83fd-87fa7d169191
+  subjects:
+  - entities:
+    - role: player
+      name: Byron Buxton
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+  - entities:
+    - role: player
+      name: Torii Hunter
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: DARC-HK
+  uuid: 25a7343b-28ff-4217-8365-9eefb16c8af2
+  subjects:
+  - entities:
+    - role: player
+      name: Clayton Kershaw
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+  - entities:
+    - role: player
+      name: Orel Hershiser
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: DARC-ICA
+  uuid: 99128591-612e-48cf-9b1e-632e8679ef75
+  subjects:
+  - entities:
+    - role: player
+      name: Shota Imanaga
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+  - entities:
+    - role: player
+      name: Pete Crow-Armstrong
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: DARC-JH
+  uuid: 6e5b9e2e-ffd5-4414-8733-476ce7be9159
+  subjects:
+  - entities:
+    - role: player
+      name: Torii Hunter
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+  - entities:
+    - role: player
+      name: Reggie Jackson
+      ref: 
+    - role: team
+      name: California Angels
+      ref: 
+- number: DARC-JHZ
+  uuid: b029f955-ba39-4175-8683-16507ff81e63
+  subjects:
+  - entities:
+    - role: player
+      name: Félix Hernández
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+  - entities:
+    - role: player
+      name: Randy Johnson
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: DARC-JJ
+  uuid: d8ccb011-4d17-406c-b726-441f7516a174
+  subjects:
+  - entities:
+    - role: player
+      name: Aaron Judge
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+  - entities:
+    - role: player
+      name: Derek Jeter
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: DARC-JR
+  uuid: dacbd130-e7e2-4b98-9e80-e6b185ba8d92
+  subjects:
+  - entities:
+    - role: player
+      name: Chipper Jones
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+  - entities:
+    - role: player
+      name: Austin Riley
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: DARC-LB
+  uuid: e95e3cde-8c9d-46c3-88eb-b1f68035c5d5
+  subjects:
+  - entities:
+    - role: player
+      name: Brooks Lee
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+  - entities:
+    - role: player
+      name: Byron Buxton
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: DARC-MO
+  uuid: e511fd18-3e65-42ae-b87c-efcbf99f55d0
+  subjects:
+  - entities:
+    - role: player
+      name: Matt Olson
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+  - entities:
+    - role: player
+      name: Fred McGriff
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: DARC-MY
+  uuid: 8fe9e920-db6e-48ee-ab9e-da586b136176
+  subjects:
+  - entities:
+    - role: player
+      name: Masataka Yoshida
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+  - entities:
+    - role: player
+      name: Hideki Matsui
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: DARC-PP
+  uuid: ef6cde1b-947e-4b84-bf63-35f02b75280d
+  subjects:
+  - entities:
+    - role: player
+      name: Jorge Posada
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+  - entities:
+    - role: player
+      name: Andy Pettitte
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: DARC-PR
+  uuid: 9e046171-cd74-44c6-acfd-3abc01a065d5
+  subjects:
+  - entities:
+    - role: player
+      name: Scott Rolen
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+  - entities:
+    - role: player
+      name: Tony Pérez
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: DARC-PS
+  uuid: b6f01f94-d59c-47f5-8f6b-c52d58edefb0
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Piazza
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+  - entities:
+    - role: player
+      name: Will Smith
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: DARC-PT
+  uuid: 37c2c74d-0aab-459a-b7f0-606fd7fe2be0
+  subjects:
+  - entities:
+    - role: player
+      name: Albert Pujols
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+  - entities:
+    - role: player
+      name: Mike Trout
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: DARC-RA
+  uuid: c0261eaf-c237-48aa-8cf2-37dce2c0b774
+  subjects:
+  - entities:
+    - role: player
+      name: Ozzie Albies
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+  - entities:
+    - role: player
+      name: Austin Riley
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: DARC-RU
+  uuid: c54b7eed-c885-4a76-a2bc-c2818c5925b4
+  subjects:
+  - entities:
+    - role: player
+      name: Jimmy Rollins
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+  - entities:
+    - role: player
+      name: Chase Utley
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: DARC-SM
+  uuid: c43897d1-1154-4fbe-9152-6e153469ab03
+  subjects:
+  - entities:
+    - role: player
+      name: Andrew McCutchen
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+  - entities:
+    - role: player
+      name: Paul Skenes
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: DARC-SP
+  uuid: 1907e2c9-f50b-4671-b7b1-50c7707fc797
+  subjects:
+  - entities:
+    - role: player
+      name: Jorge Posada
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+  - entities:
+    - role: player
+      name: CC Sabathia
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: DARC-TR
+  uuid: 959dc81c-fdf9-426e-afc7-137a18191600
+  subjects:
+  - entities:
+    - role: player
+      name: J.T. Realmuto
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+  - entities:
+    - role: player
+      name: Trea Turner
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: DARC-VG
+  uuid: 6f11646b-8d19-4b22-9fc6-337c16e5bfce
+  subjects:
+  - entities:
+    - role: player
+      name: Vladimir Guerrero
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+  - entities:
+    - role: player
+      name: Vladimir Guerrero Jr.
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: DARC-WV
+  uuid: 53c01a42-2607-45ef-a26e-d5ee51eea377
+  subjects:
+  - entities:
+    - role: player
+      name: Larry Walker
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+  - entities:
+    - role: player
+      name: Joey Votto
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 

--- a/data/baseball/2025-26-topps-definitive-collection/checklists/dual-autographs.yaml
+++ b/data/baseball/2025-26-topps-definitive-collection/checklists/dual-autographs.yaml
@@ -1,0 +1,629 @@
+- number: DAC-AS
+  uuid: ea5606a2-32d5-45b9-a68e-2065b4e6acd7
+  subjects:
+  - entities:
+    - role: player
+      name: Cam Smith
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+  - entities:
+    - role: player
+      name: Jose Altuve
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: DAC-BCA
+  uuid: db94691b-673a-4363-be87-efff3c37ec40
+  subjects:
+  - entities:
+    - role: player
+      name: Kristian Campbell
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+  - entities:
+    - role: player
+      name: Alex Bregman
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: DAC-BP
+  uuid: 371d22cb-f53a-4a2d-8606-b86e7d40de8c
+  subjects:
+  - entities:
+    - role: player
+      name: Buster Posey
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+  - entities:
+    - role: player
+      name: Barry Bonds
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: DAC-BV
+  uuid: 606fdcb9-585a-4272-83d0-b8fca980e44a
+  subjects:
+  - entities:
+    - role: player
+      name: Johnny Bench
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+  - entities:
+    - role: player
+      name: Joey Votto
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: DAC-BWJ
+  uuid: d1547aae-ea86-4baa-908d-70f6a49e60ed
+  subjects:
+  - entities:
+    - role: player
+      name: George Brett
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+  - entities:
+    - role: player
+      name: Bobby Witt Jr.
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: DAC-CS
+  uuid: 34fed0e6-780e-4e7b-845f-08439d8d936e
+  subjects:
+  - entities:
+    - role: player
+      name: Roger Clemens
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+  - entities:
+    - role: player
+      name: CC Sabathia
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: DAC-GGJ
+  uuid: e06739a3-30ce-4110-bb2d-c2cc94f51a96
+  subjects:
+  - entities:
+    - role: player
+      name: Vladimir Guerrero
+      ref: 
+    - role: team
+      name: Montreál Expos
+      ref: 
+  - entities:
+    - role: player
+      name: Vladimir Guerrero Jr.
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: DAC-GJ
+  uuid: 99914e9b-afa3-4979-b231-8022ac9fc2d2
+  subjects:
+  - entities:
+    - role: player
+      name: Ken Griffey Jr.
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+  - entities:
+    - role: player
+      name: Randy Johnson
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: DAC-HRJ
+  uuid: 860461af-bddf-4fc1-813c-2ab7706e604a
+  subjects:
+  - entities:
+    - role: player
+      name: Cal Ripken Jr.
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+  - entities:
+    - role: player
+      name: Gunnar Henderson
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: DAC-IM
+  uuid: 4253a521-9b8d-4736-99a1-e0a257ecd092
+  subjects:
+  - entities:
+    - role: player
+      name: Hideki Matsui
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+  - entities:
+    - role: player
+      name: Ichiro
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: DAC-JAJ
+  uuid: e2afc3c5-db55-4f1d-81e9-d07ff6494fac
+  subjects:
+  - entities:
+    - role: player
+      name: Chipper Jones
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+  - entities:
+    - role: player
+      name: Ronald Acuña Jr.
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: DAC-JJ
+  uuid: 79156f47-6ccd-4bec-ab29-85d1a1be656b
+  subjects:
+  - entities:
+    - role: player
+      name: Derek Jeter
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+  - entities:
+    - role: player
+      name: Aaron Judge
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: DAC-JJU
+  uuid: 6c90d5c8-a3f9-452c-ae4f-aee72a149f0b
+  subjects:
+  - entities:
+    - role: player
+      name: Josh Jung
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+  - entities:
+    - role: player
+      name: Jace Jung
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: DAC-JM
+  uuid: 20e385d8-60be-4ea0-83b1-465ce999f996
+  subjects:
+  - entities:
+    - role: player
+      name: Mark McGwire
+      ref: 
+    - role: team
+      name: Oakland Athletics
+      ref: 
+  - entities:
+    - role: player
+      name: Reggie Jackson
+      ref: 
+    - role: team
+      name: Oakland Athletics
+      ref: 
+- number: DAC-KK
+  uuid: 02b32ad3-b230-48e8-9553-bb955ad221e5
+  subjects:
+  - entities:
+    - role: player
+      name: Sandy Koufax
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+  - entities:
+    - role: player
+      name: Clayton Kershaw
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: DAC-LJ
+  uuid: 9777901b-7cb6-489f-a12e-ead2763dfe50
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Jobe
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+  - entities:
+    - role: player
+      name: Rhett Lowder
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: DAC-LV
+  uuid: 50103dbe-22f0-4b29-88b7-c1272a921fbd
+  subjects:
+  - entities:
+    - role: player
+      name: Joey Votto
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+  - entities:
+    - role: player
+      name: Barry Larkin
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: DAC-MGS
+  uuid: 9e53ea60-977d-4a06-8787-7e169b50597c
+  subjects:
+  - entities:
+    - role: player
+      name: Mark McGwire
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+  - entities:
+    - role: player
+      name: Ozzie Smith
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: DAC-MI
+  uuid: 479f8150-252d-4e2d-abec-8c21e23e7287
+  subjects:
+  - entities:
+    - role: player
+      name: Shota Imanaga
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+  - entities:
+    - role: player
+      name: Greg Maddux
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: DAC-MW
+  uuid: 14a00f09-d924-4f15-aa93-ffc9e4dc1a3c
+  subjects:
+  - entities:
+    - role: player
+      name: Don Mattingly
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+  - entities:
+    - role: player
+      name: Dave Winfield
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: DAC-OY
+  uuid: a0284c66-d440-452c-9cb9-19aa6932c2d4
+  subjects:
+  - entities:
+    - role: player
+      name: Shohei Ohtani
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+  - entities:
+    - role: player
+      name: Yoshinobu Yamamoto
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: DAC-PS
+  uuid: 9603b6c9-f980-4422-8644-69f579719dfc
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Piazza
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: DAC-PT
+  uuid: 8ea51bbb-4c5e-4aed-b42f-77094818c4d9
+  subjects:
+  - entities:
+    - role: player
+      name: Albert Pujols
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+  - entities:
+    - role: player
+      name: Mike Trout
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: DAC-RR
+  uuid: 5e4deedd-e131-463f-bf6c-886ae798ac4a
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan Ryan
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+  - entities:
+    - role: player
+      name: Ivan Rodriguez
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: DAC-RS
+  uuid: bd6ff741-d9cc-4b9c-9d24-bda3096f12c6
+  subjects:
+  - entities:
+    - role: player
+      name: Jimmy Rollins
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+  - entities:
+    - role: player
+      name: Mike Schmidt
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: DAC-SB
+  uuid: 915e1591-3d23-49c2-873e-994840269cd0
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Schmidt
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+  - entities:
+    - role: player
+      name: Adrian Beltré
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: DAC-SC
+  uuid: 76ea0e72-0878-4f74-8c52-b2adf2921eb1
+  subjects:
+  - entities:
+    - role: player
+      name: Paul Skenes
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+  - entities:
+    - role: player
+      name: Dylan Crews
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: DAC-SF
+  uuid: ed7a9fdb-e8fe-4b72-a9e4-e783e2f44d35
+  subjects:
+  - entities:
+    - role: player
+      name: CC Sabathia
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+  - entities:
+    - role: player
+      name: Prince Fielder
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: DAC-SL
+  uuid: d26cf589-67f2-432d-aee4-563caf7a28c7
+  subjects:
+  - entities:
+    - role: player
+      name: Francisco Lindor
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: DAC-SR
+  uuid: feb62ed2-f0fe-4788-8e53-6f84824e4bcf
+  subjects:
+  - entities:
+    - role: player
+      name: CC Sabathia
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+  - entities:
+    - role: player
+      name: Alex Rodriguez
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: DAC-ST
+  uuid: 6b488273-f8b1-44f4-aeb7-67c12d669ba8
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Tucker
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+  - entities:
+    - role: player
+      name: Sammy Sosa
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: DAC-UT
+  uuid: 42a8a464-e427-4a27-98be-e777c6581d86
+  subjects:
+  - entities:
+    - role: player
+      name: Chase Utley
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+  - entities:
+    - role: player
+      name: Trea Turner
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: DAC-WC
+  uuid: 1251c9f5-d1c9-46db-a466-f67b2cf4f61c
+  subjects:
+  - entities:
+    - role: player
+      name: Dylan Crews
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+  - entities:
+    - role: player
+      name: James Wood
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: DAC-WJH
+  uuid: aeaa84b1-2d9f-4f27-b953-dbb498b71726
+  subjects:
+  - entities:
+    - role: player
+      name: Bobby Witt Jr.
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+  - entities:
+    - role: player
+      name: Gunnar Henderson
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: DAC-WK
+  uuid: ee34e411-1b5c-41ff-af3f-b1842e73c23b
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Kurtz
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+  - entities:
+    - role: player
+      name: Jacob Wilson
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: DAC-WV
+  uuid: d60d0307-ece9-4182-9f6c-4b0502b12b50
+  subjects:
+  - entities:
+    - role: player
+      name: Larry Walker
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+  - entities:
+    - role: player
+      name: Joey Votto
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: DAC-YS
+  uuid: 2489bcd0-c27e-42e9-bf4a-ac13167c62e9
+  subjects:
+  - entities:
+    - role: player
+      name: Yoshinobu Yamamoto
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+  - entities:
+    - role: player
+      name: Roki Sasaki
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 

--- a/data/baseball/2025-26-topps-definitive-collection/checklists/dual-autographs.yaml
+++ b/data/baseball/2025-26-topps-definitive-collection/checklists/dual-autographs.yaml
@@ -108,7 +108,7 @@
       name: Vladimir Guerrero
       ref: 
     - role: team
-      name: Montreál Expos
+      name: Montréal Expos
       ref: 
   - entities:
     - role: player

--- a/data/baseball/2025-26-topps-definitive-collection/checklists/dual-world-series-autograph-collection.yaml
+++ b/data/baseball/2025-26-topps-definitive-collection/checklists/dual-world-series-autograph-collection.yaml
@@ -1,0 +1,221 @@
+- number: DWSA-AT
+  uuid: 80dffeca-a3d1-4a6a-8dd9-44bdeaa912e4
+  subjects:
+  - entities:
+    - role: player
+      name: Jose Altuve
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+  - entities:
+    - role: player
+      name: Kyle Tucker
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: DWSA-BP
+  uuid: e71f1bb4-0ff2-4c70-b4dd-06db3a0c0d3e
+  subjects:
+  - entities:
+    - role: player
+      name: Johnny Bench
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+  - entities:
+    - role: player
+      name: Tony Pérez
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: DWSA-FA
+  uuid: 6c22b609-4d4a-43ff-bfed-a638a535f851
+  subjects:
+  - entities:
+    - role: player
+      name: Freddie Freeman
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+  - entities:
+    - role: player
+      name: Ozzie Albies
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: DWSA-JG
+  uuid: 529cddd3-586b-4a7d-a506-89a566ce76f0
+  subjects:
+  - entities:
+    - role: player
+      name: Tom Glavine
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+  - entities:
+    - role: player
+      name: Chipper Jones
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: DWSA-JP
+  uuid: 20aecaca-f365-4c2b-a75a-288eb3dedae4
+  subjects:
+  - entities:
+    - role: player
+      name: Andy Pettitte
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+  - entities:
+    - role: player
+      name: Derek Jeter
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: DWSA-MR
+  uuid: 0a3cac72-7d6b-4447-a980-02e97f5953a4
+  subjects:
+  - entities:
+    - role: player
+      name: Alex Rodriguez
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+  - entities:
+    - role: player
+      name: Hideki Matsui
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: DWSA-OJ
+  uuid: aef35a91-ba46-43b1-9a30-c4cbc53dd769
+  subjects:
+  - entities:
+    - role: player
+      name: Aaron Judge
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+  - entities:
+    - role: player
+      name: Shohei Ohtani
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: DWSA-PH
+  uuid: 79902c11-d762-45c4-a3ba-e28a6620ee1c
+  subjects:
+  - entities:
+    - role: player
+      name: Albert Pujols
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+  - entities:
+    - role: player
+      name: Matt Holliday
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: DWSA-RH
+  uuid: a3e0699b-b578-4319-aab4-6ef2abcb906d
+  subjects:
+  - entities:
+    - role: player
+      name: Jimmy Rollins
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+  - entities:
+    - role: player
+      name: Ryan Howard
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: DWSA-RJM
+  uuid: 344752f8-d52f-4688-8d12-d3b75bc1e742
+  subjects:
+  - entities:
+    - role: player
+      name: Cal Ripken Jr.
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+  - entities:
+    - role: player
+      name: Eddie Murray
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: DWSA-SCA
+  uuid: 4fb46355-3617-4a31-b4d5-d6fbfb811eec
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Schmidt
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+  - entities:
+    - role: player
+      name: Steve Carlton
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: DWSA-SP
+  uuid: d58f7f27-9bc6-46f7-a708-ecf824e5c892
+  subjects:
+  - entities:
+    - role: player
+      name: Andy Pettitte
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+  - entities:
+    - role: player
+      name: CC Sabathia
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: DWSA-ST
+  uuid: 5a0a84e1-3f8f-4c49-8bfc-b17c4fb35741
+  subjects:
+  - entities:
+    - role: player
+      name: Trea Turner
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 

--- a/data/baseball/2025-26-topps-definitive-collection/checklists/framed-autograph-collection.yaml
+++ b/data/baseball/2025-26-topps-definitive-collection/checklists/framed-autograph-collection.yaml
@@ -1,0 +1,450 @@
+- number: FAC-AD
+  uuid: df6bc979-be2a-48e1-8997-33a8bd0e5b00
+  subjects:
+  - entities:
+    - role: player
+      name: Andre Dawson
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: FAC-AJ
+  uuid: 1c7f058b-fc40-47d5-8f0b-2cbef14ac0cf
+  subjects:
+  - entities:
+    - role: player
+      name: Aaron Judge
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: FAC-AP
+  uuid: 31bc8b6d-5f33-48e8-91be-f99b5e30d9e4
+  subjects:
+  - entities:
+    - role: player
+      name: Albert Pujols
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: FAC-BB
+  uuid: 84e4d31e-221b-4726-8929-e8e957803546
+  subjects:
+  - entities:
+    - role: player
+      name: Barry Bonds
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: FAC-BJ
+  uuid: 9cef484e-f22b-4325-9399-f59321f6116a
+  subjects:
+  - entities:
+    - role: player
+      name: Bo Jackson
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: FAC-BW
+  uuid: 221ed242-91d6-43e2-a89a-507eaa6e7055
+  subjects:
+  - entities:
+    - role: player
+      name: Bernie Williams
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: FAC-BWJ
+  uuid: e5c65981-4572-41b9-95ec-595f36affca7
+  subjects:
+  - entities:
+    - role: player
+      name: Bobby Witt Jr.
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: FAC-CB
+  uuid: '064911d7-2052-4a09-9bd8-615d51aeca72'
+  subjects:
+  - entities:
+    - role: player
+      name: Craig Biggio
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: FAC-CC
+  uuid: e9e342fd-1882-4d70-96e0-acf10d979f26
+  subjects:
+  - entities:
+    - role: player
+      name: CC Sabathia
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: FAC-CS
+  uuid: d0e7d359-64b5-43b4-b4a1-33f4e3687886
+  subjects:
+  - entities:
+    - role: player
+      name: Corey Seager
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: FAC-CSA
+  uuid: 27f35307-8e74-4e31-b946-5e2ad3ffb545
+  subjects:
+  - entities:
+    - role: player
+      name: Chris Sale
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: FAC-DC
+  uuid: 179bffb7-f28f-48e3-9a1b-af4e392f9bd9
+  subjects:
+  - entities:
+    - role: player
+      name: Dylan Crews
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: FAC-DJ
+  uuid: 9711b852-205e-4036-b631-aa87184a5bf6
+  subjects:
+  - entities:
+    - role: player
+      name: Derek Jeter
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: FAC-DW
+  uuid: 96c8906e-e992-47f3-9c35-83948efff555
+  subjects:
+  - entities:
+    - role: player
+      name: David Wright
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: FAC-FF
+  uuid: ab9fe2d3-e5e4-4c16-8bd1-358b5f39a03f
+  subjects:
+  - entities:
+    - role: player
+      name: Freddie Freeman
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: FAC-FL
+  uuid: eab6336b-6580-4603-a8bb-365e326375c9
+  subjects:
+  - entities:
+    - role: player
+      name: Francisco Lindor
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: FAC-GH
+  uuid: b5da5720-4f51-4a14-a98b-c19150ef16cd
+  subjects:
+  - entities:
+    - role: player
+      name: Gunnar Henderson
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: FAC-JB
+  uuid: 9a2ff6bd-611a-4e60-8259-9723bed09c7b
+  subjects:
+  - entities:
+    - role: player
+      name: Jeff Bagwell
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: FAC-JC
+  uuid: b9692a2d-e3e9-4f49-a42a-02747fc8f9b2
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Chourio
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: FAC-JCA
+  uuid: 1f2ac070-c7e4-40f6-9f63-96d783a198fc
+  subjects:
+  - entities:
+    - role: player
+      name: Junior Caminero
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: FAC-JH
+  uuid: e08b9fd5-1c57-471b-bee2-c548df3b58bd
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Holliday
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: FAC-JJ
+  uuid: bc2c2b71-17f7-4b97-8632-960eefef75ca
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Jobe
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: FAC-JM
+  uuid: 985548da-9791-486f-ba3a-e6da4e572006
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Merrill
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: FAC-JS
+  uuid: 4eb37c7e-bce8-4fa8-b4a3-49494a9bcefc
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: FAC-JW
+  uuid: 5a4e64e8-96f8-44fb-9b33-7dde2260061f
+  subjects:
+  - entities:
+    - role: player
+      name: James Wood
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: FAC-KC
+  uuid: 20b1391e-0575-40ec-9c25-ae4df3a043ba
+  subjects:
+  - entities:
+    - role: player
+      name: Kristian Campbell
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: FAC-KT
+  uuid: 9a963456-41ff-4043-8154-e9052efeca1f
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Tucker
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: FAC-MM
+  uuid: c3263561-5d65-4bbd-b10f-2cad702318ab
+  subjects:
+  - entities:
+    - role: player
+      name: Mark McGwire
+      ref: 
+    - role: team
+      name: Oakland Athletics
+      ref: 
+- number: FAC-MMA
+  uuid: 522858ce-f717-4618-92ff-02e3624ab963
+  subjects:
+  - entities:
+    - role: player
+      name: Marcelo Mayer
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: FAC-MS
+  uuid: 16aa4004-b0e1-4b4d-8ed7-f9db9718da46
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Schmidt
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: FAC-MSH
+  uuid: eb22a254-f592-452c-b7c5-139142b26afc
+  subjects:
+  - entities:
+    - role: player
+      name: Matt Shaw
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: FAC-NK
+  uuid: 5b271298-8d87-415e-97e0-a541116103ab
+  subjects:
+  - entities:
+    - role: player
+      name: Nick Kurtz
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: FAC-PA
+  uuid: 50dacfd9-b5a1-4fce-80b0-487cf466b497
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Alonso
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: FAC-PM
+  uuid: e4f58c42-efd2-4511-9e5e-233ecc295739
+  subjects:
+  - entities:
+    - role: player
+      name: Paul Molitor
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: FAC-PS
+  uuid: f73a2250-ebbc-4956-84a9-0a25d6e90a3b
+  subjects:
+  - entities:
+    - role: player
+      name: Paul Skenes
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: FAC-RA
+  uuid: f7807e2a-df23-42a3-8a45-3e41a8fdadda
+  subjects:
+  - entities:
+    - role: player
+      name: Ronald Acuña Jr.
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: FAC-RS
+  uuid: 1015b85b-cea4-44c2-827e-f516456cf544
+  subjects:
+  - entities:
+    - role: player
+      name: Roki Sasaki
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: FAC-SI
+  uuid: 52e5a0f1-64cc-4860-be6b-a1f6b9dfd46d
+  subjects:
+  - entities:
+    - role: player
+      name: Shota Imanaga
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: FAC-SO
+  uuid: f04613d3-a453-4f6e-b65b-a2d06bbd2b37
+  subjects:
+  - entities:
+    - role: player
+      name: Shohei Ohtani
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: FAC-SR
+  uuid: 30b9afcc-5f52-4494-91f8-17e59eb51b14
+  subjects:
+  - entities:
+    - role: player
+      name: Scott Rolen
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: FAC-TG
+  uuid: fb25bd0d-0624-4b45-b9fb-ff05b3b83fe2
+  subjects:
+  - entities:
+    - role: player
+      name: Tom Glavine
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: FAC-TS
+  uuid: df81a26d-8630-4279-8ac6-4fb79193ec25
+  subjects:
+  - entities:
+    - role: player
+      name: Tarik Skubal
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: FAC-VG
+  uuid: 66066382-5079-4fab-a922-fd5d128e1202
+  subjects:
+  - entities:
+    - role: player
+      name: Vladimir Guerrero Jr.
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: FAC-WL
+  uuid: 29e0b395-1e11-4328-9401-b792c5d7e02f
+  subjects:
+  - entities:
+    - role: player
+      name: Wyatt Langford
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: FAC-YY
+  uuid: d31a222b-1d1a-4ab6-bbcb-24c3884731e3
+  subjects:
+  - entities:
+    - role: player
+      name: Yoshinobu Yamamoto
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 

--- a/data/baseball/2025-26-topps-definitive-collection/checklists/framed-autograph-patches.yaml
+++ b/data/baseball/2025-26-topps-definitive-collection/checklists/framed-autograph-patches.yaml
@@ -1,0 +1,410 @@
+- number: FAPC-AG
+  uuid: ddc6a100-2823-42d3-9add-a70607061b21
+  subjects:
+  - entities:
+    - role: player
+      name: Adolis García
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: FAPC-AM
+  uuid: 4ec9d1e8-be6e-4242-b40f-3c7ff0275d5f
+  subjects:
+  - entities:
+    - role: player
+      name: Andrew McCutchen
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: FAPC-AP
+  uuid: 37dd5c27-45c7-4539-bf63-56f53245a0f3
+  subjects:
+  - entities:
+    - role: player
+      name: Andy Pettitte
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: FAPC-AV
+  uuid: c8908d39-06ca-427b-87f0-899abce43541
+  subjects:
+  - entities:
+    - role: player
+      name: Anthony Volpe
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: FAPC-BP
+  uuid: d903d2e8-0733-4630-9e97-2d469be94001
+  subjects:
+  - entities:
+    - role: player
+      name: Buster Posey
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: FAPC-BW
+  uuid: f0c443ef-3aa4-4708-b06a-e978fda62c10
+  subjects:
+  - entities:
+    - role: player
+      name: Bobby Witt Jr.
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: FAPC-CC
+  uuid: c760c96b-c765-4290-a46d-c681d1f24c37
+  subjects:
+  - entities:
+    - role: player
+      name: Corbin Carroll
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: FAPC-CY
+  uuid: a6a960ad-102e-4598-b968-c2203fc8b870
+  subjects:
+  - entities:
+    - role: player
+      name: Christian Yelich
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: FAPC-EM
+  uuid: ed66bcd9-d003-41a8-8d7a-4fc911977970
+  subjects:
+  - entities:
+    - role: player
+      name: Eddie Murray
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: FAPC-FH
+  uuid: 50f7568b-efc0-456c-b585-ed42f32e0568
+  subjects:
+  - entities:
+    - role: player
+      name: Félix Hernández
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: FAPC-I
+  uuid: c11c9b8c-6578-48a9-9374-ad1583d2a314
+  subjects:
+  - entities:
+    - role: player
+      name: Ichiro
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: FAPC-IR
+  uuid: 8270e56a-d7d5-4194-acb7-fabab493d590
+  subjects:
+  - entities:
+    - role: player
+      name: Ivan Rodriguez
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: FAPC-JD
+  uuid: 525465bd-4b53-4efa-821f-752a3d1080d2
+  subjects:
+  - entities:
+    - role: player
+      name: Jasson Domínguez
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: FAPC-JH
+  uuid: ed529cc4-d85f-40d9-ab44-0a80ed3f1218
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Holliday
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: FAPC-JL
+  uuid: 24f6cae1-b8be-46cd-97ea-8d6f9bb94c64
+  subjects:
+  - entities:
+    - role: player
+      name: Jung Hoo Lee
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: FAPC-JM
+  uuid: 6335822b-d78f-46df-8f17-5ff76671d211
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Merrill
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: FAPC-JRA
+  uuid: a08e8fd7-3ee7-4ab4-be72-677a7591bf9f
+  subjects:
+  - entities:
+    - role: player
+      name: José Ramírez
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: FAPC-JRO
+  uuid: 596644f7-5ce7-4e76-8983-7f97d41f8054
+  subjects:
+  - entities:
+    - role: player
+      name: Julio Rodríguez
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: FAPC-JS
+  uuid: ee097590-0001-4bf8-95cd-fd042104fe1c
+  subjects:
+  - entities:
+    - role: player
+      name: John Smoltz
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: FAPC-JT
+  uuid: 5818563f-a5e1-4167-a3b1-ecfd99a0b070
+  subjects:
+  - entities:
+    - role: player
+      name: J.T. Realmuto
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: FAPC-JV
+  uuid: e5c1ecb2-687f-4c83-beab-73a36232b813
+  subjects:
+  - entities:
+    - role: player
+      name: Joey Votto
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: FAPC-JW
+  uuid: 49c4b76c-efc1-44cb-a121-0a3915ffc744
+  subjects:
+  - entities:
+    - role: player
+      name: Jacob Wilson
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: FAPC-KT
+  uuid: 4bcb89a8-5a15-4122-9015-42adda6826f6
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Tucker
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: FAPC-LA
+  uuid: 07b05d89-159c-4c63-b195-2e6df6e3ad7c
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Arraez
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: FAPC-LW
+  uuid: a5341eff-0e58-40d6-a3c6-12360175a23b
+  subjects:
+  - entities:
+    - role: player
+      name: Larry Walker
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: FAPC-MO
+  uuid: a22261a3-cb5b-42a2-a43f-e5c29fa99dda
+  subjects:
+  - entities:
+    - role: player
+      name: Matt Olson
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: FAPC-MT
+  uuid: ad4ab5e5-9df4-49ee-8434-c0aabc5ca9bc
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Trout
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: FAPC-OA
+  uuid: c4ca0d15-8068-43da-96de-5312fd31281a
+  subjects:
+  - entities:
+    - role: player
+      name: Ozzie Albies
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: FAPC-OH
+  uuid: a4d03aed-1afe-4d0b-a3a5-368b0e25bc16
+  subjects:
+  - entities:
+    - role: player
+      name: Orel Hershiser
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: FAPC-PC
+  uuid: 1a486b6b-5ea9-4b14-80ad-664f885c7976
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Crow-Armstrong
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: FAPC-PF
+  uuid: 44fd0b69-5522-4b02-8238-d80b0f40f825
+  subjects:
+  - entities:
+    - role: player
+      name: Prince Fielder
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: FAPC-PM
+  uuid: b130a4c3-d58c-44f7-9428-901ea9474ae3
+  subjects:
+  - entities:
+    - role: player
+      name: Paul Molitor
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: FAPC-RA
+  uuid: 0b44b4d4-7a32-46eb-827b-6897044a9c14
+  subjects:
+  - entities:
+    - role: player
+      name: Ronald Acuña Jr.
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: FAPC-RJ
+  uuid: f0e81def-74ce-4b6e-88c4-ac213d31fedb
+  subjects:
+  - entities:
+    - role: player
+      name: Reggie Jackson
+      ref: 
+    - role: team
+      name: California Angels
+      ref: 
+- number: FAPC-SR
+  uuid: 38898a5f-ee6e-4412-8b4e-ea222ac2d02d
+  subjects:
+  - entities:
+    - role: player
+      name: Scott Rolen
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: FAPC-TH
+  uuid: 1523d01d-7de9-42eb-8791-17eb87fc3909
+  subjects:
+  - entities:
+    - role: player
+      name: Torii Hunter
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: FAPC-TS
+  uuid: 3bee4f2e-954d-448c-bb08-f6250d65b961
+  subjects:
+  - entities:
+    - role: player
+      name: Tarik Skubal
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: FAPC-TT
+  uuid: 6081ca46-593c-4104-ac7b-733cadeb4546
+  subjects:
+  - entities:
+    - role: player
+      name: Trea Turner
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: FAPC-VG
+  uuid: 4b62a7ba-c5aa-41e5-8c5a-ea95f843aef7
+  subjects:
+  - entities:
+    - role: player
+      name: Vladimir Guerrero
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: FAPC-VGJ
+  uuid: fd270281-0226-4d57-9623-528e8dbc2b2a
+  subjects:
+  - entities:
+    - role: player
+      name: Vladimir Guerrero Jr.
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: FAPC-WS
+  uuid: 532d3280-a768-4a2c-90d9-be8ee5d3d712
+  subjects:
+  - entities:
+    - role: player
+      name: Will Smith
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 

--- a/data/baseball/2025-26-topps-definitive-collection/checklists/jumbo-relic-collection.yaml
+++ b/data/baseball/2025-26-topps-definitive-collection/checklists/jumbo-relic-collection.yaml
@@ -1,0 +1,910 @@
+- number: DJRC-AB
+  uuid: a3b3c828-b103-43d5-a837-4ad3a381f1d1
+  subjects:
+  - entities:
+    - role: player
+      name: Alec Bohm
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: DJRC-ABR
+  uuid: 6980c515-0927-4369-b156-d36e50a6803e
+  subjects:
+  - entities:
+    - role: player
+      name: Alex Bregman
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: DJRC-AG
+  uuid: 070cc0e8-4cf2-4dc3-a0d8-ddcfe06d5bf5
+  subjects:
+  - entities:
+    - role: player
+      name: Adolis García
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: DJRC-AJ
+  uuid: a9954b0b-ed1e-4d0e-be3d-b18786224998
+  subjects:
+  - entities:
+    - role: player
+      name: Aaron Judge
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: DJRC-AP
+  uuid: 5082cb35-9716-4956-8331-2c64d5619faa
+  subjects:
+  - entities:
+    - role: player
+      name: Albert Pujols
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: DJRC-AR
+  uuid: '084ed3a1-214e-422d-b999-d25623a6ec72'
+  subjects:
+  - entities:
+    - role: player
+      name: Austin Riley
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: DJRC-AROD
+  uuid: ccb2009c-c108-4497-80bc-1b88059b5b51
+  subjects:
+  - entities:
+    - role: player
+      name: Alex Rodriguez
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: DJRC-ARU
+  uuid: 06ec74f0-69ea-44f9-81f5-c092a71a58b5
+  subjects:
+  - entities:
+    - role: player
+      name: Adley Rutschman
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: DJRC-BB
+  uuid: 5aa38047-3b92-42a3-8cf2-6b37053ef226
+  subjects:
+  - entities:
+    - role: player
+      name: Bo Bichette
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: DJRC-BBX
+  uuid: 5e222325-d035-47e9-a96c-8bbc722780c7
+  subjects:
+  - entities:
+    - role: player
+      name: Byron Buxton
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: DJRC-BH
+  uuid: 99256bec-fb68-42f7-a939-70aee57de122
+  subjects:
+  - entities:
+    - role: player
+      name: Bryce Harper
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: DJRC-BIG
+  uuid: 9e0d06e6-ac63-496b-8140-3f643bd06b76
+  subjects:
+  - entities:
+    - role: player
+      name: Craig Biggio
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: DJRC-BN
+  uuid: b3bccd6a-e7f1-4473-9e88-60ab1e6a5c6d
+  subjects:
+  - entities:
+    - role: player
+      name: Brandon Nimmo
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: DJRC-BR
+  uuid: b94e87b5-4d18-4cea-beb4-8defdb7fe39a
+  subjects:
+  - entities:
+    - role: player
+      name: Bryan Reynolds
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: DJRC-CA
+  uuid: f0ab3268-bd3b-4e72-b579-81bd18e550a3
+  subjects:
+  - entities:
+    - role: player
+      name: CJ Abrams
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: DJRC-CBE
+  uuid: 33c9aac9-1c90-43ab-b72c-677278f36048
+  subjects:
+  - entities:
+    - role: player
+      name: Cody Bellinger
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: DJRC-CC
+  uuid: '08a54c70-8d5b-4daa-83ed-c5840a0e6824'
+  subjects:
+  - entities:
+    - role: player
+      name: Carlos Correa
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: DJRC-CCA
+  uuid: d7d7d6ed-f93d-4e2d-a1e3-25bc597695d3
+  subjects:
+  - entities:
+    - role: player
+      name: Corbin Carroll
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: DJRC-CJ
+  uuid: 9d7dd30e-0c0b-433a-8043-707daa8cfcf9
+  subjects:
+  - entities:
+    - role: player
+      name: Chipper Jones
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: DJRC-CR
+  uuid: 31412605-543c-4769-aadd-e02eb8e07587
+  subjects:
+  - entities:
+    - role: player
+      name: Cal Raleigh
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: DJRC-CS
+  uuid: dbc60321-9623-49c3-9a10-7e922dd553a0
+  subjects:
+  - entities:
+    - role: player
+      name: CC Sabathia
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: DJRC-CY
+  uuid: 95b8ef7f-91ad-47dc-9279-afad6c4fe9e0
+  subjects:
+  - entities:
+    - role: player
+      name: Christian Yelich
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: DJRC-DC
+  uuid: 8230d3a5-9022-4672-9074-863c92559841
+  subjects:
+  - entities:
+    - role: player
+      name: Dylan Crews
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: DJRC-EM
+  uuid: 65f1efa9-092d-4c6c-b295-1c2888846258
+  subjects:
+  - entities:
+    - role: player
+      name: Eddie Murray
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: DJRC-ET
+  uuid: 1849734d-7112-4052-a531-42c1f6035ad9
+  subjects:
+  - entities:
+    - role: player
+      name: Ezequiel Tovar
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: DJRC-FA
+  uuid: defeea71-00bb-4a42-b7aa-9ad6952f303e
+  subjects:
+  - entities:
+    - role: player
+      name: Francisco Alvarez
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: DJRC-FF
+  uuid: e5cc3ed8-c21d-4a1e-8c4b-afb3c8630314
+  subjects:
+  - entities:
+    - role: player
+      name: Freddie Freeman
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: DJRC-FL
+  uuid: 723243f2-dfa2-4d87-be81-9bfc349cb32b
+  subjects:
+  - entities:
+    - role: player
+      name: Francisco Lindor
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: DJRC-FT
+  uuid: 8258762c-f78e-4c5b-89a0-069aeb81ff79
+  subjects:
+  - entities:
+    - role: player
+      name: Fernando Tatis Jr.
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: DJRC-GC
+  uuid: 215e828b-df4e-478b-aa0e-c04aa585a39f
+  subjects:
+  - entities:
+    - role: player
+      name: Gerrit Cole
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: DJRC-GH
+  uuid: ab910fbd-e6dc-4c52-892a-8d9e5a038b0d
+  subjects:
+  - entities:
+    - role: player
+      name: Gunnar Henderson
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: DJRC-GS
+  uuid: bae2c98e-cd31-42be-b79c-99877345ef41
+  subjects:
+  - entities:
+    - role: player
+      name: George Springer
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: DJRC-GST
+  uuid: 692894c9-f29c-438a-b0ae-238f307d90fa
+  subjects:
+  - entities:
+    - role: player
+      name: Giancarlo Stanton
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: DJRC-HG
+  uuid: 0b38c847-70fc-4ce5-baec-d07022a87ca5
+  subjects:
+  - entities:
+    - role: player
+      name: Hunter Greene
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: DJRC-I
+  uuid: 1b3ce3e9-f510-42a6-96c5-7dd57cf16851
+  subjects:
+  - entities:
+    - role: player
+      name: Ichiro
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: DJRC-IH
+  uuid: d7896d99-84a7-4f28-92ce-d74d46128817
+  subjects:
+  - entities:
+    - role: player
+      name: Ian Happ
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: DJRC-JA
+  uuid: af8bec88-bf23-4a73-8124-8a74bb9ed2f8
+  subjects:
+  - entities:
+    - role: player
+      name: Jose Altuve
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: DJRC-JC
+  uuid: d68e7cef-9fbe-4a91-8aa3-f366d8e12794
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Chourio
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: DJRC-JCA
+  uuid: 92e3cd38-e78d-424a-b9c3-7f04365892eb
+  subjects:
+  - entities:
+    - role: player
+      name: Junior Caminero
+      ref: 
+    - role: team
+      name: Tampa Bay Rays
+      ref: 
+- number: DJRC-JCJ
+  uuid: f2a03d86-7fd3-43e1-a2dc-b1f3b1e36a90
+  subjects:
+  - entities:
+    - role: player
+      name: Jazz Chisholm Jr.
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: DJRC-JD
+  uuid: ca395e77-8f7c-4b2b-b8aa-ad5348875470
+  subjects:
+  - entities:
+    - role: player
+      name: Jasson Domínguez
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: DJRC-JH
+  uuid: 3ded2b13-e43f-4e17-94c3-13346be7f034
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Holliday
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: DJRC-JL
+  uuid: 94d1b3f4-b3c4-47e6-80a9-fcaa0c3b5cae
+  subjects:
+  - entities:
+    - role: player
+      name: Jung Hoo Lee
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: DJRC-JM
+  uuid: b79cad14-d938-4184-8114-2d07ffc1d7b0
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Merrill
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: DJRC-JP
+  uuid: 0a9346c5-35d1-4e86-9f7a-935729cdb42c
+  subjects:
+  - entities:
+    - role: player
+      name: Jeremy Peña
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: DJRC-JR
+  uuid: fc0efa87-4b27-4d0b-bf1a-3483a5b797c4
+  subjects:
+  - entities:
+    - role: player
+      name: José Ramírez
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: DJRC-JRO
+  uuid: 3bd3d907-8781-45bc-bb43-69c9c4bc4059
+  subjects:
+  - entities:
+    - role: player
+      name: Julio Rodríguez
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: DJRC-JS
+  uuid: 761c0d19-7c08-4efa-ad40-60dbeee736e8
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: DJRC-JT
+  uuid: 971f5ea6-e295-44c1-b310-c5aba6184961
+  subjects:
+  - entities:
+    - role: player
+      name: J.T. Realmuto
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: DJRC-JW
+  uuid: 9b7aabe2-2967-455d-ac3f-e99f3be05afe
+  subjects:
+  - entities:
+    - role: player
+      name: James Wood
+      ref: 
+    - role: team
+      name: Washington Nationals
+      ref: 
+- number: DJRC-KM
+  uuid: 71c6ad81-fd15-46b6-b6f0-bf78aca9d047
+  subjects:
+  - entities:
+    - role: player
+      name: Ketel Marte
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: DJRC-KS
+  uuid: 67d2e3d3-8596-4867-82bf-6bb95b5ef66c
+  subjects:
+  - entities:
+    - role: player
+      name: Kodai Senga
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: DJRC-KSC
+  uuid: '068c3bf5-be6a-4d3a-a440-2cbd07f000e9'
+  subjects:
+  - entities:
+    - role: player
+      name: Kyle Schwarber
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: DJRC-LA
+  uuid: f0eaf16c-7526-4538-9610-5a3d7ea37917
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Arraez
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: DJRC-LB
+  uuid: 6ea704ef-5ddf-41e3-a7af-4ad1fd35f57a
+  subjects:
+  - entities:
+    - role: player
+      name: Lawrence Butler
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: DJRC-LG
+  uuid: 2ada9116-00e7-4f7b-8aad-ff146451558c
+  subjects:
+  - entities:
+    - role: player
+      name: Logan Gilbert
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: DJRC-LR
+  uuid: 22def32f-4549-4ad4-987b-a1c622a0fca9
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Robert Jr.
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: DJRC-LW
+  uuid: 2e84d838-1a9e-49e0-9ac8-4e619379f34b
+  subjects:
+  - entities:
+    - role: player
+      name: Logan Webb
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: DJRC-LWA
+  uuid: 3703b6e3-efc6-478b-9c25-6ca495ea51cd
+  subjects:
+  - entities:
+    - role: player
+      name: Larry Walker
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+- number: DJRC-MB
+  uuid: ec0e7bcb-2906-4c35-ba2f-6b6a586a725b
+  subjects:
+  - entities:
+    - role: player
+      name: Mookie Betts
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: DJRC-MC
+  uuid: 30e50032-fcff-4226-9f37-213230b372db
+  subjects:
+  - entities:
+    - role: player
+      name: Miguel Cabrera
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: DJRC-MF
+  uuid: 243d0f52-a267-41b0-b4b4-732cf5e41a8c
+  subjects:
+  - entities:
+    - role: player
+      name: Max Fried
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: DJRC-MH
+  uuid: ba0f60d7-cc1b-4f9b-96c0-dccdcb1ea033
+  subjects:
+  - entities:
+    - role: player
+      name: Michael Harris II
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: DJRC-MM
+  uuid: b2141d3a-091c-4851-91eb-f6306aec16de
+  subjects:
+  - entities:
+    - role: player
+      name: Manny Machado
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: DJRC-MO
+  uuid: 7bb32265-531b-454d-b6da-73e303639c93
+  subjects:
+  - entities:
+    - role: player
+      name: Matt Olson
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: DJRC-MT
+  uuid: c9144b23-d007-472f-99bc-e57f1d6208d2
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Trout
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: DJRC-MW
+  uuid: 5dbf7b90-f57e-4b92-9816-b65d381d1bea
+  subjects:
+  - entities:
+    - role: player
+      name: Masyn Winn
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: DJRC-NA
+  uuid: a0c3addc-7dfa-411a-bf4c-e400022c1ffb
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan Arenado
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: DJRC-OC
+  uuid: 2a95862d-6861-4eba-a2bb-bd9b5e0b95f2
+  subjects:
+  - entities:
+    - role: player
+      name: Oneil Cruz
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: DJRC-PA
+  uuid: 4c5eb7cb-e5bc-461d-8130-12b35f5688a0
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Alonso
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: DJRC-PC
+  uuid: c5658cb0-157c-4e72-8c3d-92a578753303
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Crow-Armstrong
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: DJRC-PR
+  uuid: 3fcfb812-9cad-49a8-9f30-7be730ceda2b
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Rose
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: DJRC-PS
+  uuid: 53d4e1ab-8241-4c4a-992d-f2e685988b31
+  subjects:
+  - entities:
+    - role: player
+      name: Paul Skenes
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: DJRC-RG
+  uuid: f6d300fd-205d-44d6-92e2-4b138e44e99c
+  subjects:
+  - entities:
+    - role: player
+      name: Riley Greene
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: DJRC-SA
+  uuid: 971e2e79-ddb9-4f77-be56-4dfe1f6a910d
+  subjects:
+  - entities:
+    - role: player
+      name: Sandy Alcántara
+      ref: 
+    - role: team
+      name: Miami Marlins
+      ref: 
+- number: DJRC-SK
+  uuid: 0d98bd25-85de-4cb5-829d-c1beca91f6ae
+  subjects:
+  - entities:
+    - role: player
+      name: Steven Kwan
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: DJRC-SO
+  uuid: 174df06a-87ca-4752-b433-ed4714ab8ada
+  subjects:
+  - entities:
+    - role: player
+      name: Shohei Ohtani
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: DJRC-SP
+  uuid: 64fd4334-4dc0-44ae-a1ea-4bd8bf4282c9
+  subjects:
+  - entities:
+    - role: player
+      name: Salvador Perez
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: DJRC-SS
+  uuid: e65e90c9-5db8-4cbc-a22c-1b003a03ce62
+  subjects:
+  - entities:
+    - role: player
+      name: Spencer Strider
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: DJRC-TG
+  uuid: 79e2efe3-48ec-4db5-b96c-f17938d0f1d3
+  subjects:
+  - entities:
+    - role: player
+      name: Tony Gwynn
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: DJRC-TS
+  uuid: 60bbaad0-d58b-4ac6-a2ee-ea5616ac26b6
+  subjects:
+  - entities:
+    - role: player
+      name: Trevor Story
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: DJRC-TSK
+  uuid: 684cce19-2708-4d69-bae2-703647b9d889
+  subjects:
+  - entities:
+    - role: player
+      name: Tarik Skubal
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: DJRC-TSO
+  uuid: 0da7e684-ce04-424e-852c-1d739e89f6f9
+  subjects:
+  - entities:
+    - role: player
+      name: Tyler Soderstrom
+      ref: 
+    - role: team
+      name: Athletics
+      ref: 
+- number: DJRC-TT
+  uuid: baac6b84-f396-409b-af50-13e0c1adf0b2
+  subjects:
+  - entities:
+    - role: player
+      name: Trea Turner
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: DJRC-VG
+  uuid: 69efaa81-686a-4a38-a17c-f8ac9d21e8b3
+  subjects:
+  - entities:
+    - role: player
+      name: Vladimir Guerrero Jr.
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: DJRC-WA
+  uuid: f939319a-fb04-471c-ac66-1183a7e59df7
+  subjects:
+  - entities:
+    - role: player
+      name: Willy Adames
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: DJRC-WS
+  uuid: 1fd26855-5812-4677-be65-bb56598e791f
+  subjects:
+  - entities:
+    - role: player
+      name: Will Smith
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: DJRC-YA
+  uuid: bb2302d6-1602-4ec2-98a0-90d5e4eaeb2c
+  subjects:
+  - entities:
+    - role: player
+      name: Yordan Alvarez
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+- number: DJRC-YD
+  uuid: 5b61b302-8bc8-4dfa-805e-0ac8a08e0f82
+  subjects:
+  - entities:
+    - role: player
+      name: Yu Darvish
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: DJRC-YM
+  uuid: a608bc50-943c-4664-8cbb-98666ecf9dd0
+  subjects:
+  - entities:
+    - role: player
+      name: Yadier Molina
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: DJRC-ZW
+  uuid: f9da63f8-f168-4002-8da4-8983fb516107
+  subjects:
+  - entities:
+    - role: player
+      name: Zack Wheeler
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 

--- a/data/baseball/2025-26-topps-definitive-collection/checklists/legendary-autograph-collection.yaml
+++ b/data/baseball/2025-26-topps-definitive-collection/checklists/legendary-autograph-collection.yaml
@@ -446,7 +446,7 @@
       name: Vladimir Guerrero
       ref: 
     - role: team
-      name: Montreál Expos
+      name: Montréal Expos
       ref: 
 - number: LAC-WB
   uuid: f353779c-d8cf-4dda-bf1f-c9821c509061

--- a/data/baseball/2025-26-topps-definitive-collection/checklists/legendary-autograph-collection.yaml
+++ b/data/baseball/2025-26-topps-definitive-collection/checklists/legendary-autograph-collection.yaml
@@ -1,0 +1,460 @@
+- number: LAC-AB
+  uuid: a279ef66-66fc-4fd4-be2b-3ebe10502ab3
+  subjects:
+  - entities:
+    - role: player
+      name: Adrian Beltré
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: LAC-AP
+  uuid: 6fb9153d-8fde-4a2e-9714-17ca6bd9c110
+  subjects:
+  - entities:
+    - role: player
+      name: Andy Pettitte
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: LAC-AR
+  uuid: 35b30aae-06ab-4850-baf1-f5f9c0386479
+  subjects:
+  - entities:
+    - role: player
+      name: Alex Rodriguez
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: LAC-BB
+  uuid: f6deb81f-e531-4b17-b585-78b9a37d7a55
+  subjects:
+  - entities:
+    - role: player
+      name: Barry Bonds
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: LAC-BJ
+  uuid: 61bb4217-6648-4e60-80f7-378f5c7b9aa5
+  subjects:
+  - entities:
+    - role: player
+      name: Bo Jackson
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: LAC-BP
+  uuid: 7dc68acf-f568-4261-9ba1-db322d4a16fe
+  subjects:
+  - entities:
+    - role: player
+      name: Buster Posey
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: LAC-CF
+  uuid: 3dc009d9-26ff-4598-857f-d209e3429478
+  subjects:
+  - entities:
+    - role: player
+      name: Carlton Fisk
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: LAC-CJ
+  uuid: f36b860d-0f17-4a13-a540-3648249611a9
+  subjects:
+  - entities:
+    - role: player
+      name: Chipper Jones
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: LAC-CR
+  uuid: 56222887-5d1a-40bd-a8f6-4b3b8423717f
+  subjects:
+  - entities:
+    - role: player
+      name: Cal Ripken Jr.
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: LAC-DJ
+  uuid: 539004e0-11dd-4a8b-8ccd-655753ed8261
+  subjects:
+  - entities:
+    - role: player
+      name: Derek Jeter
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: LAC-DM
+  uuid: 64918446-30a1-4c01-8584-f5853b66fca4
+  subjects:
+  - entities:
+    - role: player
+      name: Don Mattingly
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: LAC-DMU
+  uuid: 880e3661-ea04-43c9-b261-26881cd80b01
+  subjects:
+  - entities:
+    - role: player
+      name: Dale Murphy
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: LAC-DO
+  uuid: 6250dfe9-d608-4515-9080-7f2c1cf9321f
+  subjects:
+  - entities:
+    - role: player
+      name: David Ortiz
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: LAC-DW
+  uuid: 077f7a31-85f9-44d2-a07e-c1a6f9e77795
+  subjects:
+  - entities:
+    - role: player
+      name: Dave Winfield
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: LAC-EM
+  uuid: 53b8cea8-35e6-4207-9ba2-f02298f9a181
+  subjects:
+  - entities:
+    - role: player
+      name: Edgar Martinez
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: LAC-EMU
+  uuid: 8171b00c-7143-4b58-abfa-61e943441d17
+  subjects:
+  - entities:
+    - role: player
+      name: Eddie Murray
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: LAC-FM
+  uuid: 1f3e9077-3d29-44bf-b397-be1abb05cfdd
+  subjects:
+  - entities:
+    - role: player
+      name: Fred McGriff
+      ref: 
+    - role: team
+      name: Tampa Bay Devil Rays
+      ref: 
+- number: LAC-FT
+  uuid: 22df21f1-0408-4021-9f03-82aeb215e3b1
+  subjects:
+  - entities:
+    - role: player
+      name: Frank Thomas
+      ref: 
+    - role: team
+      name: Chicago White Sox
+      ref: 
+- number: LAC-GB
+  uuid: 31563827-5741-4c1f-bddf-beb5448e155f
+  subjects:
+  - entities:
+    - role: player
+      name: George Brett
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: LAC-GM
+  uuid: 6319e600-99cb-4692-ab57-eb73128f2514
+  subjects:
+  - entities:
+    - role: player
+      name: Greg Maddux
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: LAC-HM
+  uuid: 3d974673-a34c-4dcb-baf1-476d91f385fe
+  subjects:
+  - entities:
+    - role: player
+      name: Hideki Matsui
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: LAC-HN
+  uuid: 3d0f43bf-dc51-4541-838f-42fba6f0d265
+  subjects:
+  - entities:
+    - role: player
+      name: Hideo Nomo
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: LAC-I
+  uuid: 9a671b91-8e95-45d6-bf17-e85f5bc7f37c
+  subjects:
+  - entities:
+    - role: player
+      name: Ichiro
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: LAC-IR
+  uuid: 560d27f3-858f-4e5a-b3bc-642d3d905b63
+  subjects:
+  - entities:
+    - role: player
+      name: Ivan Rodriguez
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: LAC-JB
+  uuid: 3b681802-4ea1-4c6d-9331-e926e410f2c7
+  subjects:
+  - entities:
+    - role: player
+      name: Johnny Bench
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: LAC-JR
+  uuid: 4f4da643-9192-43a6-a959-61f04c77dd46
+  subjects:
+  - entities:
+    - role: player
+      name: Jimmy Rollins
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: LAC-JS
+  uuid: f7891ea3-015f-4dcd-ae24-ecdf520c0171
+  subjects:
+  - entities:
+    - role: player
+      name: John Smoltz
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: LAC-JSA
+  uuid: e1bdc76a-9076-41ad-9aba-23a15f9a2de9
+  subjects:
+  - entities:
+    - role: player
+      name: Johan Santana
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: LAC-JV
+  uuid: 53a173aa-5cdd-40d9-85eb-9bb6b31983bb
+  subjects:
+  - entities:
+    - role: player
+      name: Joey Votto
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: LAC-KG
+  uuid: bbbcafe9-dfd5-41aa-9106-86d4c8ec6091
+  subjects:
+  - entities:
+    - role: player
+      name: Ken Griffey Jr.
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: LAC-MC
+  uuid: 8a5fbb88-3b68-4f9e-aaf9-78221517f19e
+  subjects:
+  - entities:
+    - role: player
+      name: Miguel Cabrera
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: LAC-MM
+  uuid: 85bcc5fd-e679-47f3-985e-a4b70563986b
+  subjects:
+  - entities:
+    - role: player
+      name: Mark McGwire
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: LAC-MP
+  uuid: 9041e124-0a9b-48c7-af78-3223a92ac7da
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Piazza
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: LAC-MS
+  uuid: 2cd15776-b0f4-4521-97ed-5edc41af0a32
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Schmidt
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: LAC-NR
+  uuid: d861362c-9239-42e5-9e57-769c3498bbc8
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan Ryan
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: LAC-OH
+  uuid: e7c0b399-a7f7-45fd-8351-8dd73829032c
+  subjects:
+  - entities:
+    - role: player
+      name: Orel Hershiser
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: LAC-RC
+  uuid: e55864df-0728-4fe3-acd4-f415f670a2d5
+  subjects:
+  - entities:
+    - role: player
+      name: Roger Clemens
+      ref: 
+    - role: team
+      name: Toronto Blue Jays
+      ref: 
+- number: LAC-RJ
+  uuid: 3a3b75fd-2919-4864-a8db-c74adde81417
+  subjects:
+  - entities:
+    - role: player
+      name: Randy Johnson
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: LAC-RJA
+  uuid: de36e6dc-f04b-4d9f-b0c1-58be63b34b3e
+  subjects:
+  - entities:
+    - role: player
+      name: Reggie Jackson
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: LAC-RY
+  uuid: 137d8e2a-1c43-4a39-bee8-e61a2f4b8cc6
+  subjects:
+  - entities:
+    - role: player
+      name: Robin Yount
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: LAC-SK
+  uuid: 32b3d112-7875-48bf-aa0a-2728617219ec
+  subjects:
+  - entities:
+    - role: player
+      name: Sandy Koufax
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: LAC-TG
+  uuid: cf496c78-18d4-485b-94a5-397738766046
+  subjects:
+  - entities:
+    - role: player
+      name: Tom Glavine
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: LAC-TH
+  uuid: da5a113e-0441-40ec-b8c4-f43748c85f9a
+  subjects:
+  - entities:
+    - role: player
+      name: Torii Hunter
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: LAC-TO
+  uuid: f01d07e0-e9f4-44ec-8107-85eb9735bcd5
+  subjects:
+  - entities:
+    - role: player
+      name: Tony Oliva
+      ref: 
+    - role: team
+      name: Minnesota Twins
+      ref: 
+- number: LAC-VG
+  uuid: a437e949-c5b9-4b12-8aa1-f0f7268f39a4
+  subjects:
+  - entities:
+    - role: player
+      name: Vladimir Guerrero
+      ref: 
+    - role: team
+      name: Montreál Expos
+      ref: 
+- number: LAC-WB
+  uuid: f353779c-d8cf-4dda-bf1f-c9821c509061
+  subjects:
+  - entities:
+    - role: player
+      name: Wade Boggs
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 

--- a/data/baseball/2025-26-topps-definitive-collection/checklists/protector-at-the-plate.yaml
+++ b/data/baseball/2025-26-topps-definitive-collection/checklists/protector-at-the-plate.yaml
@@ -1,0 +1,100 @@
+- number: PPR-AJ
+  uuid: 75240270-cfdc-40f6-bfcc-1c60c49bd456
+  subjects:
+  - entities:
+    - role: player
+      name: Aaron Judge
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: PPR-DR
+  uuid: 684b9189-fb28-42ef-9bf5-0ddbcaa0a192
+  subjects:
+  - entities:
+    - role: player
+      name: Dalton Rushing
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: PPR-JR
+  uuid: 22a45bd7-ce47-4307-9a02-6ad663c5d35e
+  subjects:
+  - entities:
+    - role: player
+      name: José Ramírez
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+- number: PPR-JT
+  uuid: 4609a3d8-f55b-4849-a0e4-4e1d1d1f0275
+  subjects:
+  - entities:
+    - role: player
+      name: J.T. Realmuto
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: PPR-OA
+  uuid: cf66799c-2816-44ec-a743-5dc33dda6189
+  subjects:
+  - entities:
+    - role: player
+      name: Ozzie Albies
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: PPR-RA
+  uuid: 94835e51-c830-45c2-963b-b9743f0de0fa
+  subjects:
+  - entities:
+    - role: player
+      name: Ronald Acuña Jr.
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: PPR-SO
+  uuid: 0400ad4c-3339-4e05-91cf-654a99ce17c1
+  subjects:
+  - entities:
+    - role: player
+      name: Shohei Ohtani
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: PPR-SP
+  uuid: 00df16a2-fc6b-4088-9bfd-1d434ba34e23
+  subjects:
+  - entities:
+    - role: player
+      name: Salvador Perez
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: PPR-TH
+  uuid: 56715717-10c7-4096-864d-829ac83358d3
+  subjects:
+  - entities:
+    - role: player
+      name: Teoscar Hernández
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: PPR-WS
+  uuid: 661ed8b2-a41f-496d-8f24-1890dec2ff09
+  subjects:
+  - entities:
+    - role: player
+      name: Will Smith
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 

--- a/data/baseball/2025-26-topps-definitive-collection/checklists/protectors-at-the-plate-autographed-relics.yaml
+++ b/data/baseball/2025-26-topps-definitive-collection/checklists/protectors-at-the-plate-autographed-relics.yaml
@@ -1,0 +1,100 @@
+- number: PPAR-AJ
+  uuid: 0bc0dd1b-a879-4291-a23b-4c866ec64725
+  subjects:
+  - entities:
+    - role: player
+      name: Aaron Judge
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: PPAR-JT
+  uuid: fc334275-e6d0-495d-b36a-3e57ed94515e
+  subjects:
+  - entities:
+    - role: player
+      name: J.T. Realmuto
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: PPAR-JV
+  uuid: 53225be1-754f-471a-b6f9-030df31a832d
+  subjects:
+  - entities:
+    - role: player
+      name: Joey Votto
+      ref: 
+    - role: team
+      name: Cincinnati Reds
+      ref: 
+- number: PPAR-LA
+  uuid: e3fbea8e-ccbb-4a91-b8e7-70f7f032364d
+  subjects:
+  - entities:
+    - role: player
+      name: Luis Arraez
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: PPAR-MT
+  uuid: 9aa0eff7-cee4-41a0-8b9d-e541a6d8bd27
+  subjects:
+  - entities:
+    - role: player
+      name: Mike Trout
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+- number: PPAR-MY
+  uuid: 597db6e4-e446-4632-b054-481e4072ecfe
+  subjects:
+  - entities:
+    - role: player
+      name: Masataka Yoshida
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: PPAR-PA
+  uuid: 6646a3da-c78a-4cf3-b50e-c986d3ae6264
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Alonso
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: PPAR-RA
+  uuid: 1fce9435-9c51-402f-841a-8b772e5cc81f
+  subjects:
+  - entities:
+    - role: player
+      name: Ronald Acuña Jr.
+      ref: 
+    - role: team
+      name: Atlanta Braves
+      ref: 
+- number: PPAR-SO
+  uuid: 438e3f3b-562a-411b-88f9-81af9c5cecb2
+  subjects:
+  - entities:
+    - role: player
+      name: Shohei Ohtani
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: PPAR-WS
+  uuid: 4d74227c-5bd2-467a-94c6-93d7267093fe
+  subjects:
+  - entities:
+    - role: player
+      name: Will Smith
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 

--- a/data/baseball/2025-26-topps-definitive-collection/checklists/quad-patch-collection.yaml
+++ b/data/baseball/2025-26-topps-definitive-collection/checklists/quad-patch-collection.yaml
@@ -502,7 +502,7 @@
       name: Eddie Murray
       ref: 
     - role: team
-      name: Cleveland
+      name: Cleveland Indians
       ref: 
   - entities:
     - role: player
@@ -516,14 +516,14 @@
       name: CC Sabathia
       ref: 
     - role: team
-      name: Cleveland
+      name: Cleveland Indians
       ref: 
   - entities:
     - role: player
       name: Jim Thome
       ref: 
     - role: team
-      name: Cleveland
+      name: Cleveland Indians
       ref: 
 - number: QPC-SCMS
   uuid: e5d6a60b-4f02-48b2-ab20-6d861718befe

--- a/data/baseball/2025-26-topps-definitive-collection/checklists/quad-patch-collection.yaml
+++ b/data/baseball/2025-26-topps-definitive-collection/checklists/quad-patch-collection.yaml
@@ -1,0 +1,620 @@
+- number: QPC-BFOY
+  uuid: 75750a0a-6cb4-40ec-bd86-c50f3c05a69c
+  subjects:
+  - entities:
+    - role: player
+      name: Mookie Betts
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+  - entities:
+    - role: player
+      name: Shohei Ohtani
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+  - entities:
+    - role: player
+      name: Freddie Freeman
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+  - entities:
+    - role: player
+      name: Yoshinobu Yamamoto
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+- number: QPC-CMGL
+  uuid: be5a7ef1-f840-4f11-a0a9-b608e2c892f3
+  subjects:
+  - entities:
+    - role: player
+      name: Corbin Carroll
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+  - entities:
+    - role: player
+      name: Jordan Lawlar
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+  - entities:
+    - role: player
+      name: Zac Gallen
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+  - entities:
+    - role: player
+      name: Ketel Marte
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: QPC-CSGT
+  uuid: a5de8985-511c-4668-aad4-562be9e3eb59
+  subjects:
+  - entities:
+    - role: player
+      name: Miguel Cabrera
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+  - entities:
+    - role: player
+      name: Riley Greene
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+  - entities:
+    - role: player
+      name: Tarik Skubal
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+  - entities:
+    - role: player
+      name: Spencer Torkelson
+      ref: 
+    - role: team
+      name: Detroit Tigers
+      ref: 
+- number: QPC-CYCF
+  uuid: 42dad48f-9b9a-4f80-b082-a273241e5ed0
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Chourio
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+  - entities:
+    - role: player
+      name: Sal Frelick
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+  - entities:
+    - role: player
+      name: William Contreras
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+  - entities:
+    - role: player
+      name: Christian Yelich
+      ref: 
+    - role: team
+      name: Milwaukee Brewers
+      ref: 
+- number: QPC-HTWS
+  uuid: 5045161e-25cb-49aa-b0b8-e147d372efb0
+  subjects:
+  - entities:
+    - role: player
+      name: Trea Turner
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+  - entities:
+    - role: player
+      name: Zack Wheeler
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+  - entities:
+    - role: player
+      name: Kyle Schwarber
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+  - entities:
+    - role: player
+      name: Bryce Harper
+      ref: 
+    - role: team
+      name: Philadelphia Phillies
+      ref: 
+- number: QPC-IMDI
+  uuid: d7b3a0f3-71ff-4df4-b59a-c292174520a4
+  subjects:
+  - entities:
+    - role: player
+      name: Yu Darvish
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+  - entities:
+    - role: player
+      name: Ichiro
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+  - entities:
+    - role: player
+      name: Hideki Matsui
+      ref: 
+    - role: team
+      name: Oakland Athletics
+      ref: 
+  - entities:
+    - role: player
+      name: Shota Imanaga
+      ref: 
+    - role: team
+      name: Chicago Cubs
+      ref: 
+- number: QPC-JSCC
+  uuid: 50bfaa07-4f24-42ce-80b2-8f886694db1b
+  subjects:
+  - entities:
+    - role: player
+      name: Aaron Judge
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+  - entities:
+    - role: player
+      name: Jazz Chisholm Jr.
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+  - entities:
+    - role: player
+      name: Gerrit Cole
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+  - entities:
+    - role: player
+      name: Giancarlo Stanton
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: QPC-JSRP
+  uuid: 73a63b64-f79d-48bb-84ed-71d69068a132
+  subjects:
+  - entities:
+    - role: player
+      name: Derek Jeter
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+  - entities:
+    - role: player
+      name: Andy Pettitte
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+  - entities:
+    - role: player
+      name: CC Sabathia
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+  - entities:
+    - role: player
+      name: Alex Rodriguez
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+- number: QPC-JTSG
+  uuid: 5b8f151a-40d7-4673-a2d9-64a94bff03c2
+  subjects:
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+  - entities:
+    - role: player
+      name: Mike Trout
+      ref: 
+    - role: team
+      name: Los Angeles Angels
+      ref: 
+  - entities:
+    - role: player
+      name: Aaron Judge
+      ref: 
+    - role: team
+      name: New York Yankees
+      ref: 
+  - entities:
+    - role: player
+      name: Tony Gwynn
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: QPC-LASN
+  uuid: 88f40473-f513-48f3-9826-8a19a29424de
+  subjects:
+  - entities:
+    - role: player
+      name: Pete Alonso
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+  - entities:
+    - role: player
+      name: Juan Soto
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+  - entities:
+    - role: player
+      name: Francisco Lindor
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+  - entities:
+    - role: player
+      name: Brandon Nimmo
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: QPC-LBWH
+  uuid: 4fcf76c3-8a4e-4bc8-8d33-0f135ca61368
+  subjects:
+  - entities:
+    - role: player
+      name: Francisco Lindor
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+  - entities:
+    - role: player
+      name: Mookie Betts
+      ref: 
+    - role: team
+      name: Los Angeles Dodgers
+      ref: 
+  - entities:
+    - role: player
+      name: Gunnar Henderson
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+  - entities:
+    - role: player
+      name: Bobby Witt Jr.
+      ref: 
+    - role: team
+      name: Kansas City Royals
+      ref: 
+- number: QPC-MMTG
+  uuid: 01e11ead-8db4-42e2-b74f-0dee58f83170
+  subjects:
+  - entities:
+    - role: player
+      name: Tony Gwynn
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+  - entities:
+    - role: player
+      name: Fernando Tatis Jr.
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+  - entities:
+    - role: player
+      name: Manny Machado
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+  - entities:
+    - role: player
+      name: Jackson Merrill
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+- number: QPC-OPBC
+  uuid: aff7f445-a5fb-461d-8a0c-093190d247e6
+  subjects:
+  - entities:
+    - role: player
+      name: Alex Bregman
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+  - entities:
+    - role: player
+      name: Dustin Pedroia
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+  - entities:
+    - role: player
+      name: David Ortiz
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+  - entities:
+    - role: player
+      name: Kristian Campbell
+      ref: 
+    - role: team
+      name: Boston Red Sox
+      ref: 
+- number: QPC-RCAT
+  uuid: 886ec573-9edb-4a00-974d-a619fb2ede0f
+  subjects:
+  - entities:
+    - role: player
+      name: Yordan Alvarez
+      ref: 
+    - role: team
+      name: Houston Astros
+      ref: 
+  - entities:
+    - role: player
+      name: Fernando Tatis Jr.
+      ref: 
+    - role: team
+      name: San Diego Padres
+      ref: 
+  - entities:
+    - role: player
+      name: Julio Rodríguez
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+  - entities:
+    - role: player
+      name: Corbin Carroll
+      ref: 
+    - role: team
+      name: Arizona Diamondbacks
+      ref: 
+- number: QPC-RHHR
+  uuid: 1241fb1e-cc7d-414d-a43d-a2a1250e4ddb
+  subjects:
+  - entities:
+    - role: player
+      name: Jackson Holliday
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+  - entities:
+    - role: player
+      name: Gunnar Henderson
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+  - entities:
+    - role: player
+      name: Cal Ripken Jr.
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+  - entities:
+    - role: player
+      name: Adley Rutschman
+      ref: 
+    - role: team
+      name: Baltimore Orioles
+      ref: 
+- number: QPC-RRHG
+  uuid: e1152ed8-0c15-4231-8af8-442734d462f9
+  subjects:
+  - entities:
+    - role: player
+      name: Cal Raleigh
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+  - entities:
+    - role: player
+      name: Félix Hernández
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+  - entities:
+    - role: player
+      name: Julio Rodríguez
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+  - entities:
+    - role: player
+      name: Alex Rodriguez
+      ref: 
+    - role: team
+      name: Seattle Mariners
+      ref: 
+- number: QPC-RTMS
+  uuid: 630ffb62-5789-4fbb-b712-43198cfb4002
+  subjects:
+  - entities:
+    - role: player
+      name: Eddie Murray
+      ref: 
+    - role: team
+      name: Cleveland
+      ref: 
+  - entities:
+    - role: player
+      name: José Ramírez
+      ref: 
+    - role: team
+      name: Cleveland Guardians
+      ref: 
+  - entities:
+    - role: player
+      name: CC Sabathia
+      ref: 
+    - role: team
+      name: Cleveland
+      ref: 
+  - entities:
+    - role: player
+      name: Jim Thome
+      ref: 
+    - role: team
+      name: Cleveland
+      ref: 
+- number: QPC-SCMS
+  uuid: e5d6a60b-4f02-48b2-ab20-6d861718befe
+  subjects:
+  - entities:
+    - role: player
+      name: Oneil Cruz
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+  - entities:
+    - role: player
+      name: Willie Stargell
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+  - entities:
+    - role: player
+      name: Paul Skenes
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+  - entities:
+    - role: player
+      name: Andrew McCutchen
+      ref: 
+    - role: team
+      name: Pittsburgh Pirates
+      ref: 
+- number: QPC-SGSD
+  uuid: a0d86722-d9ce-46bd-87e8-814ea11bb92a
+  subjects:
+  - entities:
+    - role: player
+      name: Adolis García
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+  - entities:
+    - role: player
+      name: Marcus Semien
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+  - entities:
+    - role: player
+      name: Jacob deGrom
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+  - entities:
+    - role: player
+      name: Corey Seager
+      ref: 
+    - role: team
+      name: Texas Rangers
+      ref: 
+- number: QPC-WBTD
+  uuid: c7256fea-148d-4154-b4c3-dd4cd6a15072
+  subjects:
+  - entities:
+    - role: player
+      name: Ezequiel Tovar
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+  - entities:
+    - role: player
+      name: Larry Walker
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+  - entities:
+    - role: player
+      name: Kris Bryant
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 
+  - entities:
+    - role: player
+      name: Chase Dollander
+      ref: 
+    - role: team
+      name: Colorado Rockies
+      ref: 

--- a/data/baseball/2025-26-topps-definitive-collection/checklists/willie-mays-commemorative-patches.yaml
+++ b/data/baseball/2025-26-topps-definitive-collection/checklists/willie-mays-commemorative-patches.yaml
@@ -1,0 +1,476 @@
+- number: WMCP-ALM
+  uuid: 64e5460a-2633-4de1-9356-012be809f569
+  subjects:
+  - entities:
+    - role: player
+      name: Francisco Alvarez
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+  - entities:
+    - role: player
+      name: Willie Mays
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: WMCP-AM
+  uuid: ee25b9d3-cfcd-4908-b3a3-16dc6cd7fb6c
+  subjects:
+  - entities:
+    - role: player
+      name: Luisangel Acuña
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+  - entities:
+    - role: player
+      name: Willie Mays
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: WMCP-AMA
+  uuid: 9d5bad5b-b9f0-4cbc-88f8-38c05de27c32
+  subjects:
+  - entities:
+    - role: player
+      name: Willie Mays
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+  - entities:
+    - role: player
+      name: Pete Alonso
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: WMCP-ARM
+  uuid: c97eca5f-4255-4838-87f8-e0d1808035f2
+  subjects:
+  - entities:
+    - role: player
+      name: Nolan Arenado
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+  - entities:
+    - role: player
+      name: Willie Mays
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: WMCP-BM
+  uuid: 673026c5-a9ff-4d98-b19d-243cd05f6010
+  subjects:
+  - entities:
+    - role: player
+      name: Hayden Birdsong
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+  - entities:
+    - role: player
+      name: Willie Mays
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: WMCP-BMA
+  uuid: a45b2777-c43c-4ae9-be0f-e14c6db53567
+  subjects:
+  - entities:
+    - role: player
+      name: Patrick Bailey
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+  - entities:
+    - role: player
+      name: Willie Mays
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: WMCP-CAM
+  uuid: 3c577099-8124-432c-b710-410397d8c74b
+  subjects:
+  - entities:
+    - role: player
+      name: Willie Mays
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+  - entities:
+    - role: player
+      name: Dylan Carlson
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: WMCP-CM
+  uuid: aba4d524-cd8b-40ec-b9ff-c876802fc512
+  subjects:
+  - entities:
+    - role: player
+      name: Willie Mays
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+  - entities:
+    - role: player
+      name: Matt Chapman
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: WMCP-CMA
+  uuid: 19f1daa7-60fb-4cb0-94f8-68a690cb0bda
+  subjects:
+  - entities:
+    - role: player
+      name: Michael Conforto
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+  - entities:
+    - role: player
+      name: Willie Mays
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: WMCP-CRM
+  uuid: be235b25-6055-4ad7-95e6-1cc4f46dcb56
+  subjects:
+  - entities:
+    - role: player
+      name: Willie Mays
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+  - entities:
+    - role: player
+      name: Brandon Crawford
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: WMCP-DM
+  uuid: 4e1ae4e7-9010-4860-9b04-b2d88e7a17c4
+  subjects:
+  - entities:
+    - role: player
+      name: Willie Mays
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+  - entities:
+    - role: player
+      name: Edwin Díaz
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: WMCP-DMA
+  uuid: 0b75e522-7f3b-463b-844a-ffa83109a4fd
+  subjects:
+  - entities:
+    - role: player
+      name: Willie Mays
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+  - entities:
+    - role: player
+      name: Brendan Donovan
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: WMCP-EM
+  uuid: b2b8193a-5cfe-4417-8752-cc6800097144
+  subjects:
+  - entities:
+    - role: player
+      name: Willie Mays
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+  - entities:
+    - role: player
+      name: Thairo Estrada
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: WMCP-FLWM
+  uuid: 31d7b637-480c-4ebc-84a0-5f0b36543c53
+  subjects:
+  - entities:
+    - role: player
+      name: Francisco Lindor
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+  - entities:
+    - role: player
+      name: Willie Mays
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: WMCP-FMA
+  uuid: f346fd03-8086-45e3-a288-55f34d1cca73
+  subjects:
+  - entities:
+    - role: player
+      name: Willie Mays
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+  - entities:
+    - role: player
+      name: Wilmer Flores
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: WMCP-GMA
+  uuid: 6a232624-c98c-45f3-be17-df4e1ec7622f
+  subjects:
+  - entities:
+    - role: player
+      name: Willie Mays
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+  - entities:
+    - role: player
+      name: Paul Goldschmidt
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: WMCP-GOM
+  uuid: 751a9674-8d5e-4c95-bcb9-6c95e9d1ff4f
+  subjects:
+  - entities:
+    - role: player
+      name: Willie Mays
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+  - entities:
+    - role: player
+      name: Nolan Gorman
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: WMCP-HM
+  uuid: 986d8058-e894-4c34-b930-4abd23c62dd8
+  subjects:
+  - entities:
+    - role: player
+      name: Willie Mays
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+  - entities:
+    - role: player
+      name: Kyle Harrison
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: WMCP-LM
+  uuid: eea58355-441d-40d3-8d90-450c24917c83
+  subjects:
+  - entities:
+    - role: player
+      name: Willie Mays
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+  - entities:
+    - role: player
+      name: Francisco Lindor
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: WMCP-LUM
+  uuid: ffdeed73-0ce9-4b71-a081-e348396fb5f7
+  subjects:
+  - entities:
+    - role: player
+      name: Willie Mays
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+  - entities:
+    - role: player
+      name: Marco Luciano
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: WMCP-MLWM
+  uuid: 84fda4ad-af45-4254-a459-025cb5d2f38f
+  subjects:
+  - entities:
+    - role: player
+      name: Marco Luciano
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+  - entities:
+    - role: player
+      name: Willie Mays
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: WMCP-MMA
+  uuid: 2f2f0754-1bb8-4fc5-95c8-72a37a5bd722
+  subjects:
+  - entities:
+    - role: player
+      name: Willie Mays
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+  - entities:
+    - role: player
+      name: Grant McCray
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: WMCP-NM
+  uuid: 0ee33687-cb47-4750-ba61-94bf0bd38130
+  subjects:
+  - entities:
+    - role: player
+      name: Brandon Nimmo
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+  - entities:
+    - role: player
+      name: Willie Mays
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: WMCP-PAWM
+  uuid: aea96e30-d58b-4a0b-9580-8457372fdb6e
+  subjects:
+  - entities:
+    - role: player
+      name: Willie Mays
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+  - entities:
+    - role: player
+      name: Pete Alonso
+      ref: 
+    - role: team
+      name: New York Mets
+      ref: 
+- number: WMCP-SOM
+  uuid: 25b59fb0-1b33-4f52-a9d7-c8bf32f4dfd8
+  subjects:
+  - entities:
+    - role: player
+      name: Willie Mays
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+  - entities:
+    - role: player
+      name: Jorge Soler
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: WMCP-WIM
+  uuid: 3d3c6f33-9535-4b77-a867-590f8f90b684
+  subjects:
+  - entities:
+    - role: player
+      name: Willie Mays
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+  - entities:
+    - role: player
+      name: Masyn Winn
+      ref: 
+    - role: team
+      name: St. Louis Cardinals
+      ref: 
+- number: WMCP-WM
+  uuid: c881cc8d-943c-42c5-bcf6-ba7a88c5dbff
+  subjects:
+  - entities:
+    - role: player
+      name: Willie Mays
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+  - entities:
+    - role: player
+      name: Logan Webb
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+- number: WMCP-YM
+  uuid: b9965354-4b0b-41bc-9244-f0aad944a01e
+  subjects:
+  - entities:
+    - role: player
+      name: Willie Mays
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 
+  - entities:
+    - role: player
+      name: Mike Yastrzemski
+      ref: 
+    - role: team
+      name: San Francisco Giants
+      ref: 

--- a/data/baseball/2025-26-topps-definitive-collection/manifest.yaml
+++ b/data/baseball/2025-26-topps-definitive-collection/manifest.yaml
@@ -116,6 +116,7 @@ subsets:
   uuid: 39813a7d-9dbd-5119-a110-c87455b04d01
   type:
   - insert
+  - relic
   declared_card_count: 43
   parallels:
   - name: MLB Logo Gold
@@ -161,6 +162,7 @@ subsets:
   uuid: 47cd3de2-9453-5d6c-a262-005f29d256b3
   type:
   - insert
+  - relic
   declared_card_count: 80
 - id: definitive-patch-collection
   name: Definitive Patch Collection
@@ -371,6 +373,7 @@ subsets:
   uuid: f00779bb-347f-5a4e-9acf-7eb7d8620e6a
   type:
   - insert
+  - relic
   declared_card_count: 10
   parallels:
   - name: Black

--- a/data/baseball/2025-26-topps-definitive-collection/manifest.yaml
+++ b/data/baseball/2025-26-topps-definitive-collection/manifest.yaml
@@ -1,0 +1,411 @@
+set_id: 2025-26-topps-definitive-collection
+subsets:
+- id: autographed-patch-booklets
+  name: Autographed Patch Booklets
+  uuid: ce37a35c-a43d-5a71-b3cd-55cd0752627e
+  type:
+  - autograph
+  - relic
+  declared_card_count: 40
+  parallels:
+  - name: Red
+    print_run: 1
+    serial_numbered: true
+- id: base-autographed-relics
+  name: Base Autographed Relics
+  uuid: 12909fdd-c4b2-5a0b-81d6-db2c2872d52e
+  type:
+  - autograph
+  - relic
+  declared_card_count: 49
+  parallels:
+  - name: Black
+    print_run: 10
+    serial_numbered: true
+  - name: Brand Logo Gold
+    print_run: 1
+    serial_numbered: true
+  - name: Jersey Button Gold
+    print_run: 1
+    serial_numbered: true
+  - name: Laundry Tag Gold
+    print_run: 1
+    serial_numbered: true
+  - name: MLB Logo Gold
+    print_run: 1
+    serial_numbered: true
+  - name: Orange
+    print_run: 25
+    serial_numbered: true
+  - name: Red
+    print_run: 5
+    serial_numbered: true
+- id: defining-images-autographs
+  name: Defining Images Autographs
+  uuid: 821db65e-4cbc-5a63-9a13-5fa1551048d1
+  type:
+  - autograph
+  declared_card_count: 43
+  parallels:
+  - name: Black
+    print_run: 10
+    serial_numbered: true
+  - name: Gold
+    print_run: 1
+    serial_numbered: true
+  - name: Red
+    print_run: 5
+    serial_numbered: true
+- id: definitive-autographed-first-batting-gloves
+  name: Definitive Autographed First Batting Gloves
+  uuid: dddb9226-0cdb-5348-ae9e-ece813da6807
+  type:
+  - autograph
+  declared_card_count: 49
+  parallels:
+  - name: Gold
+    print_run: 1
+    serial_numbered: true
+  - name: Red
+    print_run: 5
+    serial_numbered: true
+- id: definitive-autographed-relics
+  name: Definitive Autographed Relics
+  uuid: 49498d63-ec44-52f6-a1d2-bea2ec4722f9
+  type:
+  - autograph
+  - relic
+  declared_card_count: 86
+  parallels:
+  - name: Green
+    print_run: 10
+    serial_numbered: true
+  - name: Purple
+    print_run: 5
+    serial_numbered: true
+  - name: Red
+    print_run: 1
+    serial_numbered: true
+- id: definitive-autographed-ultra-patches
+  name: Definitive Autographed Ultra Patches
+  uuid: 38f75d9f-51a8-5504-9be5-3012336b09e9
+  type:
+  - autograph
+  - relic
+  declared_card_count: 40
+- id: definitive-city-connect-slogan-autographed-booklets
+  name: Definitive City Connect Slogan Autographed Booklets
+  uuid: 8d9e0d2b-42a5-501f-b044-ea218bd35836
+  type:
+  - autograph
+  declared_card_count: 32
+- id: definitive-cut-signatures
+  name: Definitive Cut Signatures
+  uuid: 9019ae63-c226-5f9a-b71a-3fec7fedba79
+  type:
+  - autograph
+  declared_card_count: 42
+- id: definitive-dual-mlb-logo-patch-booklets
+  name: Definitive Dual MLB Logo Patch Booklets
+  uuid: 30974ea0-0f20-5be6-90b2-36a3eb71947b
+  type:
+  - relic
+  declared_card_count: 22
+- id: definitive-helmet-collection
+  name: Definitive Helmet Collection
+  uuid: 39813a7d-9dbd-5119-a110-c87455b04d01
+  type:
+  - insert
+  declared_card_count: 43
+  parallels:
+  - name: MLB Logo Gold
+    print_run: 1
+    serial_numbered: true
+  - name: Player Number Gold
+    print_run: 1
+    serial_numbered: true
+  - name: Rawlings Authentic Tag Gold
+    print_run: 1
+    serial_numbered: true
+  - name: Rawlings Logo Gold
+    print_run: 1
+    serial_numbered: true
+  - name: Red
+    print_run: 5
+    serial_numbered: true
+  subsets:
+  - id: definitive-helmet-collection-autographs
+    name: Definitive Helmet Collection Autographs
+    uuid: ced91335-4c70-5c23-a546-d532f8fd28f5
+    type:
+    - autograph
+    declared_card_count: 21
+    parallels:
+    - name: Gold
+      print_run: 1
+      serial_numbered: true
+- id: definitive-mlb-logo-patches
+  name: Definitive MLB Logo Patches
+  uuid: df91a135-9e37-5d20-9370-c91ba440be55
+  type:
+  - relic
+  declared_card_count: 87
+- id: definitive-moments-autographs
+  name: Definitive Moments Autographs
+  uuid: e3ee3fe2-b371-5670-bbaf-5530871b5693
+  type:
+  - autograph
+  declared_card_count: 23
+- id: definitive-nameplate-collection
+  name: Definitive Nameplate Collection
+  uuid: 47cd3de2-9453-5d6c-a262-005f29d256b3
+  type:
+  - insert
+  declared_card_count: 80
+- id: definitive-patch-collection
+  name: Definitive Patch Collection
+  uuid: 05e24d20-342e-5c59-9caf-0b4e8953da19
+  type:
+  - relic
+  declared_card_count: 87
+- id: definitive-quad-autographs
+  name: Definitive Quad Autographs
+  uuid: b72a7e10-c163-5e67-81ff-10e7bdb8c974
+  type:
+  - autograph
+  declared_card_count: 7
+  parallels:
+  - name: Gold
+    print_run: 1
+    serial_numbered: true
+- id: definitive-rookie-autographs
+  name: Definitive Rookie Autographs
+  uuid: 9af2e3fb-de0c-5722-b8ec-377a019b1019
+  type:
+  - autograph
+  declared_card_count: 42
+  parallels:
+  - name: Black
+    print_run: 10
+    serial_numbered: true
+  - name: Gold
+    print_run: 1
+    serial_numbered: true
+  - name: Orange
+    print_run: 25
+    serial_numbered: true
+  - name: Red
+    print_run: 5
+    serial_numbered: true
+- id: definitive-rookie-patch-autographs
+  name: Definitive Rookie Patch Autographs
+  uuid: a6f34ca4-607e-5b8e-99d1-345a118b8d42
+  type:
+  - autograph
+  - relic
+  declared_card_count: 34
+  parallels:
+  - name: Black
+    print_run: 10
+    serial_numbered: true
+  - name: Gold
+    print_run: 1
+    serial_numbered: true
+  - name: Orange
+    print_run: 25
+    serial_numbered: true
+  - name: Red
+    print_run: 5
+    serial_numbered: true
+- id: definitive-triple-autographs
+  name: Definitive Triple Autographs
+  uuid: 56881e8f-705f-5eb2-9110-6938166bd3c5
+  type:
+  - autograph
+  declared_card_count: 8
+  parallels:
+  - name: Black
+    print_run: 10
+    serial_numbered: true
+  - name: Gold
+    print_run: 1
+    serial_numbered: true
+  - name: Red
+    print_run: 5
+    serial_numbered: true
+- id: definitive-triple-mlb-logo-patch-booklets
+  name: Definitive Triple MLB Logo Patch Booklets
+  uuid: 9fb84c93-abe1-50fe-8b43-9019b714cad5
+  type:
+  - relic
+  declared_card_count: 15
+- id: definitive-world-series-baseball-autographed-relics
+  name: Definitive World Series Baseball Autographed Relics
+  uuid: e4a4f4f8-fea0-55c1-8725-2dd3ae0b15b0
+  type:
+  - autograph
+  - relic
+  declared_card_count: 9
+- id: dual-autograph-relic-collection
+  name: Dual Autograph Relic Collection
+  uuid: e2ef1bb0-b0eb-534d-a0ea-dbefb9b0331a
+  type:
+  - autograph
+  - relic
+  declared_card_count: 29
+  parallels:
+  - name: Black
+    print_run: 10
+    serial_numbered: true
+  - name: Gold
+    print_run: 1
+    serial_numbered: true
+  - name: Red
+    print_run: 5
+    serial_numbered: true
+- id: dual-autographs
+  name: Dual Autographs
+  uuid: 587660a2-8e5e-587c-8f3c-aba537399dad
+  type:
+  - autograph
+  declared_card_count: 37
+  parallels:
+  - name: Black
+    print_run: 10
+    serial_numbered: true
+  - name: Gold
+    print_run: 1
+    serial_numbered: true
+  - name: Red
+    print_run: 5
+    serial_numbered: true
+- id: dual-world-series-autograph-collection
+  name: Dual World Series Autograph Collection
+  uuid: 3ab44979-48c3-5813-b733-d8f45849c8ff
+  type:
+  - autograph
+  declared_card_count: 13
+  parallels:
+  - name: Black
+    print_run: 10
+    serial_numbered: true
+  - name: Gold
+    print_run: 1
+    serial_numbered: true
+  - name: Red
+    print_run: 5
+    serial_numbered: true
+- id: framed-autograph-collection
+  name: Framed Autograph Collection
+  uuid: 50142017-be8a-536d-9e1f-1cb8f6b8d6de
+  type:
+  - autograph
+  declared_card_count: 45
+  parallels:
+  - name: Black
+    print_run: 10
+    serial_numbered: true
+  - name: Gold
+    print_run: 1
+    serial_numbered: true
+  - name: Red
+    print_run: 5
+    serial_numbered: true
+- id: framed-autograph-patches
+  name: Framed Autograph Patches
+  uuid: 60db8d93-81fa-5cdd-9a4c-48ccfac7437b
+  type:
+  - autograph
+  - relic
+  declared_card_count: 41
+  parallels:
+  - name: Black
+    print_run: 10
+    serial_numbered: true
+  - name: Gold
+    print_run: 1
+    serial_numbered: true
+  - name: Red
+    print_run: 5
+    serial_numbered: true
+- id: jumbo-relic-collection
+  name: Jumbo Relic Collection
+  uuid: ca0427fe-16ee-55c9-9e50-953780e14800
+  type:
+  - relic
+  declared_card_count: 91
+  parallels:
+  - name: Black
+    print_run: 10
+    serial_numbered: true
+  - name: Gold
+    print_run: 1
+    serial_numbered: true
+  - name: Orange
+    print_run: 25
+    serial_numbered: true
+  - name: Pink
+    print_run: 15
+    serial_numbered: true
+  - name: Red
+    print_run: 5
+    serial_numbered: true
+- id: legendary-autograph-collection
+  name: Legendary Autograph Collection
+  uuid: 6685c316-b445-53a6-ab3a-2c408705b72f
+  type:
+  - autograph
+  declared_card_count: 46
+  parallels:
+  - name: Black
+    print_run: 10
+    serial_numbered: true
+  - name: Gold
+    print_run: 1
+    serial_numbered: true
+  - name: Red
+    print_run: 5
+    serial_numbered: true
+- id: protector-at-the-plate
+  name: Protector At The Plate
+  uuid: f00779bb-347f-5a4e-9acf-7eb7d8620e6a
+  type:
+  - insert
+  declared_card_count: 10
+  parallels:
+  - name: Black
+    print_run: 10
+    serial_numbered: true
+  - name: Gold
+    print_run: 1
+    serial_numbered: true
+  - name: Red
+    print_run: 5
+    serial_numbered: true
+- id: protectors-at-the-plate-autographed-relics
+  name: Protectors At The Plate Autographed Relics
+  uuid: 15b91261-f3a3-5502-bd3c-848658e6c68e
+  type:
+  - autograph
+  - relic
+  declared_card_count: 10
+  parallels:
+  - name: Red
+    print_run: 1
+    serial_numbered: true
+- id: quad-patch-collection
+  name: Quad Patch Collection
+  uuid: da03c850-cb80-5442-b24b-9d2689048e84
+  type:
+  - relic
+  declared_card_count: 20
+  parallels:
+  - name: Gold
+    print_run: 1
+    serial_numbered: true
+- id: willie-mays-commemorative-patches
+  name: Willie Mays Commemorative Patches
+  uuid: f62d53c6-4688-5aee-9980-ebcbb79a2340
+  type:
+  - relic
+  declared_card_count: 28

--- a/data/baseball/2025-26-topps-definitive-collection/set.yaml
+++ b/data/baseball/2025-26-topps-definitive-collection/set.yaml
@@ -1,0 +1,19 @@
+uuid: 37675d01-2353-4475-b55e-25a979f0f219
+set_id: 2025-26-topps-definitive-collection
+name: 2025-26 Topps Definitive Collection
+genre: Sports
+category:
+- MLB
+sports:
+- Baseball
+season: 2025-26
+years:
+- 2025
+- 2026
+manufacturer: Topps
+release_date: '2026-04-29'
+description: 2025-26 Topps Definitive Collection was released April 29th, 2026.
+source:
+  name: BaseballCardpedia
+  url: https://baseballcardpedia.com/index.php/2025-26_Topps_Definitive_Collection#Checklist
+  file: import/2025-Topps-Definitive-Baseball-Checklist.xlsx

--- a/data/baseball/2025-26-topps-definitive-collection/set.yaml
+++ b/data/baseball/2025-26-topps-definitive-collection/set.yaml
@@ -16,4 +16,3 @@ description: 2025-26 Topps Definitive Collection was released April 29th, 2026.
 source:
   name: BaseballCardpedia
   url: https://baseballcardpedia.com/index.php/2025-26_Topps_Definitive_Collection#Checklist
-  file: import/2025-Topps-Definitive-Baseball-Checklist.xlsx

--- a/schemas/manifest/CHANGELOG.md
+++ b/schemas/manifest/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [v0.1] - 2026-07-09
+- base_sets is optional: a product needs at least one base set OR one product-level subset, so base-less releases (all-autograph/relic high-end products) are valid.
 - Initial release of the manifest schema (v0.3 "manifest form").
 - `base_sets[]` (roots) plus optional product-level `subsets[]`; base sets and subsets
   share one recursive node shape (checklist + parallels + sections + child subsets).

--- a/schemas/manifest/CHANGELOG.md
+++ b/schemas/manifest/CHANGELOG.md
@@ -1,5 +1,4 @@
 ## [v0.1] - 2026-07-09
-- base_sets is optional: a product needs at least one base set OR one product-level subset, so base-less releases (all-autograph/relic high-end products) are valid.
 - Initial release of the manifest schema (v0.3 "manifest form").
 - `base_sets[]` (roots) plus optional product-level `subsets[]`; base sets and subsets
   share one recursive node shape (checklist + parallels + sections + child subsets).

--- a/schemas/manifest/v0.1/README.md
+++ b/schemas/manifest/v0.1/README.md
@@ -17,10 +17,8 @@ data/<genre>/<set-id>/
 ## Top level
 
 - **`set_id`** (required) — must match `set.yaml` and the directory name.
-- **`base_sets`** (optional, ≥1 when present) — the root checklists of the product. A
-  base set is **not** a subset: it has no `type` and is never nested. Omitted for a
-  base-less product (e.g. an all-autograph/relic high-end release). A product must have
-  at least one base set **or** at least one product-level subset.
+- **`base_sets`** (required, ≥1) — the root checklists of the product. A base set is
+  **not** a subset: it has no `type` and is never nested.
 - **`subsets`** (optional) — **product-level** subsets: inserts that belong to the
   product but not to any single base set (e.g. an "Anime" insert).
 

--- a/schemas/manifest/v0.1/README.md
+++ b/schemas/manifest/v0.1/README.md
@@ -17,8 +17,10 @@ data/<genre>/<set-id>/
 ## Top level
 
 - **`set_id`** (required) — must match `set.yaml` and the directory name.
-- **`base_sets`** (required, ≥1) — the root checklists of the product. A base set is
-  **not** a subset: it has no `type` and is never nested.
+- **`base_sets`** (optional, ≥1 when present) — the root checklists of the product. A
+  base set is **not** a subset: it has no `type` and is never nested. Omitted for a
+  base-less product (e.g. an all-autograph/relic high-end release). A product must have
+  at least one base set **or** at least one product-level subset.
 - **`subsets`** (optional) — **product-level** subsets: inserts that belong to the
   product but not to any single base set (e.g. an "Anime" insert).
 

--- a/schemas/manifest/v0.1/schema.yaml
+++ b/schemas/manifest/v0.1/schema.yaml
@@ -1,12 +1,10 @@
 $schema_version: "0.1"
-description: "Manifest schema for the Open Checklist Project — the compact generating structure. A product (set.yaml) holds base sets and/or product-level subsets. Most products have one or more base sets; a base-less product (e.g. a high-end all-autograph/relic release) has only subsets. A base set and a subset are the same recursive node (own checklist + parallels + sections + child subsets), differing only in role: base sets are roots with no `type`; subsets carry a `type` and nest under a base set, another subset, or the product. The per-card explosion is derived from this + checklists/, never committed."
+description: "Manifest schema for the Open Checklist Project — the compact generating structure. A product (set.yaml) holds ONE OR MORE base sets, plus optional product-level subsets (inserts not tied to a base set). A base set and a subset are the same recursive node (own checklist + parallels + sections + child subsets), differing only in role: base sets are roots with no `type`; subsets carry a `type` and nest under a base set, another subset, or the product. The per-card explosion is derived from this + checklists/, never committed."
 title: Manifest
 type: object
 required:
   - set_id
-anyOf:  # a product must have at least one base set or at least one product-level subset
-  - required: [base_sets]
-  - required: [subsets]
+  - base_sets
 additionalProperties: false
 properties:
   set_id:
@@ -17,11 +15,8 @@ properties:
     type: array
     minItems: 1
     description: >
-      The base sets — the roots of the product (optional, but at least one base set or
-      one product-level subset is required). Present for most products; omitted for a
-      base-less product (e.g. an all-autograph/relic high-end release). A base set is NOT
-      a subset: it has no `type` and is never nested. Each is a recursive node
-      (see $defs/baseSet).
+      One or more base sets — the roots of the product. A base set is NOT a subset: it
+      has no `type` and is never nested. Each is a recursive node (see $defs/baseSet).
     items:
       $ref: "#/$defs/baseSet"
   subsets:

--- a/schemas/manifest/v0.1/schema.yaml
+++ b/schemas/manifest/v0.1/schema.yaml
@@ -1,10 +1,12 @@
 $schema_version: "0.1"
-description: "Manifest schema for the Open Checklist Project — the compact generating structure. A product (set.yaml) holds ONE OR MORE base sets, plus optional product-level subsets (inserts not tied to a base set). A base set and a subset are the same recursive node (own checklist + parallels + sections + child subsets), differing only in role: base sets are roots with no `type`; subsets carry a `type` and nest under a base set, another subset, or the product. The per-card explosion is derived from this + checklists/, never committed."
+description: "Manifest schema for the Open Checklist Project — the compact generating structure. A product (set.yaml) holds base sets and/or product-level subsets. Most products have one or more base sets; a base-less product (e.g. a high-end all-autograph/relic release) has only subsets. A base set and a subset are the same recursive node (own checklist + parallels + sections + child subsets), differing only in role: base sets are roots with no `type`; subsets carry a `type` and nest under a base set, another subset, or the product. The per-card explosion is derived from this + checklists/, never committed."
 title: Manifest
 type: object
 required:
   - set_id
-  - base_sets
+anyOf:  # a product must have at least one base set or at least one product-level subset
+  - required: [base_sets]
+  - required: [subsets]
 additionalProperties: false
 properties:
   set_id:
@@ -15,8 +17,11 @@ properties:
     type: array
     minItems: 1
     description: >
-      One or more base sets — the roots of the product. A base set is NOT a subset: it
-      has no `type` and is never nested. Each is a recursive node (see $defs/baseSet).
+      The base sets — the roots of the product (optional, but at least one base set or
+      one product-level subset is required). Present for most products; omitted for a
+      base-less product (e.g. an all-autograph/relic high-end release). A base set is NOT
+      a subset: it has no `type` and is never nested. Each is a recursive node
+      (see $defs/baseSet).
     items:
       $ref: "#/$defs/baseSet"
   subsets:


### PR DESCRIPTION
Converts jmurphyrum's **2025-26 Topps Definitive Collection** (#17, exploded) to v0.3.

Definitive is an all-autograph/relic high-end product with **no base set** — every subset is a hit. In v0.3 that's a manifest of `set_id` + `subsets` (no `base_sets`): **32 product-level autograph/relic subsets**, auto-relics typed `[autograph, relic]`. Supersedes #17.

## Schema dependency (resolved)
This relies on the base-less-products schema change (**#39** — `base_sets` optional). #39 is now **merged into `main`**, and `main`'s manifest schema symlink points at `v0.2/schema.yaml`, whose `anyOf: [required base_sets] OR [required subsets]` accepts subsets-only products. There is no longer a blocking dependency and CI is green.

Draft — open for @jmurphyrum to review the data.