### PR TITLE
chore: deprecate the exploded card format (#33)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,8 +12,19 @@ Thank you for helping improve the open trading card data ecosystem!
 ## Guidelines
 
 - Follow the existing folder structure
-- Validate your YAML before submitting
+- Validate your YAML before submitting (`python tools/validate.py`)
 - Use pull requests — all changes are reviewed
+
+## Data format — use the v0.3 manifest form
+
+New set data must use the **v0.3 manifest form**: `set.yaml` + `manifest.yaml` +
+`checklists/<node-id>.yaml`, from which the per-card explosion is *derived* (never
+committed). See the [schemas overview](schemas/README.md) for the structure.
+
+The old **exploded one-file-per-card format** (`cards/*.yaml`, validated by the `card`
+schema) is **deprecated** — do not author new data in it. It's retained only to validate
+sets not yet migrated, and will be removed once migration completes
+([#33](https://github.com/cardtechie/open-checklist-project/issues/33)).
 
 ## Pull request scope
 

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -15,7 +15,7 @@ legacy data isn't broken during migration.
 | **Set** | v0.3 (manifest form) | [`set/schema.yaml`](set/schema.yaml) | [set/README.md](set/README.md) |
 | **Manifest** | v0.2 | [`manifest/schema.yaml`](manifest/schema.yaml) | [manifest/README.md](manifest/README.md) |
 | **Checklist** | v0.1 | [`checklist/schema.yaml`](checklist/schema.yaml) | [checklist/README.md](checklist/README.md) |
-| **Card** | v0.1 (legacy, exploded) | [`card/schema.yaml`](card/schema.yaml) | [card/README.md](card/README.md) |
+| **Card** | v0.1 (DEPRECATED, exploded) | [`card/schema.yaml`](card/schema.yaml) | [card/README.md](card/README.md) |
 
 The identity/UUID contract that spans the manifest form (which UUIDs are committed vs.
 derived, and the cross-file invariants) is the frozen spec in [`IDENTITY.md`](IDENTITY.md).
@@ -48,7 +48,7 @@ from tens of thousands of files to a handful. See [`IDENTITY.md`](IDENTITY.md) f
 derivation rules and [manifest/README.md](manifest/README.md) for `parallels`,
 `applies_to`, and `sections`.
 
-### Legacy exploded format (v0.2)
+### Legacy exploded format (v0.2) — DEPRECATED
 
 Earlier sets use `data/<genre>/<set-id>/set.yaml` (Set schema **v0.2**) plus
 `cards/*.yaml` (Card schema **v0.1**), one file per card and per parallel. The validator
@@ -145,7 +145,7 @@ schema = load_schema("schemas/set/v0.2/schema.yaml")
 ### Checklist ([changelog](checklist/CHANGELOG.md))
 - **v0.1** ([schema](checklist/v0.1/schema.yaml), [docs](checklist/v0.1/README.md)) — initial checklist schema: committed rows with `subjects` as combinations of `entities`.
 
-### Card ([changelog](card/CHANGELOG.md)) — legacy
+### Card ([changelog](card/CHANGELOG.md)) — DEPRECATED (exploded format, see #33)
 - **v0.1** ([schema](card/v0.1/schema.yaml), [docs](card/v0.1/README.md)) — initial card schema for the exploded format.
 
 ---

--- a/schemas/card/CHANGELOG.md
+++ b/schemas/card/CHANGELOG.md
@@ -1,7 +1,6 @@
-## [DEPRECATED] - 2026-07-11
-- The exploded one-file-per-card format is deprecated, superseded by the v0.3 manifest
-  form (manifest + checklist schemas). Retained only to validate not-yet-migrated
-  exploded data; will be removed once migration completes. Tracking: #33.
+> **DEPRECATED (2026-07-11)** — the exploded one-file-per-card format is superseded by
+> the v0.3 manifest form (manifest + checklist schemas). Retained only to validate
+> not-yet-migrated exploded data; removed once migration completes. Tracking: #33.
 
 ## [v0.1] - 2025-06-22
 - Initial release of card schema

--- a/schemas/card/CHANGELOG.md
+++ b/schemas/card/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [DEPRECATED] - 2026-07-11
+- The exploded one-file-per-card format is deprecated, superseded by the v0.3 manifest
+  form (manifest + checklist schemas). Retained only to validate not-yet-migrated
+  exploded data; will be removed once migration completes. Tracking: #33.
+
 ## [v0.1] - 2025-06-22
 - Initial release of card schema
 - Added support for sports and TCG genres

--- a/schemas/card/v0.1/README.md
+++ b/schemas/card/v0.1/README.md
@@ -1,5 +1,16 @@
 # Card Schema v0.1
 
+> ## ⚠️ DEPRECATED
+> The **exploded one-file-per-card format** this schema validates is **deprecated**,
+> superseded by the **v0.3 manifest form** ([`../../manifest`](../../manifest), [`../../checklist`](../../checklist)).
+> A set is now `set.yaml` + `manifest.yaml` + `checklists/`, from which per-card data is
+> *derived* — see the [schemas overview](../../README.md).
+>
+> - **Do not author new data in this format.** New contributions must use the manifest form.
+> - This schema is retained only to validate exploded sets that haven't been migrated yet.
+> - It (and the `v0.2` set schema + the validator's v0.2 path) will be **removed** once all
+>   exploded data is migrated. Tracking: cardtechie/open-checklist-project#33.
+
 This schema defines the structure for individual trading card data in the Open Checklist Project.
 
 ## Required Fields

--- a/tools/validate.py
+++ b/tools/validate.py
@@ -321,13 +321,15 @@ def main(argv):
         print(f"no sets found under {data_dir}")
         return 0
 
+    deprecated = []  # exploded v0.2 sets — still validated, but flagged for migration
     for sd in set_dirs:
         try:
             if (sd / "manifest.yaml").exists():
                 fmt = "v0.3"
                 validate_v03(sd, schemas, rep)
             elif (sd / "cards").is_dir():
-                fmt = "v0.2"
+                fmt = "v0.2 DEPRECATED"
+                deprecated.append(sd)
                 validate_v02(sd, schemas, rep)
             else:
                 fmt = "?"
@@ -336,6 +338,12 @@ def main(argv):
             fmt = "!"
             rep.err(str(sd), f"unexpected error during validation: {e}")
         print(f"  [{fmt}] {sd}")
+
+    if deprecated:  # non-fatal: the exploded format is deprecated but still validated
+        print(f"\n⚠️  {len(deprecated)} set(s) use the DEPRECATED exploded (v0.2) format —"
+              " migrate to the v0.3 manifest form (set.yaml + manifest.yaml + checklists/):")
+        for sd in deprecated:
+            print(f"  - {sd}")
 
     if rep.errors:
         print(f"\n❌ {len(rep.errors)} validation error(s):")

--- a/tools/validate.py
+++ b/tools/validate.py
@@ -344,8 +344,8 @@ def main(argv):
         noun = "set uses" if n == 1 else "sets use"
         print(f"\n⚠️  {n} {noun} the DEPRECATED exploded (v0.2) format —"
               " migrate to the v0.3 manifest form (set.yaml + manifest.yaml + checklists/):")
-        for sd in deprecated:
-            print(f"  - {sd}")
+        for dep_dir in deprecated:
+            print(f"  - {dep_dir}")
 
     if rep.errors:
         print(f"\n❌ {len(rep.errors)} validation error(s):")

--- a/tools/validate.py
+++ b/tools/validate.py
@@ -340,7 +340,9 @@ def main(argv):
         print(f"  [{fmt}] {sd}")
 
     if deprecated:  # non-fatal: the exploded format is deprecated but still validated
-        print(f"\n⚠️  {len(deprecated)} set(s) use the DEPRECATED exploded (v0.2) format —"
+        n = len(deprecated)
+        noun = "set uses" if n == 1 else "sets use"
+        print(f"\n⚠️  {n} {noun} the DEPRECATED exploded (v0.2) format —"
               " migrate to the v0.3 manifest form (set.yaml + manifest.yaml + checklists/):")
         for sd in deprecated:
             print(f"  - {sd}")


### PR DESCRIPTION
Marks the **exploded one-file-per-card format** as **deprecated**, superseded by the v0.3 manifest form. Non-breaking — exploded sets still validate.

## Changes
- **Card schema** — deprecation banner in `schemas/card/v0.1/README.md` + `[DEPRECATED]` CHANGELOG entry.
- **schemas/README.md** — card/exploded marked DEPRECATED (was 'legacy').
- **CONTRIBUTING.md** — new set data must use the manifest form; the exploded format is deprecated.
- **Validator** — exploded sets print `[v0.2 DEPRECATED]` and a **non-fatal** migration warning (still exit 0).

## Not done here
**Removal** of the card schema / set v0.2 / validator v0.2 path is gated on migrating the remaining exploded data — tracked in #33.

Addresses the deprecation-notice part of #33.